### PR TITLE
Fix refresh token rotation during credential validation

### DIFF
--- a/custom_components/electrolux/config_flow.py
+++ b/custom_components/electrolux/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowHandler, FlowResult
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import issue_registry as ir
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.aiohttp_client import async_get_clientsession  # noqa: F401
 from homeassistant.helpers.selector import (
     TextSelector,
     TextSelectorConfig,
@@ -108,6 +108,63 @@ def _extract_token_expiry(access_token: str | None) -> int | None:
     return None
 
 
+async def _validate_credentials_and_capture_rotation(
+    api_key: str | None, access_token: str | None, refresh_token: str | None
+) -> dict[str, Any] | None:
+    """Validate credentials and return the final tokens after SDK refresh.
+
+    Electrolux refresh tokens are single-use. During validation the SDK can decide
+    to refresh, which rotates both tokens. If we then save the originally entered
+    refresh token, Home Assistant stores a token that has already been consumed and
+    the next runtime refresh fails with "Refresh token is invalid".
+    """
+    if api_key is None or access_token is None or refresh_token is None:
+        return None
+
+    credential_data: dict[str, Any] = {
+        CONF_API_KEY: api_key,
+        CONF_ACCESS_TOKEN: access_token,
+        CONF_REFRESH_TOKEN: refresh_token,
+    }
+
+    def on_token_update(
+        new_access_token: str,
+        new_refresh_token: str,
+        new_api_key: str,
+        expires_at: int,
+    ) -> None:
+        credential_data[CONF_API_KEY] = new_api_key
+        credential_data[CONF_ACCESS_TOKEN] = new_access_token
+        credential_data[CONF_REFRESH_TOKEN] = new_refresh_token
+        credential_data["token_expires_at"] = expires_at
+
+    client = get_electrolux_session(api_key, access_token, refresh_token)
+    client.set_token_update_callback_with_expiry(on_token_update)
+
+    try:
+        await client.get_appliances_list()
+    except (ConnectionError, TimeoutError, ValueError, KeyError) as e:
+        _LOGGER.error("Authentication to Electrolux failed: %s", type(e).__name__)
+        return None
+    except Exception as e:
+        _LOGGER.error(
+            "Unexpected error during Electrolux authentication: %s",
+            type(e).__name__,
+        )
+        return None
+    finally:
+        try:
+            await client.close()
+        except Exception:
+            _LOGGER.debug("Failed to close temporary Electrolux validation client")
+
+    credential_data.setdefault(
+        "token_expires_at",
+        _extract_token_expiry(cast(str | None, credential_data[CONF_ACCESS_TOKEN])),
+    )
+    return credential_data
+
+
 class ElectroluxStatusFlowHandler(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]  # HA metaclass requires domain kwarg
     """Config flow for Electrolux."""
 
@@ -143,19 +200,16 @@ class ElectroluxStatusFlowHandler(ConfigFlow, domain=DOMAIN):  # type: ignore[ca
         ):
             return self.async_abort(reason="already_configured_account")
 
