### PR TITLE
fix(select): case-insensitive mode lookup, skip disabled values + Bogong device docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The table below lists all appliance types and the known-tested diagnostic sample
 | `WM` | Washing Machine | Full | `WM-914501128`, `WM-914915144` |
 | `WD` | Washer Dryer | Full | `WD-914611000`, `WD-914611500` |
 | `TD` | Tumble Dryer | Full | `TD-916098401`, `TD-916098618`, `TD-916099548`, `TD-916099949`, `TD-916099971` |
-| `AC` / `CA` / `Azul` / `Bogong` / `Panther` / `Telica` | Air Conditioner | Full (`AC` + `Bogong` verified) | `AC-910280820`; `Bogong` — `VM211_A_04.43.06_BOGONG` (3 units, AU) — `CA`/`Azul`/`Panther`/`Telica` unverified, [submit yours](https://github.com/TTLucian/ha-electrolux/issues) |
+| `AC` / `CA` / `Azul` / `Bogong` / `Panther` / `Telica` | Air Conditioner | Full (`AC` + `Bogong` verified) | `AC-910280820`; `Bogong` — `VM211_A_04.43.06_BOGONG` (3 units, AU) — see [Bogong device notes](docs/devices/bogong.md) — `CA`/`Azul`/`Panther`/`Telica` unverified, [submit yours](https://github.com/TTLucian/ha-electrolux/issues) |
 | `DAM_AC` | DAM Air Conditioner | Catalog *(unverified)* | No samples — [submit yours](https://github.com/TTLucian/ha-electrolux/issues) |
 | `DW` | Dishwasher | Full | `DW-911434654`, `DW-911434834` |
 | `Muju` / `Verbier` / `PUREA9` / `Fuji` / `WELLA5` / `WELLA7` | Air Purifier | Full (Muju/Verbier verified) | UltimateHome 500 (EP53); Verbier — PUREA9/Fuji/WELLA5/WELLA7 unverified, [submit yours](https://github.com/TTLucian/ha-electrolux/issues) |

--- a/custom_components/electrolux/select.py
+++ b/custom_components/electrolux/select.py
@@ -155,19 +155,19 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
                 value = mapping.get(value, value)
 
         label = None
-        try:
-            if value is not None:
-                str_value = str(value)
-                label = list(self.options_list.keys())[
-                    list(self.options_list.values()).index(str_value)
-                ]
-        except (ValueError, IndexError) as ex:
-            _LOGGER.info(
-                "Electrolux error value %s does not exist in the list %s. %s",
-                value,
-                self.options_list.values(),
-                ex,
-            )
+        if value is not None:
+            str_value = str(value)
+            str_value_upper = str_value.upper()
+            for k, v in self.options_list.items():
+                if v == str_value or v.upper() == str_value_upper:
+                    label = k
+                    break
+            if label is None:
+                _LOGGER.debug(
+                    "Electrolux value %s not in options list %s, will add dynamically",
+                    value,
+                    list(self.options_list.values()),
+                )
         # When value not in the catalog → add the value to the list dynamically.
         # For non-numeric capability types, guard against numeric sentinel values
         # (e.g. "0") that the appliance may report as a transient/default state.
@@ -180,10 +180,23 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
                 and str_value.lstrip("-").isdigit()
                 and not is_numeric_capability
             )
-            if str_value and not is_numeric_sentinel:
+            cap_values: dict = self.capability.get("values") or {}
+            is_disabled_value = any(
+                k.upper() == str_value.upper()
+                and isinstance(v, dict)
+                and v.get("disabled")
+                for k, v in cap_values.items()
+            )
+            if str_value and not is_numeric_sentinel and not is_disabled_value:
                 label = self.format_label(value)
                 if label is not None and value is not None:
                     self.options_list[label] = str_value
+            elif is_disabled_value:
+                _LOGGER.debug(
+                    "Electrolux skipping disabled capability value %r for %s",
+                    value,
+                    self.entity_attr,
+                )
             else:
                 _LOGGER.debug(
                     "Electrolux skipping numeric sentinel value %r for %s",

--- a/docs/devices/bogong.md
+++ b/docs/devices/bogong.md
@@ -1,0 +1,142 @@
+# Bogong AC (Westinghouse WSD27HWAI)
+
+## Hardware
+
+| Property | Value |
+|----------|-------|
+| Model | Westinghouse WSD27HWAI |
+| Firmware | `VM211_A_04.43.06_BOGONG` |
+| Data model | `1.0.1` |
+| API type | DAM (cloud command API) |
+| Verified units | 3 (`956007025415068981045767`, `956007025415070231045767`, `956007025436004181045767`) |
+
+## Entities
+
+### Climate
+
+| Entity | Notes |
+|--------|-------|
+| `climate.<name>` | Supports off/auto/cool/heat/dry/fan_only. Power via `executeCommand ON/OFF`. |
+
+### Select
+
+| Entity | Options | Notes |
+|--------|---------|-------|
+| `select.<name>_mode` | Auto, Cool, Heat, Dry, Fanonly | `autoClean` reported as `unknown` — disabled value, not user-selectable |
+| `select.<name>_fan_speed_setting` | Auto, Quiet, Low, Middle, High | Non-auto speeds rejected by API when mode=Auto |
+| `select.<name>_temperature_unit` | Celsius, Fahrenheit | Changes AC display unit |
+
+### Number
+
+| Entity | Range | Notes |
+|--------|-------|-------|
+| `number.<name>_target_temperature_c` | 16–30°C | Fully functional |
+| `number.<name>_target_temperature_f` | — | **Known issue**: stuck at 16°F, not synced with `_c` entity |
+
+### Switch
+
+| Entity | SSE | Notes |
+|--------|-----|-------|
+| `switch.<name>_display_light` | ✅ real-time | LED display on/off |
+| `switch.<name>_vertical_swing` | ⚠️ poll-only | Works via HA/Home+; remote IR doesn't round-trip to cloud |
+| `switch.<name>_horizontal_swing` | ⚠️ poll-only | Same as vertical |
+| `switch.<name>_turbo_function` | ⚠️ poll-only | Same |
+| `switch.<name>_energy_saving_mode` | ⚠️ poll-only | ECO button on remote = local IR only |
+| `switch.<name>_clean_air_mode` | ⚠️ poll-only | Ioniser |
+| `switch.<name>_sleep_mode` | ⚠️ poll-only | Actual sleep comfort mode (separate from timer) |
+| `switch.<name>_flap_position_avoid_user` | ⚠️ poll-only | "Diffuse" in Home+ app |
+| `switch.<name>_auto_clean_trigger` | ⚠️ poll-only | Self-clean; also sets `mode=autoClean` |
+
+### Sensor
+
+| Entity | Notes |
+|--------|-------|
+| `sensor.<name>_ambient_temperature_c` | Real-time SSE |
+| `sensor.<name>_appliance_state` | Real-time SSE |
+| `sensor.<name>_compressor_state` | Poll |
+| `sensor.<name>_fan_speed_state` | Actual fan speed (vs setting) |
+| `sensor.<name>_scheduler_mode` | Timer state (poll-only) |
+| `sensor.<name>_scheduler_session` | Timer session details |
+| `sensor.<name>_network_interface_rssi` | Wi-Fi signal strength |
+
+## SSE Behaviour
+
+Properties the Electrolux cloud pushes in real-time via SSE:
+
+- `mode`
+- `fanSpeedSetting`
+- `targetTemperatureC`
+- `displayLight`
+- `applianceState` (triggers full state refresh)
+- `ambientTemperatureC`
+
+Properties that are **cloud-aware but SSE-silent** (updated on full poll only):
+
+- `verticalSwing`, `horizontalSwing`
+- `turboFunction`
+- `energySavingMode`
+- `sleepMode`
+- `cleanAirMode`
+- `flapPositionAvoidUser`
+- `schedulerMode`, `schedulerSession`
+
+Full poll interval: 6 hours (SSE health check). A full state refresh is also triggered on `applianceState` SSE events.
+
+## Remote vs Cloud Behaviour
+
+The physical remote controls some features purely via IR without reporting to the cloud:
+
+- Swing (vertical) — remote toggles louvers locally; cloud state unchanged until next Home+ or HA command
+- Turbo, ECO, self-clean — same pattern
+
+Commands sent via **Home+ app** or **HA** always round-trip through cloud → SSE or poll picks up the change.
+
+## Known Issues
+
+| Issue | Details |
+|-------|---------|
+| `autoClean` shows `unknown` | Device enters self-clean mode (`mode=autoClean`) which is `disabled` in capability. HA shows `unknown` instead of a read-only label. |
+| `target_temperature_f` stuck at 16°F | `number.<name>_target_temperature_f` not synced with `_c`. Shows default/min value. |
+| Poll-only switches | Swing/turbo/eco/sleep/cleanAir not updated via SSE — state only refreshes on 6h poll or `applianceState` event. |
+| Fan speed rejected in Auto mode | Sending non-Auto fan speed when mode=Auto returns `COMMAND_VALIDATION_ERROR`. Expected API behaviour. |
+
+## Test Results
+
+Tested 2026-05-16 against unit `956007025415068981045767` (office).
+
+### Remote → HA (SSE)
+
+| Action | SSE fired | HA updated |
+|--------|-----------|------------|
+| Mode change (heat/cool/etc.) | ✅ | ✅ |
+| Fan speed change | ✅ | ✅ |
+| Target temperature change | ✅ | ✅ |
+| Display light toggle | ✅ | ✅ |
+| Vertical swing | ❌ | ❌ (remote IR only) |
+| Turbo on | ❌ | ❌ (remote IR only) |
+| ECO on | ❌ | ❌ (remote IR only) |
+| Power off | ✅ (`mode=OFF` — skipped correctly) | ✅ (no options pollution) |
+| Self-clean | ✅ (`mode=autoClean`) | ⚠️ shows `unknown` |
+
+### Home+ → HA
+
+| Action | HA updated |
+|--------|------------|
+| Vertical swing on | ✅ (via full state refresh) |
+| Horizontal swing on | ✅ (via full state refresh) |
+| Turbo on | ✅ (via full state refresh) |
+| ECO on | ⚠️ poll-only |
+| Sleep on | ⚠️ poll-only |
+| Clean air (ioniser) on | ⚠️ poll-only |
+| Diffuse (flap) on | ⚠️ poll-only |
+
+### HA → Appliance
+
+| Command | Result |
+|---------|--------|
+| Mode: Cool/Heat/Dry/Fanonly/Auto | ✅ all accepted, AC responded |
+| Fan speed: all 5 options | ✅ (Auto mode rejects non-Auto — correct) |
+| Target temp: 18/24/30°C | ✅ AC display changed |
+| Temperature unit: C/F | ✅ AC display switched |
+| All switches on then off | ✅ AC responded to each |
+| Power off (`hvac_mode: off`) | ✅ |

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -296,6 +296,91 @@ class TestElectroluxSelect:
         assert entity.options_list == {}
         assert entity.options == []
 
+    def test_current_option_case_insensitive_match(self, mock_coordinator):
+        """Reported state value 'heat' matches capability option 'HEAT' case-insensitively.
+
+        Bogong AC (and other models) report mode values lowercase while capabilities
+        define them uppercase. Verify correct label is returned without dynamic add.
+        """
+        capability = {
+            "access": "readwrite",
+            "type": "string",
+            "values": {
+                "AUTO": {},
+                "COOL": {},
+                "HEAT": {},
+                "DRY": {},
+                "FANONLY": {},
+                "OFF": {"disabled": True},
+            },
+        }
+        entity = ElectroluxSelect(
+            coordinator=mock_coordinator,
+            capability=capability,
+            name="Mode",
+            config_entry=mock_coordinator.config_entry,
+            pnc_id="TEST_PNC",
+            entity_type=SELECT,
+            entity_name="mode",
+            entity_attr="mode",
+            entity_source=None,
+            unit=None,
+            device_class="",
+            entity_category=EntityCategory.CONFIG,
+            icon="mdi:fan",
+        )
+        entity.hass = mock_coordinator.hass
+        entity.appliance_status = {"properties": {"reported": {"mode": "heat"}}}
+        entity.reported_state = {"mode": "heat"}
+
+        label = entity.current_option
+        assert label == "Heat"
+        # 'heat' must NOT be added as a duplicate dynamic entry alongside 'HEAT'
+        assert list(entity.options_list.values()).count("HEAT") == 1
+        assert "heat" not in entity.options_list.values()
+
+    def test_current_option_disabled_value_not_added_to_options(self, mock_coordinator):
+        """Disabled capability value (mode=OFF when AC powered off) must not pollute options list.
+
+        Device sends mode=OFF when powered off. OFF is marked disabled in capabilities
+        and should be silently skipped, not added as a dynamic option.
+        """
+        capability = {
+            "access": "readwrite",
+            "type": "string",
+            "values": {
+                "AUTO": {},
+                "COOL": {},
+                "HEAT": {},
+                "DRY": {},
+                "FANONLY": {},
+                "OFF": {"disabled": True},
+            },
+        }
+        entity = ElectroluxSelect(
+            coordinator=mock_coordinator,
+            capability=capability,
+            name="Mode",
+            config_entry=mock_coordinator.config_entry,
+            pnc_id="TEST_PNC",
+            entity_type=SELECT,
+            entity_name="mode",
+            entity_attr="mode",
+            entity_source=None,
+            unit=None,
+            device_class="",
+            entity_category=EntityCategory.CONFIG,
+            icon="mdi:fan",
+        )
+        entity.hass = mock_coordinator.hass
+        entity.appliance_status = {"properties": {"reported": {"mode": "OFF"}}}
+        entity.reported_state = {"mode": "OFF"}
+
+        label = entity.current_option
+        assert label == ""
+        assert "OFF" not in entity.options_list.values()
+        assert "Off" not in entity.options_list
+
 
 class TestSelectAvailableProperty:
     """Test the available property for select entities."""


### PR DESCRIPTION
Discovered while live-testing Bogong AC with debug logging enabled.

## Root cause

Bogong AC (Westinghouse WSD27HWAI, firmware `VM211_A_04.43.06_BOGONG`) reports `mode` in **lowercase** in the reported state (e.g. `"mode": "heat"`) while API capabilities define values in **uppercase** (`"HEAT"`). The select entity used `list.index()` for an exact string match, which fails on the case mismatch.

Two failure modes observed in live logs:
1. `mode=heat` — exact match fails → INFO log → `heat` added as duplicate dynamic option alongside `HEAT`
2. `mode=OFF` — sent by device when powered off, but `OFF` is marked `"disabled": true` in capabilities → same failure path → `Off` added to options list, polluting the mode select

## Fix

- Replace `list.index()` exact match with case-insensitive loop lookup (matches `heat` → `HEAT`)
- Before dynamic add, check if value is a disabled capability entry → skip and log debug instead of adding to options
- Demote "value not in list" log from `INFO` to `DEBUG` (noise, not actionable)

## Bogong device docs

Add `docs/devices/bogong.md` with:
- Full entity reference and SSE behaviour
- SSE-capable vs poll-only property classification
- Known issues
- Live test results matrix (remote → HA, Home+ → HA, HA → appliance)

## Test plan

- [x] `test_current_option_case_insensitive_match` — `mode=heat` matches `HEAT`, returns `Heat`, no duplicate
- [x] `test_current_option_disabled_value_not_added_to_options` — `mode=OFF` (disabled) returns `""`, not added to options
- [x] 1456 tests passing
- [x] Live Bogong AC: remote → HA SSE confirmed for mode/fan/temp/displayLight
- [x] Live Bogong AC: HA → appliance confirmed for all entities (mode, fan speed, temp, temp unit, all switches, power on/off)
- [x] Power-off path: `mode=OFF` silently skipped, no options pollution

## Known issues (separate PRs)

- `autoClean` shows `unknown` — disabled value needs read-only display support
- `number.<name>_target_temperature_f` not synced with `_c`
- Swing/turbo/eco/sleep/cleanAir SSE-silent — Electrolux cloud limitation

Closes #43