### PR TITLE
fix(util): handle HTTP 500/502/504 in STATUS_CODE_MAPPING

### DIFF
--- a/custom_components/electrolux/strings.json
+++ b/custom_components/electrolux/strings.json
@@ -128,6 +128,9 @@
     "appliance_disconnected": {
       "message": "Appliance is disconnected or not available. Check the appliance's network connection."
     },
+    "service_temporarily_unavailable": {
+      "message": "Electrolux service is temporarily unavailable, please try again."
+    },
     "command_rate_limited": {
       "message": "Too many commands sent. Please wait a moment and try again."
     },

--- a/custom_components/electrolux/translations/bg.json
+++ b/custom_components/electrolux/translations/bg.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Уредът е изключен или не е наличен. Проверете мрежовата връзка на уреда."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Изпратени са твърде много команди. Моля, изчакайте малко и опитайте отново."
         },

--- a/custom_components/electrolux/translations/cs.json
+++ b/custom_components/electrolux/translations/cs.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Spotřebič je odpojený nebo nedostupný. Zkontrolujte síťové připojení spotřebiče."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Bylo odesláno příliš mnoho příkazů. Chvíli počkejte a zkuste to znovu."
         },

--- a/custom_components/electrolux/translations/da.json
+++ b/custom_components/electrolux/translations/da.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Apparatet er afbrudt eller ikke tilgængeligt. Kontroller apparatets netværksforbindelse."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Der er sendt for mange kommandoer. Vent et øjeblik, og prøv igen."
         },

--- a/custom_components/electrolux/translations/de.json
+++ b/custom_components/electrolux/translations/de.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Gerät ist nicht angeschlossen oder nicht verfügbar. Überprüfen Sie die Netzwerkverbindung des Geräts."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Zu viele Befehle gesendet. Bitte warten Sie einen Moment und versuchen Sie es erneut."
         },

--- a/custom_components/electrolux/translations/el.json
+++ b/custom_components/electrolux/translations/el.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Η συσκευή είναι αποσυνδεδεμένη ή δεν είναι διαθέσιμη. Ελέγξτε τη σύνδεση δικτύου της συσκευής."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Στάλθηκαν πάρα πολλές εντολές. Περιμένετε λίγο και προσπαθήστε ξανά."
         },

--- a/custom_components/electrolux/translations/en.json
+++ b/custom_components/electrolux/translations/en.json
@@ -128,6 +128,9 @@
     "appliance_disconnected": {
       "message": "Appliance is disconnected or not available. Check the appliance's network connection."
     },
+    "service_temporarily_unavailable": {
+      "message": "Electrolux service is temporarily unavailable, please try again."
+    },
     "command_rate_limited": {
       "message": "Too many commands sent. Please wait a moment and try again."
     },

--- a/custom_components/electrolux/translations/es.json
+++ b/custom_components/electrolux/translations/es.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "El aparato está desconectado o no está disponible. Verifique la conexión de red del aparato."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Se enviaron demasiados comandos. Espere un momento e inténtelo de nuevo."
         },

--- a/custom_components/electrolux/translations/et.json
+++ b/custom_components/electrolux/translations/et.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Seade on lahti ühendatud või pole saadaval. Kontrollige seadme võrguühendust."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Saadeti liiga palju käske. Palun oodake veidi ja proovige uuesti."
         },

--- a/custom_components/electrolux/translations/fi.json
+++ b/custom_components/electrolux/translations/fi.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Laite on irrotettu tai ei ole käytettävissä. Tarkista laitteen verkkoyhteys."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Liian monta komentoa lähetetty. Odota hetki ja yritä uudelleen."
         },

--- a/custom_components/electrolux/translations/fr.json
+++ b/custom_components/electrolux/translations/fr.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "L'appareil est déconnecté ou n'est pas disponible. Vérifiez la connexion réseau de l'appareil."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Trop de commandes envoyées. Veuillez patienter un moment et réessayer."
         },

--- a/custom_components/electrolux/translations/hr.json
+++ b/custom_components/electrolux/translations/hr.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Aparat je isključen ili nije dostupan. Provjerite mrežnu vezu uređaja."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Poslano je previše naredbi. Pričekajte trenutak i pokušajte ponovno."
         },

--- a/custom_components/electrolux/translations/hu.json
+++ b/custom_components/electrolux/translations/hu.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "A készülék le van választva, vagy nem elérhető. Ellenőrizze a készülék hálózati csatlakozását."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Túl sok parancs lett elküldve. Kérjük, várjon egy kicsit, és próbálja újra."
         },