-        valid = await self._test_credentials(
+        credential_data = await _validate_credentials_and_capture_rotation(
             user_input.get("api_key"),
             user_input.get("access_token"),
             user_input.get("refresh_token"),
         )
-        if valid:
-            # Extract token expiry from JWT and store it in config entry
-            access_token = user_input.get("access_token")
-            token_expiry = _extract_token_expiry(access_token)
-            if token_expiry:
-                user_input["token_expires_at"] = token_expiry
-                # Log when token will expire for visibility
-                time_remaining = token_expiry - time.time()
+        if credential_data:
+            user_input.update(credential_data)
+            token_expiry = user_input.get("token_expires_at")
+            if token_expiry is not None:
+                time_remaining = cast(int, token_expiry) - time.time()
                 _LOGGER.info(
                     f"Initial token expires in {time_remaining/3600:.1f} hours "
                     f"(at timestamp {token_expiry})"
@@ -208,12 +262,12 @@ class ElectroluxStatusFlowHandler(ConfigFlow, domain=DOMAIN):  # type: ignore[ca
             _mask_token(user_input.get("access_token")),
             _mask_token(user_input.get("refresh_token")),
         )
-        valid = await self._test_credentials(
+        credential_data = await _validate_credentials_and_capture_rotation(
             user_input.get("api_key"),
             user_input.get("access_token"),
             user_input.get("refresh_token"),
         )
-        if valid:
+        if credential_data:
             _LOGGER.info("[AUTH-DEBUG] Reauth credentials validated successfully")
             # Dismiss the token refresh issue since re-authentication succeeded
             from homeassistant.helpers import issue_registry
@@ -230,13 +284,11 @@ class ElectroluxStatusFlowHandler(ConfigFlow, domain=DOMAIN):  # type: ignore[ca
             _LOGGER.info(f"[AUTH-DEBUG] Dismissing repair issue: {issue_id}")
             issue_registry.async_delete_issue(self.hass, DOMAIN, issue_id)
 
-            # Extract token expiry from JWT and store it
-            access_token = user_input.get("access_token")
-            token_expiry = _extract_token_expiry(access_token)
             entry_data = dict(user_input)
-            if token_expiry:
-                entry_data["token_expires_at"] = token_expiry
-                time_remaining = token_expiry - time.time()
+            entry_data.update(credential_data)
+            token_expiry = entry_data.get("token_expires_at")
+            if token_expiry is not None:
+                time_remaining = cast(int, token_expiry) - time.time()
                 _LOGGER.info(
                     f"[AUTH-DEBUG] Reauth: New token expires in {time_remaining/3600:.1f} hours (at timestamp {token_expiry})"
                 )
@@ -305,18 +357,20 @@ class ElectroluxStatusFlowHandler(ConfigFlow, domain=DOMAIN):  # type: ignore[ca
                     "; ".join(validation_errors),
                 )
             else:
-                valid = await self._test_credentials(
+                credential_data = await _validate_credentials_and_capture_rotation(
                     user_input.get("api_key"),
                     user_input.get("access_token"),
                     user_input.get("refresh_token"),
                 )
-                if valid:
-                    access_token = user_input.get("access_token")
-                    token_expiry = _extract_token_expiry(access_token)
+                if credential_data:
                     new_data = dict(entry.data)
                     new_data.update(user_input)
-                    if token_expiry:
-                        new_data["token_expires_at"] = token_expiry
+                    new_data.update(credential_data)
+                    ir.async_delete_issue(
+                        self.hass,
+                        DOMAIN,
+                        f"invalid_refresh_token_{entry.entry_id}",
+                    )
                     return self.async_update_reload_and_abort(entry, data=new_data)
                 self._errors["base"] = "invalid_auth"
 
@@ -398,24 +452,15 @@ class ElectroluxStatusFlowHandler(ConfigFlow, domain=DOMAIN):  # type: ignore[ca
             _mask_token(refresh_token),
         )
         try:
-            client = get_electrolux_session(
-                api_key,
-                access_token,
-                refresh_token,
-                async_get_clientsession(self.hass),
-                self.hass,
+            return (
+                await _validate_credentials_and_capture_rotation(
+                    api_key, access_token, refresh_token
+                )
+                is not None
             )
-            await client.get_appliances_list()
-        except (ConnectionError, TimeoutError, ValueError, KeyError) as e:
-            _LOGGER.error("Authentication to Electrolux failed: %s", type(e).__name__)
+        except Exception:
+            _LOGGER.exception("Electrolux credential validation failed")
             return False
-        except Exception as e:  # Fallback for unexpected errors
-            _LOGGER.error(
-                "Unexpected error during Electrolux authentication: %s",
-                type(e).__name__,
-            )
-            return False
-        return True
 
 
 class ElectroluxStatusOptionsFlowHandler(OptionsFlow):
@@ -492,45 +537,43 @@ class ElectroluxStatusOptionsFlowHandler(OptionsFlow):
             _mask_token(refresh_token),
         )
         try:
-            client = get_electrolux_session(
-                api_key,
-                access_token,
-                refresh_token,
-                async_get_clientsession(self.hass),
-                self.hass,
+            return (
+                await _validate_credentials_and_capture_rotation(
+                    api_key, access_token, refresh_token
+                )
+                is not None
             )
-            await client.get_appliances_list()
-        except (ConnectionError, TimeoutError, ValueError, KeyError) as e:
-            _LOGGER.error("Authentication to Electrolux failed: %s", type(e).__name__)
+        except Exception:
+            _LOGGER.exception("Electrolux credential validation failed")
             return False
-        except Exception as e:  # Fallback for unexpected errors
-            _LOGGER.error(
-                "Unexpected error during Electrolux authentication: %s",
-                type(e).__name__,
-            )
-            return False
-        return True
 
     async def _validate_and_update_options(
         self, user_input: dict[str, Any]
     ) -> ConfigFlowResult | None:
         """Validate credentials and update options if provided."""
-        # Test credentials if any API credentials were provided
-        if any(
-            key in user_input
+        credential_input_present = any(
+            user_input.get(key)
             for key in [CONF_API_KEY, CONF_ACCESS_TOKEN, CONF_REFRESH_TOKEN]
-        ):
+        )
+        credential_data: dict[str, Any] | None = None
+
+        # Test credentials only when the user actually entered credential values.
+        # Empty password fields are normal in the options form.
+        if credential_input_present:
             api_key = user_input.get(
                 CONF_API_KEY, self._config_entry.data.get(CONF_API_KEY)
             )
             access_token = user_input.get(
-                CONF_ACCESS_TOKEN, self._config_entry.data.get(CONF_ACCESS_TOKEN)
-            )
+                CONF_ACCESS_TOKEN
+            ) or self._config_entry.data.get(CONF_ACCESS_TOKEN)
             refresh_token = user_input.get(
-                CONF_REFRESH_TOKEN, self._config_entry.data.get(CONF_REFRESH_TOKEN)
-            )
+                CONF_REFRESH_TOKEN
+            ) or self._config_entry.data.get(CONF_REFRESH_TOKEN)
 
