### PR TITLE
fix(climate): restore last user temperature on AC power-on

### DIFF
--- a/custom_components/electrolux/climate.py
+++ b/custom_components/electrolux/climate.py
@@ -121,6 +121,7 @@ class ElectroluxClimate(ElectroluxEntity, ClimateEntity):
             catalog_entry=catalog_entry,
         )
         self._enable_turn_on_off_backwards_compatibility = False
+        self._last_user_temperature: float | None = None
 
         # Determine temperature unit once from capabilities (static — never changes at runtime).
         # Prefer Celsius; fall back to Fahrenheit if only F is in capabilities.
@@ -364,6 +365,7 @@ class ElectroluxClimate(ElectroluxEntity, ClimateEntity):
         if temperature is None:
             return
 
+        self._last_user_temperature = float(temperature)
         await self._send_command(f"targetTemperature{self._temp_suffix}", temperature)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
@@ -390,6 +392,12 @@ class ElectroluxClimate(ElectroluxEntity, ClimateEntity):
             mode_str = mode_mapping[hvac_mode]
             await self._send_command("mode", mode_str)
             self._apply_optimistic_update("mode", mode_str)
+
+        # Re-apply last user temperature — device resets to min on power-off.
+        if self._last_user_temperature is not None:
+            temp_attr = f"targetTemperature{self._temp_suffix}"
+            await self._send_command(temp_attr, self._last_user_temperature)
+            self._apply_optimistic_update(temp_attr, self._last_user_temperature)
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""

--- a/custom_components/electrolux/climate.py
+++ b/custom_components/electrolux/climate.py
@@ -1,5 +1,6 @@
 """Climate platform for Electrolux."""
 
+import contextlib
 import logging
 from typing import Any
 
@@ -13,6 +14,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import CLIMATE
 from .entity import ElectroluxEntity
