### PR TITLE
chore: add pre-commit config with CI-matching hooks (optional)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.9
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^custom_components/electrolux/
+
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+        files: ^custom_components/electrolux/
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.15.0
+    hooks:
+      - id: mypy
+        args: [--ignore-missing-imports]
+        files: ^custom_components/electrolux/
+        additional_dependencies:
+          - homeassistant
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        pass_filenames: false
+        args: [--cov=custom_components/electrolux, --cov-fail-under=70, -q]
+        stages: [pre-push]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,16 @@
 - Run `ruff check custom_components/electrolux` and `black custom_components/electrolux` before pushing
 - CI will fail on lint/format errors
 
+## Pre-commit (optional)
+
+A `.pre-commit-config.yaml` is included that mirrors CI checks (ruff, black, mypy on commit; pytest on push).
+
+```bash
+pip install pre-commit && pre-commit install
+```
+
+Not required — CI catches the same issues — but useful for fast local feedback.
+
 ## Files to never commit
 
 - `*.log`

--- a/README.md
+++ b/README.md
@@ -745,7 +745,13 @@ Contributions are welcome! This integration is actively maintained and improved.
 1. Fork the repository
 2. Clone your fork
 3. Install development dependencies: `pip install -r requirements-dev.txt`
-4. Test scripts are available in the root directory for API testing
+4. Install test dependencies: `pip install -r requirements_test.txt`
+5. Test scripts are available in the `scripts/` directory for API testing
+
+**Optional:** Install pre-commit hooks to run the same checks as CI (ruff, black, mypy, pytest) automatically before each commit/push:
+```bash
+pip install pre-commit && pre-commit install
+```
 
 ### 🧪 Testing Your Appliances
 Use the provided test scripts to verify API connectivity:


### PR DESCRIPTION
## Summary

- Add `.pre-commit-config.yaml` mirroring CI: ruff + black on commit, mypy on commit, pytest on push
- Update README Development Setup — pre-commit marked as optional
- Update AGENTS.md with pre-commit section

## Details

Pre-commit is opt-in. CI catches the same issues. Hooks scoped to `custom_components/electrolux/`. Pytest runs at `pre-push` stage only (slower).

## Test plan

- [ ] `pre-commit install` succeeds
- [ ] `pre-commit run --all-files` passes on current codebase
- [ ] CI checks still pass