### PR TITLE
docs(readme): mark Bogong AC as verified in supported models table

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The table below lists all appliance types and the known-tested diagnostic sample
 | `WM` | Washing Machine | Full | `WM-914501128`, `WM-914915144` |
 | `WD` | Washer Dryer | Full | `WD-914611000`, `WD-914611500` |
 | `TD` | Tumble Dryer | Full | `TD-916098401`, `TD-916098618`, `TD-916099548`, `TD-916099949`, `TD-916099971` |
-| `AC` / `CA` / `Azul` / `Bogong` / `Panther` / `Telica` | Air Conditioner | Full (`AC` verified) | `AC-910280820` — other variants unverified, [submit yours](https://github.com/TTLucian/ha-electrolux/issues) |
+| `AC` / `CA` / `Azul` / `Bogong` / `Panther` / `Telica` | Air Conditioner | Full (`AC` + `Bogong` verified) | `AC-910280820`; `Bogong` — `VM211_A_04.43.06_BOGONG` (3 units, AU) — `CA`/`Azul`/`Panther`/`Telica` unverified, [submit yours](https://github.com/TTLucian/ha-electrolux/issues) |
 | `DAM_AC` | DAM Air Conditioner | Catalog *(unverified)* | No samples — [submit yours](https://github.com/TTLucian/ha-electrolux/issues) |
 | `DW` | Dishwasher | Full | `DW-911434654`, `DW-911434834` |
 | `Muju` / `Verbier` / `PUREA9` / `Fuji` / `WELLA5` / `WELLA7` | Air Purifier | Full (Muju/Verbier verified) | UltimateHome 500 (EP53); Verbier — PUREA9/Fuji/WELLA5/WELLA7 unverified, [submit yours](https://github.com/TTLucian/ha-electrolux/issues) |
@@ -89,7 +89,7 @@ If you own one of these appliances, please download your diagnostics from **Sett
 | 🍳 **Induction Hob** (`HB`) | `HB diagnostics — [your model]` | Catalog added in v3.5.6, unverified |
 | 💨 **Hood / Extractor Fan** (`HD`) | `HD diagnostics — [your model]` | Catalog added in v3.5.6, unverified |
 | ❄️ **DAM Air Conditioner** (`DAM_AC`) | `DAM_AC diagnostics — [your model]` | Catalog added in v3.5.6, unverified |
-| ❄️ **AC variants** (`CA`, `Azul`, `Bogong`, `Panther`, `Telica`) | `AC variant diagnostics — [your type/model]` | Registered in v3.5.6, unverified |
+| ❄️ **AC variants** (`CA`, `Azul`, `Panther`, `Telica`) | `AC variant diagnostics — [your type/model]` | Registered in v3.5.6, unverified (`Bogong` now verified — see above) |
 | 💨 **AP variants** (`PUREA9`, `Fuji`, `WELLA5`, `WELLA7`) | `AP variant diagnostics — [your type/model]` | Registered in v3.5.6, unverified |
 
 ### �🔍 Finding Your Model Number


### PR DESCRIPTION
Relates to #49.

PR #49 verified Bogong AC against 3 live units (Brisbane AU, firmware `VM211_A_04.43.06_BOGONG`). The README was not updated at the time.

## Changes

- Supported models table: `AC` + `Bogong` both listed as verified; firmware version and unit count added for Bogong; remaining variants (`CA`/`Azul`/`Panther`/`Telica`) still flagged for submission
- Diagnostics Wanted table: removed `Bogong` from unverified list, added note pointing back to verified section