-            if not await self._test_credentials(api_key, access_token, refresh_token):
+            credential_data = await _validate_credentials_and_capture_rotation(
+                api_key, access_token, refresh_token
+            )
+            if credential_data is None:
                 return None  # Invalid, caller will show form with errors
 
         # Update the config entry data with new options
@@ -538,18 +581,18 @@ class ElectroluxStatusOptionsFlowHandler(OptionsFlow):
         new_options = dict(self._config_entry.options)
 
         # API credentials and notifications go in data (require restart)
-        if "api_key" in user_input:
-            new_data["api_key"] = user_input.get("api_key")
-        if "access_token" in user_input:
-            new_data["access_token"] = user_input.get("access_token")
-        if "refresh_token" in user_input:
-            new_data["refresh_token"] = user_input.get("refresh_token")
-        if "notification_default" in user_input:
-            new_data["notification_default"] = user_input.get("notification_default")
-        if "notification_warning" in user_input:
-            new_data["notification_warning"] = user_input.get("notification_warning")
-        if "notification_diag" in user_input:
-            new_data["notification_diag"] = user_input.get("notification_diag")
+        if credential_data:
+            new_data.update(credential_data)
+        if CONF_NOTIFICATION_DEFAULT in user_input:
+            new_data[CONF_NOTIFICATION_DEFAULT] = user_input.get(
+                CONF_NOTIFICATION_DEFAULT
+            )
+        if CONF_NOTIFICATION_WARNING in user_input:
+            new_data[CONF_NOTIFICATION_WARNING] = user_input.get(
+                CONF_NOTIFICATION_WARNING
+            )
+        if CONF_NOTIFICATION_DIAG in user_input:
+            new_data[CONF_NOTIFICATION_DIAG] = user_input.get(CONF_NOTIFICATION_DIAG)
 
         self.hass.config_entries.async_update_entry(
             self._config_entry, data=new_data, options=new_options
@@ -589,7 +632,7 @@ async def async_create_fix_flow(
     data: dict[str, str | int | float | None] | None,
 ) -> FlowHandler:
     """Create fix flow for Electrolux repair issues."""
-    return ElectroluxRepairFlow()
+    return ElectroluxRepairFlow(issue_id)
 
 
 class ElectroluxRepairFlow(FlowHandler):
@@ -597,9 +640,14 @@ class ElectroluxRepairFlow(FlowHandler):
 
     VERSION = 1
 
-    def __init__(self) -> None:
+    def __init__(self, issue_id: str | None = None) -> None:
         """Initialize repair flow."""
         super().__init__()
+        self._issue_id = issue_id
+
+    def _get_issue_id(self) -> str:
+        """Return the repair issue ID from HA context or constructor."""
+        return cast(str, self.context.get("issue_id") or self._issue_id or "")
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -615,7 +663,7 @@ class ElectroluxRepairFlow(FlowHandler):
 
         if user_input is not None:
             # Extract entry_id from the issue_id
-            issue_id = cast(str, self.context.get("issue_id", ""))
+            issue_id = self._get_issue_id()
             entry_id = issue_id.replace("invalid_refresh_token_", "")
 
             # Get the config entry
@@ -639,19 +687,18 @@ class ElectroluxRepairFlow(FlowHandler):
                     "Credential validation failed: %s", "; ".join(validation_errors)
                 )
             else:
