### PR TITLE
test(switch): fix phantom-filter regression in test_switch_platform_setup_success

### DIFF
--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -170,6 +170,9 @@ class TestSwitchPlatformSetup:
         mock_entity.entity_type = SWITCH  # Match the exact constant used in switch.py
         mock_entity.entity_attr = test_attr
         mock_entity.friendly_name = "Pre-Wash"
+        # json_path must be present in reported_state so the phantom-capability
+        # filter in switch.async_setup_entry does not skip this entity.
+        mock_entity.json_path = test_attr
         # Provide the write/readwrite capabilities required by the switch platform
         mock_entity.capability_info = {"access": "readwrite", "type": "boolean"}
         mock_entity.capability = {"access": "readwrite", "type": "boolean"}
@@ -182,6 +185,9 @@ class TestSwitchPlatformSetup:
         mock_appliance.capabilities = {
             test_attr: {"access": "readwrite", "type": "boolean"}
         }
+        # reported_state is consulted by switch.async_setup_entry to filter out
+        # phantom/ghost capabilities (Issue #55).
+        mock_appliance.reported_state = {test_attr: True}
         mock_appliance.state = {
             "properties": {"reported": {test_attr: True}},
             "capabilities": {test_attr: {"access": "readwrite", "type": "boolean"}},


### PR DESCRIPTION
## Summary
- Fix the only failing test on `main` (CI run [26050289144](https://github.com/TTLucian/ha-electrolux/actions/runs/26050289144)).
- `tests/test_platform_setup.py::TestSwitchPlatformSetup::test_switch_platform_setup_success` was asserting `mock_add_entities.assert_called_once()` and getting `Called 0 times`.

## Root cause
The phantom-capability filter introduced in `switch.async_setup_entry` (Issue #55, commit a5e78e7) reads `appliance.reported_state` and `entity.json_path`. The test fixture set neither, so MagicMock auto-attributes (`reported_state` → `MagicMock`, `json_path` → `MagicMock`) made `__contains__` return `False` for every check, and the filter skipped every entity.

## Fix
- Set `mock_entity.json_path = test_attr` so the entity has a real path.
- Set `mock_appliance.reported_state = {test_attr: True}` so the path is "reported" by the appliance and the filter keeps the entity.

No production code changes.

## Test plan
- [x] `pytest tests/test_platform_setup.py` — 14 passed.
- [x] `pytest --cov=custom_components/electrolux --cov-fail-under=70` — 1455 passed, coverage 94.35%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)