### PR TITLE
fix(triggers): skip default-write when trigger action declares constraints (closes #70)

### DIFF
--- a/custom_components/electrolux/entity.py
+++ b/custom_components/electrolux/entity.py
@@ -482,23 +482,12 @@ class ElectroluxEntity(CoordinatorEntity):
         Only ``{operand_1: "value", operand_2: X, operator: "eq"}`` conditions
         are handled — these cover all known DW/WM/dryer option triggers.
 
-        Two trigger-action shapes are distinguished:
-
-        * **Force value** — ``{"default": X}`` with no schema metadata.  These
-          mean "this attribute is now forced to X by the device" (DW/WM option
-          interactions).  An SSE confirmation will follow, so writing the
-          default into ``reported`` immediately is correct.
-        * **Constraints declaration** — ``{"default": X, "min": ..., "max": ...,
-          "step": ..., "type": ..., "access": ..., "values": ..., "disabled":
-          ...}``.  These describe what the attribute looks like in the new
-          mode but do **not** mean the device has changed it (AC mode triggers
-          on Bogong, for example, declare ``targetTemperatureC`` constraints
-          per mode without the device ever resetting the setpoint).  Writing
-          the default into ``reported`` here would lie about device state until
-          the next coordinator poll because no SSE follows — see issue #70.
-
-        We detect "constraints declaration" by the presence of any schema
-        metadata keys other than ``default``.
+        A trigger action's ``default`` is treated as a forced value only when
+        the action contains nothing but ``default``.  Actions that also carry
+        schema metadata (min/max/step/type/access/values/disabled) describe
+        constraints in the new mode but do not mean the device changed the
+        value — writing such defaults into ``reported`` produces phantom UI
+        state until the next coordinator poll (see issue #70).
         """
         if not self.appliance_status:
             return
@@ -572,28 +561,16 @@ class ElectroluxEntity(CoordinatorEntity):
                     continue
 
                 # Constraints-declaration shape (issue #70): the action describes
-                # what the affected attribute looks like in the new mode (min,
-                # max, step, type, access, values, disabled) but the device does
-                # not actually reset the value.  Writing the default would lie
-                # about live state until the next coordinator poll because no
-                # SSE follows.  Skip the write — _is_disabled_by_trigger and
-                # related helpers still consult the same ``action_def`` for
-                # availability/lockout via a separate code path.
-                schema_keys = {
-                    "min",
-                    "max",
-                    "step",
-                    "type",
-                    "access",
-                    "values",
-                    "disabled",
-                }
-                is_constraint_declaration = any(k in action_def for k in schema_keys)
-                if is_constraint_declaration:
+                # what the affected attribute looks like in the new mode but the
+                # device does not actually reset the value.  A force-value
+                # action contains nothing but ``default``; anything else is a
+                # constraints declaration and the default is informational.
+                # _is_disabled_by_trigger handles availability/lockout via a
+                # separate code path against the same ``action_def``.
+                if action_def.keys() != {"default"}:
                     _LOGGER.debug(
                         "Skipping trigger default for %s — action declares "
-                        "constraints (min/max/step/type/access/values/"
-                        "disabled), not a forced value",
+                        "constraints, not a forced value",
                         affected_key,
                     )
                     continue

--- a/custom_components/electrolux/entity.py
+++ b/custom_components/electrolux/entity.py
@@ -481,6 +481,24 @@ class ElectroluxEntity(CoordinatorEntity):
 
         Only ``{operand_1: "value", operand_2: X, operator: "eq"}`` conditions
         are handled — these cover all known DW/WM/dryer option triggers.
+
+        Two trigger-action shapes are distinguished:
+
+        * **Force value** — ``{"default": X}`` with no schema metadata.  These
+          mean "this attribute is now forced to X by the device" (DW/WM option
+          interactions).  An SSE confirmation will follow, so writing the
+          default into ``reported`` immediately is correct.
+        * **Constraints declaration** — ``{"default": X, "min": ..., "max": ...,
+          "step": ..., "type": ..., "access": ..., "values": ..., "disabled":
+          ...}``.  These describe what the attribute looks like in the new
+          mode but do **not** mean the device has changed it (AC mode triggers
+          on Bogong, for example, declare ``targetTemperatureC`` constraints
+          per mode without the device ever resetting the setpoint).  Writing
+          the default into ``reported`` here would lie about device state until
+          the next coordinator poll because no SSE follows — see issue #70.
+
+        We detect "constraints declaration" by the presence of any schema
+        metadata keys other than ``default``.
         """
         if not self.appliance_status:
             return
@@ -550,6 +568,33 @@ class ElectroluxEntity(CoordinatorEntity):
                         "Skipping non-scalar trigger default for %s: %s",
                         affected_key,
                         triggered_value,
+                    )
+                    continue
+
+                # Constraints-declaration shape (issue #70): the action describes
+                # what the affected attribute looks like in the new mode (min,
+                # max, step, type, access, values, disabled) but the device does
+                # not actually reset the value.  Writing the default would lie
+                # about live state until the next coordinator poll because no
+                # SSE follows.  Skip the write — _is_disabled_by_trigger and
+                # related helpers still consult the same ``action_def`` for
+                # availability/lockout via a separate code path.
+                schema_keys = {
+                    "min",
+                    "max",
+                    "step",
+                    "type",
+                    "access",
+                    "values",
+                    "disabled",
+                }
+                is_constraint_declaration = any(k in action_def for k in schema_keys)
+                if is_constraint_declaration:
+                    _LOGGER.debug(
+                        "Skipping trigger default for %s — action declares "
+                        "constraints (min/max/step/type/access/values/"
+                        "disabled), not a forced value",
+                        affected_key,
                     )
                     continue
 

--- a/tests/test_entity_coverage_gaps.py
+++ b/tests/test_entity_coverage_gaps.py
@@ -781,6 +781,127 @@ class TestApplyOptimisticUpdateGaps:
 
         set_updated_mock.assert_not_called()
 
+    def test_trigger_skips_default_when_action_declares_constraints(self):
+        """Issue #70: AC mode trigger declares constraints, must NOT override.
+
+        On Bogong AC, switching ``mode`` to COOL/HEAT/AUTO/DRY fires a trigger
+        whose action describes ``targetTemperatureC`` constraints (``access``,
+        ``min``, ``max``, ``step``, ``type``, ``disabled``) along with a
+        ``default``. The device does not actually reset the setpoint, so
+        writing the default into ``reported`` produced phantom UI values
+        until the next coordinator poll.
+
+        The action is now classified as a "constraints declaration" by the
+        presence of any schema metadata key. Default is skipped; live value
+        is preserved.
+        """
+        reported = {
+            "mode": "HEAT",
+            "targetTemperatureC": 28,
+        }
+        capabilities = {
+            "mode": {
+                "access": "readwrite",
+                "type": "string",
+                "triggers": [
+                    {
+                        "condition": {
+                            "operand_1": "value",
+                            "operand_2": "COOL",
+                            "operator": "eq",
+                        },
+                        "action": {
+                            "targetTemperatureC": {
+                                "access": "readwrite",
+                                "default": 16,
+                                "max": 30,
+                                "min": 16,
+                                "step": 1,
+                                "type": "temperature",
+                                "disabled": False,
+                            },
+                        },
+                    }
+                ],
+            }
+        }
+        entity = make_entity(
+            entity_attr="mode",
+            reported=reported,
+            capability=capabilities["mode"],
+        )
+        entity.coordinator.data["appliances"].get_appliance(
+            "TEST_APPLIANCE_123"
+        ).data.capabilities = capabilities
+        set_updated_mock = MagicMock()
+        entity.coordinator.async_set_updated_data = set_updated_mock
+
+        entity._apply_triggered_updates("mode", "COOL")
+
+        # Live value preserved — no phantom 16
+        assert reported["targetTemperatureC"] == 28
+        # Coordinator was not notified because no write happened
+        set_updated_mock.assert_not_called()
+
+    def test_trigger_skips_default_when_disabled_constraint_declared(self):
+        """Issue #70: FANONLY trigger locks targetTemperatureC; default still skipped.
+
+        On Bogong AC, mode=FANONLY declares targetTemperatureC with
+        ``disabled: true`` and ``default: 23``. The previous behaviour wrote
+        23 into ``reported`` on every transition, masking the device's actual
+        setpoint (which the unit retains across mode changes).
+
+        Disabled-vs-enabled is handled separately via ``_is_disabled_by_trigger``
+        for entity availability; this code path does not need to mirror it
+        into reported state.
+        """
+        reported = {
+            "mode": "COOL",
+            "targetTemperatureC": 28,
+        }
+        capabilities = {
+            "mode": {
+                "access": "readwrite",
+                "type": "string",
+                "triggers": [
+                    {
+                        "condition": {
+                            "operand_1": "value",
+                            "operand_2": "FANONLY",
+                            "operator": "eq",
+                        },
+                        "action": {
+                            "targetTemperatureC": {
+                                "access": "readwrite",
+                                "default": 23,
+                                "max": 23,
+                                "min": 23,
+                                "step": 1,
+                                "type": "temperature",
+                                "disabled": True,
+                            },
+                        },
+                    }
+                ],
+            }
+        }
+        entity = make_entity(
+            entity_attr="mode",
+            reported=reported,
+            capability=capabilities["mode"],
+        )
+        entity.coordinator.data["appliances"].get_appliance(
+            "TEST_APPLIANCE_123"
+        ).data.capabilities = capabilities
+        set_updated_mock = MagicMock()
+        entity.coordinator.async_set_updated_data = set_updated_mock
+
+        entity._apply_triggered_updates("mode", "FANONLY")
+
+        # Live value preserved
+        assert reported["targetTemperatureC"] == 28
+        set_updated_mock.assert_not_called()
+
     def test_trigger_integrates_via_apply_optimistic_update(self):
         """_apply_optimistic_update calls _apply_triggered_updates transparently."""
         reported = {


### PR DESCRIPTION
Closes #70. Should also clear the residual symptoms in #43 (the remainder after #62).

## Summary

`_apply_triggered_updates` writes the trigger action's `default` into the shared `reported` dict so HA UI updates immediately, ahead of the SSE confirmation. That works when the trigger represents a **forced value** the device actually applies (DW/WM option interactions — the SSE arrives shortly after) but produces phantom UI state when the trigger is a **constraints declaration** the device does not act on.

Live testing on Bogong WSD27HWAI confirmed the AC retains `targetTemperatureC=28` regardless of mode changes (no SSE for `targetTemperatureC` is emitted), yet HA UI was showing the catalog-default 16 (cool/heat/auto/dry) or 23 (fanonly) until the next 6 h coordinator poll. See #70 for the full table.

## Heuristic

A trigger action's `default` is treated as a forced value only when the action contains nothing but `default`. If the action carries any other keys (typically `min`/`max`/`step`/`type`/`access`/`values`/`disabled`), it is a constraints declaration and the `reported`-write step is skipped (a debug log line is emitted instead). Availability/lockout for `disabled: true` is unaffected because that flows through `_is_disabled_by_trigger`, which reads `action_def` directly.

## Why this is safe for DW/WM

The existing DW/WM trigger fixtures in tests use the bare `{"default": false}` shape (e.g. `extraPowerOption=true` triggers `glassCareOption: {"default": false}`). Those actions match `keys() == {"default"}`, so the new branch does not apply and behaviour is unchanged. `test_trigger_fires_and_updates_sibling_options` and the rest of the existing trigger suite continue to pass.

## Tests

- 116 trigger tests pass (114 pre-existing + 2 new for the AC constraints case)
  - `test_trigger_skips_default_when_action_declares_constraints` — `disabled: false` AC mode action
  - `test_trigger_skips_default_when_disabled_constraint_declared` — `disabled: true` AC FANONLY action
- Full suite: 1461 tests pass.

## Live verification (Bogong office, `3.6.7+pr70.draft`)

Cycled `cool → heat → fan_only` via climate card + select dropdown:

| Step | Path | Before this PR | After this PR |
|------|------|----------------|---------------|
| Turn on cool | climate card | brief dip to 16 | stays 24 |
| Mode cool → heat | select dropdown | targetTemperatureC=16 written, persists | stays 24 |
| Mode heat → fan_only | select dropdown | targetTemperatureC=23 written, persists | stays 24 |

Same cycle on `main` produced `16, 16, 23` writes; this branch produced none.

## Notes

- This is a behaviour change in `_apply_triggered_updates` only. `_apply_optimistic_update` for the changed attribute itself, and `_is_disabled_by_trigger` for entity availability, are unaffected.
- The 16 dip seen during HA-driven mode changes (climate-card path) was a combination of this trigger lie + #48's re-apply. With this fix, the dip is gone for both UI paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)