--- a/custom_components/electrolux/translations/it.json
+++ b/custom_components/electrolux/translations/it.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "L'apparecchio è disconnesso o non disponibile. Controllare la connessione di rete dell'apparecchio."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Troppi comandi inviati. Attendi un attimo e riprova."
         },

--- a/custom_components/electrolux/translations/lb.json
+++ b/custom_components/electrolux/translations/lb.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Den Apparat ass ofgeschalt oder net verfügbar. Kontrolléiert d'Netzverbindung vum Apparat."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Ze vill Kommandoen geschéckt. Waart e Moment a probéiert nach eng Kéier."
         },

--- a/custom_components/electrolux/translations/lt.json
+++ b/custom_components/electrolux/translations/lt.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Prietaisas atjungtas arba nepasiekiamas. Patikrinkite prietaiso tinklo ryšį."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Išsiųsta per daug komandų. Šiek tiek palaukite ir bandykite dar kartą."
         },

--- a/custom_components/electrolux/translations/lv.json
+++ b/custom_components/electrolux/translations/lv.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Ierīce ir atvienota vai nav pieejama. Pārbaudiet ierīces tīkla savienojumu."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Nosūtīts pārāk daudz komandu. Lūdzu, uzgaidiet brīdi un mēģiniet vēlreiz."
         },

--- a/custom_components/electrolux/translations/nl.json
+++ b/custom_components/electrolux/translations/nl.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Apparaat is losgekoppeld of niet beschikbaar. Controleer de netwerkverbinding van het apparaat."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Te veel opdrachten verzonden. Wacht even en probeer het opnieuw."
         },

--- a/custom_components/electrolux/translations/no.json
+++ b/custom_components/electrolux/translations/no.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Apparatet er frakoblet eller ikke tilgjengelig. Sjekk apparatets nettverkstilkobling."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "For mange kommandoer sendt. Vent et øyeblikk og prøv igjen."
         },

--- a/custom_components/electrolux/translations/pl.json
+++ b/custom_components/electrolux/translations/pl.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Urządzenie jest odłączone lub niedostępne. Sprawdź połączenie sieciowe urządzenia."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Wysłano zbyt wiele poleceń. Poczekaj chwilę i spróbuj ponownie."
         },

--- a/custom_components/electrolux/translations/pt.json
+++ b/custom_components/electrolux/translations/pt.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "O aparelho está desligado ou indisponível. Verifique a conexão de rede do aparelho."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Muitos comandos enviados. Aguarde um momento e tente novamente."
         },

--- a/custom_components/electrolux/translations/pt_br.json
+++ b/custom_components/electrolux/translations/pt_br.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "O aparelho está desligado ou indisponível. Verifique a conexão de rede do aparelho."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Muitos comandos enviados. Aguarde um momento e tente novamente."
         },

--- a/custom_components/electrolux/translations/ro.json
+++ b/custom_components/electrolux/translations/ro.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Aparatul este deconectat sau nu este disponibil. Verificați conexiunea la rețea a aparatului."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Prea multe comenzi trimise. Vă rugăm să așteptați un moment și să încercați din nou."
         },

--- a/custom_components/electrolux/translations/ru.json
+++ b/custom_components/electrolux/translations/ru.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Устройство отключено или недоступно. Проверьте сетевое подключение устройства."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Отправлено слишком много команд. Пожалуйста, подождите немного и повторите попытку."
         },

--- a/custom_components/electrolux/translations/sk.json
+++ b/custom_components/electrolux/translations/sk.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Spotrebič je odpojený alebo nedostupný. Skontrolujte sieťové pripojenie spotrebiča."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Bolo odoslaných príliš veľa príkazov. Chvíľu počkajte a skúste to znova."
         },

--- a/custom_components/electrolux/translations/sl.json
+++ b/custom_components/electrolux/translations/sl.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Naprava je odklopljena ali ni na voljo. Preverite omrežno povezavo naprave."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Preveč poslanih ukazov. Počakajte trenutek in poskusite znova."
         },

--- a/custom_components/electrolux/translations/sv.json
+++ b/custom_components/electrolux/translations/sv.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Apparaten är frånkopplad eller inte tillgänglig. Kontrollera apparatens nätverksanslutning."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "För många kommandon skickade. Vänta ett ögonblick och försök igen."
         },

--- a/custom_components/electrolux/translations/tr.json
+++ b/custom_components/electrolux/translations/tr.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Cihazın bağlantısı kesilmiş veya kullanılamıyor. Cihazın ağ bağlantısını kontrol edin."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Çok fazla komut gönderildi. Lütfen biraz bekleyip tekrar deneyin."
         },