-                # Test credentials
-                if await self._test_credentials(api_key, access_token, refresh_token):
+                # Test credentials and store any rotated tokens produced by validation.
+                credential_data = await _validate_credentials_and_capture_rotation(
+                    api_key, access_token, refresh_token
+                )
+                if credential_data:
                     # Update config entry with new credentials
                     new_data = dict(entry.data)
-                    new_data[CONF_API_KEY] = api_key
-                    new_data[CONF_ACCESS_TOKEN] = access_token
-                    new_data[CONF_REFRESH_TOKEN] = refresh_token
+                    new_data.update(credential_data)
 
-                    # Extract token expiry from JWT
-                    token_expiry = _extract_token_expiry(access_token)
-                    if token_expiry:
-                        new_data["token_expires_at"] = token_expiry
-                        time_remaining = token_expiry - time.time()
+                    token_expiry = new_data.get("token_expires_at")
+                    if token_expiry is not None:
+                        time_remaining = cast(int, token_expiry) - time.time()
                         _LOGGER.info(
                             f"Repair: Token expires in {time_remaining/3600:.1f} hours"
                         )
@@ -673,7 +720,7 @@ class ElectroluxRepairFlow(FlowHandler):
                 _LOGGER.warning("Invalid credentials provided during repair")
 
         # Show the form with current values as defaults (entry_id in issue_id)
-        issue_id = cast(str, self.context.get("issue_id", ""))
+        issue_id = self._get_issue_id()
         entry_id = issue_id.replace("invalid_refresh_token_", "")
         entry = self.hass.config_entries.async_get_entry(entry_id)
 
@@ -731,21 +778,12 @@ class ElectroluxRepairFlow(FlowHandler):
             _mask_token(refresh_token),
         )
         try:
-            client = get_electrolux_session(
-                api_key,
-                access_token,
-                refresh_token,
-                async_get_clientsession(self.hass),
-                self.hass,
+            return (
+                await _validate_credentials_and_capture_rotation(
+                    api_key, access_token, refresh_token
+                )
+                is not None
             )
-            await client.get_appliances_list()
-        except (ConnectionError, TimeoutError, ValueError, KeyError) as e:
-            _LOGGER.error("Authentication to Electrolux failed: %s", type(e).__name__)
+        except Exception:
+            _LOGGER.exception("Electrolux credential validation failed")
             return False
-        except Exception as e:  # Fallback for unexpected errors
-            _LOGGER.error(
-                "Unexpected error during Electrolux authentication: %s",
-                type(e).__name__,
-            )
-            return False
-        return True

--- a/custom_components/electrolux/coordinator.py
+++ b/custom_components/electrolux/coordinator.py
@@ -238,6 +238,11 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
 
                 # Update config entry data - update_listener will check timestamp to prevent reload
                 self.hass.config_entries.async_update_entry(config_entry, data=new_data)
+                issue_registry.async_delete_issue(
+                    self.hass,
+                    DOMAIN,
+                    f"invalid_refresh_token_{config_entry.entry_id}",
+                )
 
                 _LOGGER.info(
                     "Tokens persisted to config entry (valid for %.1fh)",

--- a/custom_components/electrolux/repairs.py
+++ b/custom_components/electrolux/repairs.py
@@ -1,0 +1,17 @@
+"""Repairs support for the Electrolux integration."""
+
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowHandler
+
+from .config_flow import ElectroluxRepairFlow
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, Any] | None,
+) -> FlowHandler:
+    """Create a fix flow for Electrolux repair issues."""
+    return ElectroluxRepairFlow(issue_id)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -12,7 +12,11 @@ from custom_components.electrolux.config_flow import (
     _extract_token_expiry,
     _mask_token,
     _validate_credentials,
+    _validate_credentials_and_capture_rotation,
     async_create_fix_flow,
+)
+from custom_components.electrolux.repairs import (
+    async_create_fix_flow as async_create_repairs_fix_flow,
 )
 
 
@@ -195,6 +199,16 @@ class TestRepairFlow:
         )
         assert flow is not None
         assert isinstance(flow, ElectroluxRepairFlow)
+
+    @pytest.mark.asyncio
+    async def test_repairs_module_passes_issue_id_to_flow(self):
+        """Home Assistant's repairs module passes issue_id outside flow context."""
+        flow = await async_create_repairs_fix_flow(
+            Mock(), "invalid_refresh_token_test_entry", None
+        )
+
+        assert isinstance(flow, ElectroluxRepairFlow)
+        assert flow._get_issue_id() == "invalid_refresh_token_test_entry"
 
     @pytest.mark.asyncio
     async def test_repair_flow_form_shown(self):
@@ -430,6 +444,53 @@ class TestExtractTokenExpiry:
         assert result == 9999999999
 
 
+class TestCredentialValidationRotation:
+    """Tests for credential validation when refresh tokens rotate."""
+
+    @pytest.mark.asyncio
+    async def test_validation_returns_rotated_tokens(self):
+        """Store tokens produced during validation instead of consumed input tokens."""
+
+        callback_holder = {}
+        mock_client = Mock()
+        mock_client.close = AsyncMock()
+
+        def capture_callback(callback):
+            callback_holder["callback"] = callback
+
+        async def get_appliances_list():
+            callback_holder["callback"](
+                "rotated_access_token_1234567890",
+                "rotated_refresh_token_1234567890",
+                "api_key_1234567890",
+                9999999999,
+            )
+            return []
+
+        mock_client.set_token_update_callback_with_expiry = Mock(
+            side_effect=capture_callback
+        )
+        mock_client.get_appliances_list = AsyncMock(side_effect=get_appliances_list)
+
+        with patch(
+            "custom_components.electrolux.config_flow.get_electrolux_session",
+            return_value=mock_client,
+        ):
+            credential_data = await _validate_credentials_and_capture_rotation(
+                "api_key_1234567890",
+                "submitted_access_token_1234567890",
+                "submitted_refresh_token_1234567890",
+            )
+
+        assert credential_data == {
+            "api_key": "api_key_1234567890",
+            "access_token": "rotated_access_token_1234567890",
+            "refresh_token": "rotated_refresh_token_1234567890",
+            "token_expires_at": 9999999999,
+        }
+        mock_client.close.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # Reauth flow tests
 # ---------------------------------------------------------------------------
