### PR TITLE
fix(climate): use applianceState to detect physical power-off

### DIFF
--- a/custom_components/electrolux/climate.py
+++ b/custom_components/electrolux/climate.py
@@ -242,11 +242,18 @@ class ElectroluxClimate(ElectroluxEntity, ClimateEntity, RestoreEntity):
 
     @property
     def hvac_mode(self) -> HVACMode:
+        """Return current HVAC mode.
+
+        applianceState=Off reliably means the unit is powered off (confirmed via
+        live testing: physical remote off → applianceState=Off; all active modes
+        including fan_only keep applianceState=Running). When the physical remote
+        powers off the unit, the device does NOT update `mode` to OFF — it retains
+        the last active mode. Checking applianceState first handles that case.
         """
-        Electrolux ACs do NOT use applianceState to indicate ON/OFF.
-        They always report applianceState="OFF" unless the compressor is running.
-        Power state must be derived from `mode`, not `applianceState`.
-        """
+        appliance_state = self.get_state_attr("applianceState")
+        if appliance_state and str(appliance_state).upper() == "OFF":
+            return HVACMode.OFF
+
         mode_value = self.get_state_attr("mode")
         if not mode_value:
             return HVACMode.OFF

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -253,6 +253,12 @@ class TestElectroluxClimate:
         mock_appliance.reported_state["mode"] = "OFF"
         assert climate_entity.hvac_mode == HVACMode.OFF
 
+    def test_hvac_mode_off_via_appliance_state(self, climate_entity, mock_appliance):
+        """Physical remote power-off: applianceState=Off, mode retains last value."""
+        mock_appliance.reported_state["applianceState"] = "Off"
+        mock_appliance.reported_state["mode"] = "cool"
+        assert climate_entity.hvac_mode == HVACMode.OFF
+
     def test_hvac_mode_auto(self, climate_entity, mock_appliance):
         """Test HVAC mode returns AUTO."""
         mock_appliance.reported_state["applianceState"] = "RUNNING"


### PR DESCRIPTION
## Root cause

When the physical remote powers off the AC, the device does NOT update `mode` to `OFF` — it retains the last active mode (e.g. `cool`, `heat`). The previous `hvac_mode` logic derived power state from `mode` alone, so HA showed the last active mode instead of `off` after physical power-off.

The comment in the code claimed `applianceState=OFF` even when the compressor is idle (unit on). This was wrong.

## Live testing (Bogong AC, 3 units)

| applianceState | Condition |
|---|---|
| `Running` | Unit on — any active mode (cool/heat/fan_only/auto) |
| `Off` | Unit physically off (remote or HA command) |

`applianceState=Running` persisted across all active modes including `fan_only` (no compressor). `applianceState=Off` only appeared on physical or HA-initiated power-off. The field is reliable for power state detection.

## Fix

Check `applianceState` first in `hvac_mode` property. If `Off`, return `HVACMode.OFF` regardless of `mode` value. Fall through to mode-based mapping only when unit is on.

## Test plan

- [x] `test_hvac_mode_off_via_appliance_state` — `applianceState=Off` + `mode=cool` → returns `HVACMode.OFF`
- [x] All existing 69 climate tests pass
- [x] Live tested on 3 Bogong AC units