--- a/custom_components/electrolux/translations/uk.json
+++ b/custom_components/electrolux/translations/uk.json
@@ -128,6 +128,9 @@
         "appliance_disconnected": {
             "message": "Прилад відключений або недоступний. Перевірте підключення пристрою до мережі."
         },
+        "service_temporarily_unavailable": {
+            "message": "Electrolux service is temporarily unavailable, please try again."
+        },
         "command_rate_limited": {
             "message": "Надіслано забагато команд. Будь ласка, зачекайте трохи і спробуйте ще раз."
         },

--- a/custom_components/electrolux/util.py
+++ b/custom_components/electrolux/util.py
@@ -544,12 +544,33 @@ def map_command_error_to_home_assistant_error(
 
     # Method 2: Check HTTP status codes (already extracted above)
     if status_code:
+        SERVICE_UNAVAILABLE_MESSAGE = (
+            "Electrolux service is temporarily unavailable, please try again."
+        )
+        SERVICE_UNAVAILABLE_CODES = {500, 502, 504}
         STATUS_CODE_MAPPING = {
             403: "Remote control is disabled for this appliance. Please enable it on the appliance's control panel.",
             406: "Command not accepted by appliance. Check that the appliance supports this operation.",
             429: "Too many commands sent. Please wait a moment and try again.",
+            500: SERVICE_UNAVAILABLE_MESSAGE,
+            502: SERVICE_UNAVAILABLE_MESSAGE,
             503: "Appliance is disconnected or not available. Check the appliance's network connection.",
+            504: SERVICE_UNAVAILABLE_MESSAGE,
         }
+
+        if status_code in SERVICE_UNAVAILABLE_CODES:
+            logger.warning(
+                "Command failed for %s: HTTP %d (Electrolux service temporarily unavailable)%s | %s",
+                entity_attr,
+                status_code,
+                error_data_str,
+                ex,
+            )
+            return HomeAssistantError(
+                SERVICE_UNAVAILABLE_MESSAGE,
+                translation_domain=DOMAIN,
+                translation_key="service_temporarily_unavailable",
+            )
 
         if status_code in STATUS_CODE_MAPPING:
             user_message = STATUS_CODE_MAPPING[status_code]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1107,6 +1107,45 @@ class TestMapCommandError:
         )
         assert "disconnected" in str(result).lower()
 
+    @pytest.mark.parametrize("status", [500, 502, 504])
+    def test_http_5xx_transient_returns_service_temporarily_unavailable(self, status):
+        """HTTP 500/502/504 → 'service temporarily unavailable' translation key."""
+        from custom_components.electrolux.util import (
+            DOMAIN,
+            map_command_error_to_home_assistant_error,
+        )
+
+        class _Ex(Exception):
+            pass
+
+        ex = _Ex(f"{status}, message=\"{{'error': 'INTERNAL_SERVER_ERROR'}}\"")
+        ex.status = status
+        result = map_command_error_to_home_assistant_error(
+            ex, "attr", self._logger()
+        )
+        assert "temporarily unavailable" in str(result).lower()
+        assert getattr(result, "translation_key", None) == "service_temporarily_unavailable"
+        assert getattr(result, "translation_domain", None) == DOMAIN
+
+    @pytest.mark.parametrize("status", [500, 502, 504])
+    def test_http_5xx_transient_logs_at_warning_not_error(self, status):
+        """HTTP 500/502/504 → logger.warning, never logger.error (transient fault)."""
+        from custom_components.electrolux.util import (
+            map_command_error_to_home_assistant_error,
+        )
+
+        logger = self._logger()
+
+        class _Ex(Exception):
+            pass
+
+        ex = _Ex(f"{status} server error")
+        ex.status = status
+        map_command_error_to_home_assistant_error(ex, "attr", logger)
+
+        logger.warning.assert_called()
+        logger.error.assert_not_called()
+
     def test_http_406_plain_returns_command_not_accepted(self):
         """HTTP 406 without special detail → command not accepted."""
         from custom_components.electrolux.util import (


### PR DESCRIPTION
## Summary

- Add 500, 502, 504 to `STATUS_CODE_MAPPING` in `util.py` with a new `service_temporarily_unavailable` error key
- Add translation string to all locale files
- Add tests covering the new error paths

## Problem

Transient server errors (500/502/504) were unhandled — fell through to a generic exception instead of a user-friendly `HomeAssistantError`.

## Test plan

- [ ] New tests in `test_util.py` pass for 500/502/504 responses
- [ ] Full test suite passes