@@ -607,6 +668,7 @@ class TestReconfigureFlow:
                 "custom_components.electrolux.config_flow.get_electrolux_session"
             ) as mock_session,
             patch("custom_components.electrolux.config_flow.async_get_clientsession"),
+            patch("custom_components.electrolux.config_flow.ir.async_delete_issue"),
             patch.object(
                 flow,
                 "async_update_reload_and_abort",
@@ -929,6 +991,7 @@ class TestConfigFlowMissingCoverage:
                 "custom_components.electrolux.config_flow._extract_token_expiry",
                 return_value=9999999999,
             ),
+            patch("custom_components.electrolux.config_flow.ir.async_delete_issue"),
             patch.object(
                 flow,
                 "async_update_reload_and_abort",
@@ -978,6 +1041,7 @@ class TestConfigFlowMissingCoverage:
                 "custom_components.electrolux.config_flow._extract_token_expiry",
                 return_value=9999999999,
             ),
+            patch("custom_components.electrolux.config_flow.ir.async_delete_issue"),
             patch.object(
                 flow,
                 "async_update_reload_and_abort",


### PR DESCRIPTION
## What this fixes

This fixes a re-auth loop where users can enter freshly generated Electrolux credentials, see validation succeed, and still get the same critical repair later with `Refresh token is invalid`.

The root cause is refresh-token rotation during credential validation.

Electrolux refresh tokens are single-use. When the integration validates credentials by calling the API, the SDK can decide that the submitted access token is expired or close enough to expiry and refresh it immediately. That refresh succeeds, but it also rotates the refresh token. Before this change, the config/reauth/repair flows only treated validation as a boolean result and then saved the credentials originally entered by the user. If validation had refreshed the token internally, Home Assistant saved a refresh token that had already been consumed. The next runtime refresh then failed with `Refresh token is invalid`, creating the repair again.

So the experience for the user was confusing: they did the right thing, entered fresh credentials, the form accepted them, and then the integration later complained again because the accepted refresh token was already stale by the time it was stored.

## How the fix works

The validation path now registers the integration's token-update callback on the temporary validation client. If the SDK refreshes while validating credentials, the callback captures the rotated access token, rotated refresh token, API key, and expiry timestamp.

All credential update paths now save the final credential set after validation, not blindly the originally submitted values:

- initial config flow
- reauth flow
- reconfigure flow
- repair flow
- options flow when credential fields are actually filled in

This keeps Home Assistant's config entry aligned with the SDK's latest token chain.

The runtime token persistence callback also deletes the stale `invalid_refresh_token` repair once a refresh succeeds and is written back to the config entry. That way a recovered integration does not keep showing a repair that is no longer true.

## Repair flow entrypoint

I also added `custom_components/electrolux/repairs.py` and delegate to the existing repair flow. Home Assistant loads integration repair fix flows from the integration's repairs module, so this makes the Electrolux repair issue use the actual credential form instead of falling back to the generic confirmation flow.

Because Home Assistant passes the repair `issue_id` as an argument when creating the fix flow, the repair flow now stores that issue id on construction and still falls back to `self.context["issue_id"]` for compatibility with existing tests/direct usage.

## Tests

Added coverage for the important behavior:

- validation returns rotated tokens when the SDK refreshes during validation
- the repairs module passes the issue id into the flow
- existing config-flow, reauth, reconfigure, options, and repair-flow tests were updated for the new shared validation path

Local checks:

- `ruff check custom_components/electrolux tests/test_config_flow.py`
- `pytest -q`

Result: `1421 passed`.
