### PR TITLE
fix(tests): repair broken test_temperature_unit_converts_option_to_float

### DIFF
--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -947,7 +947,7 @@ class TestSelectMissingCoveragePaths:
         capability = {
             "access": "readwrite",
             "type": "number",
-            "values": {"30": {"label": "30 °C"}},
+            "values": {"30.5": {"label": "30.5 °C"}},
         }
         entity = ElectroluxSelect(
             coordinator=mock_coordinator,
@@ -972,12 +972,12 @@ class TestSelectMissingCoveragePaths:
         entity.api = MagicMock()
         entity.api.execute_appliance_command = AsyncMock(return_value=None)
 
-        # "30 °C" option → value = "30" → float("30") = 30.0 via contextlib.suppress
+        # "30.5 °C" option → value = "30.5" → float("30.5") = 30.5 via contextlib.suppress
         with patch(
             "custom_components.electrolux.select.format_command_for_appliance",
-            return_value=30.0,
+            return_value=30.5,
         ):
-            await entity.async_select_option("30 °C")
+            await entity.async_select_option("30.5 °C")
 
         entity.api.execute_appliance_command.assert_called_once()
 


### PR DESCRIPTION
## Problem

`TestSelectMissingCoveragePaths::test_temperature_unit_converts_option_to_float` was failing with `HomeAssistantError: Invalid option`.

Root cause: `_filter_numeric_sentinel_values()` strips any capability value key where `str(k).lstrip("-").isdigit()` is True. The test used `"30"` as the key — purely numeric, so it was filtered out. `options_list` ended up empty, making any `async_select_option` call raise immediately.

## Fix

Change the test capability key from `"30"` to `"30.5"`. A decimal value is not stripped by the filter (`.isdigit()` returns False on `"30.5"`), passes through to `options_list`, and still exercises the float-conversion code path (`float("30.5") = 30.5`).

Only `tests/test_select.py` changed — no production code touched.