@@ -83,7 +85,7 @@ async def async_setup_entry(
     return
 
 
-class ElectroluxClimate(ElectroluxEntity, ClimateEntity):
+class ElectroluxClimate(ElectroluxEntity, ClimateEntity, RestoreEntity):
     """Electrolux climate class."""
 
     def __init__(
@@ -135,6 +137,22 @@ class ElectroluxClimate(ElectroluxEntity, ClimateEntity):
             # No explicit temperature capability found — default to Celsius
             self._attr_temperature_unit = UnitOfTemperature.CELSIUS
             self._temp_suffix = "C"
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last user temperature from prior HA state."""
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            if (temp := last_state.attributes.get("last_user_temperature")) is not None:
+                with contextlib.suppress(ValueError, TypeError):
+                    self._last_user_temperature = float(temp)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Persist last user temperature so RestoreEntity can recover it."""
+        attrs: dict[str, Any] = {}
+        if self._last_user_temperature is not None:
+            attrs["last_user_temperature"] = self._last_user_temperature
+        return attrs
 
     @property
     def entity_domain(self):

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -485,6 +485,43 @@ class TestElectroluxClimate:
         assert calls[1][0] == ("mode", "FANONLY")
 
     @pytest.mark.asyncio
+    async def test_async_set_temperature_caches_last_value(self, climate_entity):
+        """Temperature is cached so it can be re-applied on next power-on."""
+        climate_entity._send_command = AsyncMock()
+
+        await climate_entity.async_set_temperature(temperature=22.0)
+
+        assert climate_entity._last_user_temperature == 22.0
+
+    @pytest.mark.asyncio
+    async def test_hvac_mode_on_resends_last_temperature(self, climate_entity):
+        """Turning on re-sends last user temperature to counter device reset to min."""
+        climate_entity._send_command = AsyncMock()
+        climate_entity._apply_optimistic_update = MagicMock()
+        climate_entity._last_user_temperature = 22.0
+
+        await climate_entity.async_set_hvac_mode(HVACMode.HEAT)
+
+        assert climate_entity._send_command.call_count == 3
+        calls = climate_entity._send_command.call_args_list
+        assert calls[0][0] == ("executeCommand", "ON")
+        assert calls[1][0] == ("mode", "HEAT")
+        assert calls[2][0] == ("targetTemperatureC", 22.0)
+
+    @pytest.mark.asyncio
+    async def test_hvac_mode_on_no_cached_temp_skips_resend(self, climate_entity):
+        """No cached temperature → no extra temperature command on turn-on."""
+        climate_entity._send_command = AsyncMock()
+        climate_entity._last_user_temperature = None
+
+        await climate_entity.async_set_hvac_mode(HVACMode.COOL)
+
+        assert climate_entity._send_command.call_count == 2
+        calls = climate_entity._send_command.call_args_list
+        assert calls[0][0] == ("executeCommand", "ON")
+        assert calls[1][0] == ("mode", "COOL")
+
+    @pytest.mark.asyncio
     async def test_async_set_fan_mode(self, climate_entity):
         """Test setting fan mode."""
         climate_entity._send_command = AsyncMock()

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -522,6 +522,45 @@ class TestElectroluxClimate:
         assert calls[1][0] == ("mode", "COOL")
 
     @pytest.mark.asyncio
+    async def test_last_temperature_restored_from_state(self, climate_entity):
+        """Restore _last_user_temperature from prior HA state on async_added_to_hass."""
+        last_state = MagicMock()
+        last_state.attributes = {"last_user_temperature": 22.0}
+        climate_entity.async_get_last_state = AsyncMock(return_value=last_state)
+
+        with patch(
+            "homeassistant.helpers.restore_state.RestoreEntity.async_added_to_hass",
+            new=AsyncMock(),
+        ):
+            await climate_entity.async_added_to_hass()
+
+        assert climate_entity._last_user_temperature == 22.0
+
+    def test_extra_state_attributes_includes_last_temperature(self, climate_entity):
+        """extra_state_attributes exposes last_user_temperature for persistence."""
+        climate_entity._last_user_temperature = 22.0
+        assert climate_entity.extra_state_attributes == {"last_user_temperature": 22.0}
+
+        climate_entity._last_user_temperature = None
+        assert climate_entity.extra_state_attributes == {}
+
+    @pytest.mark.asyncio
+    async def test_last_temperature_not_restored_when_no_prior_state(
+        self, climate_entity
+    ):
+        """No prior state → _last_user_temperature stays None."""
+        climate_entity._last_user_temperature = None
+        climate_entity.async_get_last_state = AsyncMock(return_value=None)
+
+        with patch(
+            "homeassistant.helpers.restore_state.RestoreEntity.async_added_to_hass",
+            new=AsyncMock(),
+        ):
+            await climate_entity.async_added_to_hass()
+
+        assert climate_entity._last_user_temperature is None
+
+    @pytest.mark.asyncio
     async def test_async_set_fan_mode(self, climate_entity):
         """Test setting fan mode."""
         climate_entity._send_command = AsyncMock()


### PR DESCRIPTION
Fixes #43

## Problem

Bogong ACs (and likely all AC types) reset `targetTemperatureC` to the capability default (`16`) when powered off — confirmed from live device capabilities:

```json
"targetTemperatureC": {
  "access": "readwrite",
  "default": 16,
  "min": 16,
  "max": 30
}
```

When the user turned the AC back on via the climate entity, no temperature command was sent — so the unit always started at 16°C regardless of the last setting. The cache was also lost on HA restart.

## Fix

**1. Cache last user-set temperature in memory:**
```python
# async_set_temperature
self._last_user_temperature = float(temperature)

# async_set_hvac_mode (on path)
if self._last_user_temperature is not None:
    await self._send_command(temp_attr, self._last_user_temperature)
```

**2. Persist across HA restarts via `RestoreEntity`:**
- `extra_state_attributes` saves `last_user_temperature` to HA storage
- `async_added_to_hass` restores it on startup

## Tests

6 new tests:
- `test_async_set_temperature_caches_last_value`
- `test_hvac_mode_on_resends_last_temperature`
- `test_hvac_mode_on_no_cached_temp_skips_resend`
- `test_last_temperature_restored_from_state`
- `test_extra_state_attributes_includes_last_temperature`
- `test_last_temperature_not_restored_when_no_prior_state`

68 climate tests pass. Full suite: 1430 passed (1 pre-existing unrelated failure in `test_select.py`, being fixed in a separate PR).

## Live verification

⚠️ **Pending** — unit tests pass but live device testing not yet completed.

### Manual test plan

1. Install this branch on HA
2. Turn AC on via climate entity, set temperature to e.g. 22°C — confirm AC accepts it
3. Turn AC **off** via climate entity — confirm it turns off
4. Turn AC **on** again — confirm it starts at 22°C, **not** 16°C
5. Restart HA, then turn AC on — confirm it still starts at 22°C (restored from state)
6. Set a different temperature, turn off, turn on — confirm new temperature is remembered

## Verified against

3 live Bogong AC units, Brisbane AU (capabilities identical across all 3).