### PR TITLE
fix(climate): honour hvac_mode kwarg when device is on (closes #71)

### DIFF
--- a/custom_components/electrolux/climate.py
+++ b/custom_components/electrolux/climate.py
@@ -410,19 +410,15 @@ class ElectroluxClimate(ElectroluxEntity, ClimateEntity, RestoreEntity):
                 raise HomeAssistantError(
                     "Cannot set temperature while appliance is off"
                 )
-            # async_set_hvac_mode reads _last_user_temperature mid-call and
-            # re-applies it after powering on, so the new value must be in
-            # place before we await. The pre-write/rollback is asymmetric with
-            # the on-path below (which writes after success); it exists solely
-            # to make the cache atomic with that internal read. Note that
-            # rollback only restores cache coherence — it cannot undo any
-            # partial hardware state if async_set_hvac_mode fails mid-sequence.
-            cached_temp = self._last_user_temperature
+            # async_set_hvac_mode re-applies _last_user_temperature after powering
+            # on, so the new value must be visible to it. Roll back on failure to
+            # avoid leaving a never-applied value in the cache.
+            previous = self._last_user_temperature
             self._last_user_temperature = new_temp
             try:
                 await self.async_set_hvac_mode(hvac_mode)
             except Exception:
-                self._last_user_temperature = cached_temp
+                self._last_user_temperature = previous
                 raise
             return
 

--- a/custom_components/electrolux/climate.py
+++ b/custom_components/electrolux/climate.py
@@ -388,11 +388,19 @@ class ElectroluxClimate(ElectroluxEntity, ClimateEntity, RestoreEntity):
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature.
 
+        Honours both ``temperature`` and the optional ``hvac_mode`` kwargs of
+        the standard HA ``climate.set_temperature`` service.
+
         Guard for off-state: the Electrolux API returns HTTP 500 when a
         combined power-on + set-temperature command is sent in a single call.
         If the appliance is currently off, split into sequential commands
         (power on via set_hvac_mode, which re-applies the cached temperature)
         or refuse if no hvac_mode was supplied.
+
+        When the appliance is on and ``hvac_mode`` differs from the current
+        mode, route through ``async_set_hvac_mode`` so the mode change and
+        temperature re-apply happen as one coherent sequence (#71). Same hvac
+        mode (or none supplied) goes through the simple set-temperature path.
 
         ``_last_user_temperature`` is only updated after the underlying command
         succeeds — a failed API call must not pollute the cache that #48's
@@ -404,19 +412,25 @@ class ElectroluxClimate(ElectroluxEntity, ClimateEntity, RestoreEntity):
 
         hvac_mode = kwargs.get("hvac_mode")
         new_temp = float(temperature)
+        current_mode = self.hvac_mode
 
-        if self.hvac_mode == HVACMode.OFF:
+        # Off-state branch: requires an hvac_mode to power on.
+        if current_mode == HVACMode.OFF:
             if hvac_mode is None:
                 raise HomeAssistantError(
                     "Cannot set temperature while appliance is off"
                 )
-            # async_set_hvac_mode reads _last_user_temperature mid-call and
-            # re-applies it after powering on, so the new value must be in
-            # place before we await. The pre-write/rollback is asymmetric with
-            # the on-path below (which writes after success); it exists solely
-            # to make the cache atomic with that internal read. Note that
-            # rollback only restores cache coherence — it cannot undo any
-            # partial hardware state if async_set_hvac_mode fails mid-sequence.
+            # Fall through to the shared mode-change path below.
+
+        # When a mode change is requested (off→on, or on→different mode),
+        # delegate to async_set_hvac_mode. It reads _last_user_temperature
+        # mid-call and re-applies it, so the new value must be in place
+        # before we await. The pre-write/rollback is asymmetric with the
+        # plain set-temperature path below (which writes after success);
+        # it exists solely to make the cache atomic with that internal
+        # read. Rollback only restores cache coherence — it cannot undo any
+        # partial hardware state if async_set_hvac_mode fails mid-sequence.
+        if hvac_mode is not None and hvac_mode != current_mode:
             cached_temp = self._last_user_temperature
             self._last_user_temperature = new_temp
             try:
@@ -426,6 +440,8 @@ class ElectroluxClimate(ElectroluxEntity, ClimateEntity, RestoreEntity):
                 raise
             return
 
+        # Same mode (or no mode supplied) on a running appliance: simple
+        # set-temperature. Cache only after the command succeeds.
         await self._send_command(f"targetTemperature{self._temp_suffix}", new_temp)
         self._last_user_temperature = new_temp
 

--- a/custom_components/electrolux/climate.py
+++ b/custom_components/electrolux/climate.py
@@ -410,15 +410,19 @@ class ElectroluxClimate(ElectroluxEntity, ClimateEntity, RestoreEntity):
                 raise HomeAssistantError(
                     "Cannot set temperature while appliance is off"
                 )
-            # async_set_hvac_mode re-applies _last_user_temperature after powering
-            # on, so the new value must be visible to it. Roll back on failure to
-            # avoid leaving a never-applied value in the cache.
-            previous = self._last_user_temperature
+            # async_set_hvac_mode reads _last_user_temperature mid-call and
+            # re-applies it after powering on, so the new value must be in
+            # place before we await. The pre-write/rollback is asymmetric with
+            # the on-path below (which writes after success); it exists solely
+            # to make the cache atomic with that internal read. Note that
+            # rollback only restores cache coherence — it cannot undo any
+            # partial hardware state if async_set_hvac_mode fails mid-sequence.
+            cached_temp = self._last_user_temperature
             self._last_user_temperature = new_temp
             try:
                 await self.async_set_hvac_mode(hvac_mode)
             except Exception:
-                self._last_user_temperature = previous
+                self._last_user_temperature = cached_temp
                 raise
             return
 

--- a/custom_components/electrolux/climate.py
+++ b/custom_components/electrolux/climate.py
@@ -414,13 +414,17 @@ class ElectroluxClimate(ElectroluxEntity, ClimateEntity, RestoreEntity):
         new_temp = float(temperature)
         current_mode = self.hvac_mode
 
-        # Off-state branch: requires an hvac_mode to power on.
+        # Off-state branch: requires a non-OFF hvac_mode to power on. Falling
+        # through to the simple-set path on an off device would hit the API
+        # 500 we are guarding against, so reject ``hvac_mode=None`` *and*
+        # ``hvac_mode=OFF`` here. After this block, an off appliance is
+        # guaranteed to have a live hvac_mode that differs from current_mode,
+        # which the mode-change branch below picks up.
         if current_mode == HVACMode.OFF:
-            if hvac_mode is None:
+            if hvac_mode is None or hvac_mode == HVACMode.OFF:
                 raise HomeAssistantError(
                     "Cannot set temperature while appliance is off"
                 )
-            # Fall through to the shared mode-change path below.
 
         # When a mode change is requested (off→on, or on→different mode),
         # delegate to async_set_hvac_mode. It reads _last_user_temperature

--- a/custom_components/electrolux/number.py
+++ b/custom_components/electrolux/number.py
@@ -632,9 +632,12 @@ class ElectroluxNumber(ElectroluxEntity, NumberEntity):
         # climate-entity OFF command optimistically writes ``mode=OFF`` before
         # the ``applianceState=Off`` SSE event arrives.
         if self.entity_attr in _AC_TEMPERATURE_ATTRS:
-            appliance_state = str(self.reported_state.get("applianceState") or "")
-            mode_value = str(self.reported_state.get("mode") or "")
-            if appliance_state.upper() == "OFF" or mode_value.upper() == "OFF":
+            appliance_state = self.reported_state.get("applianceState")
+            mode_value = self.reported_state.get("mode")
+            is_off = (
+                isinstance(appliance_state, str) and appliance_state.upper() == "OFF"
+            ) or (isinstance(mode_value, str) and mode_value.upper() == "OFF")
+            if is_off:
                 raise HomeAssistantError(
                     f"Cannot set '{self.entity_attr}' while appliance is off. "
                     "Turn the appliance on first.",

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -467,6 +467,52 @@ class TestElectroluxClimate:
         climate_entity._send_command.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_async_set_temperature_on_with_different_hvac_mode_routes_through_set_mode(
+        self, climate_entity, mock_appliance
+    ):
+        """On-device + hvac_mode different from current routes via set_hvac_mode (#71).
+
+        The standard ``climate.set_temperature`` service accepts both
+        ``temperature`` and ``hvac_mode``. When the appliance is on, the mode
+        change must still apply — previously it was silently dropped because
+        the integration only handled ``hvac_mode`` in the off-state branch.
+        """
+        mock_appliance.reported_state["applianceState"] = "RUNNING"
+        mock_appliance.reported_state["mode"] = "COOL"
+        climate_entity._send_command = AsyncMock()
+
+        await climate_entity.async_set_temperature(
+            temperature=28.0, hvac_mode=HVACMode.HEAT
+        )
+
+        # Three commands: ON (idempotent), mode=HEAT, targetTemperatureC=28.0
+        assert climate_entity._send_command.call_count == 3
+        calls = climate_entity._send_command.call_args_list
+        assert calls[0][0] == ("executeCommand", "ON")
+        assert calls[1][0] == ("mode", "HEAT")
+        assert calls[2][0] == ("targetTemperatureC", 28.0)
+        assert climate_entity._last_user_temperature == 28.0
+
+    @pytest.mark.asyncio
+    async def test_async_set_temperature_on_with_same_hvac_mode_uses_simple_path(
+        self, climate_entity, mock_appliance
+    ):
+        """On-device + hvac_mode equal to current uses the simple set path."""
+        mock_appliance.reported_state["applianceState"] = "RUNNING"
+        mock_appliance.reported_state["mode"] = "COOL"
+        climate_entity._send_command = AsyncMock()
+
+        await climate_entity.async_set_temperature(
+            temperature=24.0, hvac_mode=HVACMode.COOL
+        )
+
+        # One command — same-mode case must not trigger the 3-command sequence.
+        climate_entity._send_command.assert_called_once_with(
+            "targetTemperatureC", 24.0
+        )
+        assert climate_entity._last_user_temperature == 24.0
+
+    @pytest.mark.asyncio
     async def test_async_set_temperature_on_failure_does_not_pollute_cache(
         self, climate_entity, mock_appliance
     ):

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -467,6 +467,51 @@ class TestElectroluxClimate:
         climate_entity._send_command.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_async_set_temperature_off_with_hvac_mode_off_raises(
+        self, climate_entity, mock_appliance
+    ):
+        """OFF + hvac_mode=OFF must raise — never fall through to simple-set.
+
+        ``hvac_mode=OFF`` looks like a valid kwarg but cannot power the
+        appliance on, so the simple-set path would hit the very HTTP 500
+        the off-state guard exists to prevent. Refuse it explicitly.
+        """
+        from homeassistant.exceptions import HomeAssistantError
+
+        mock_appliance.reported_state["mode"] = "OFF"
+        climate_entity._send_command = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="appliance is off"):
+            await climate_entity.async_set_temperature(
+                temperature=24.0, hvac_mode=HVACMode.OFF
+            )
+
+        climate_entity._send_command.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_set_temperature_on_mode_change_failure_rolls_back_cache(
+        self, climate_entity, mock_appliance
+    ):
+        """ON + hvac_mode-change path must roll back ``_last_user_temperature`` on failure.
+
+        Mirrors the rollback contract already covered for the OFF path, but
+        on the on→on transition introduced by #71. Without this guarantee,
+        a failed ``async_set_hvac_mode`` would leave a never-applied value
+        in the cache that #48's re-apply would pick up later.
+        """
+        mock_appliance.reported_state["applianceState"] = "RUNNING"
+        mock_appliance.reported_state["mode"] = "COOL"
+        climate_entity._last_user_temperature = 22.0
+        climate_entity._send_command = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with pytest.raises(RuntimeError):
+            await climate_entity.async_set_temperature(
+                temperature=28.0, hvac_mode=HVACMode.HEAT
+            )
+
+        assert climate_entity._last_user_temperature == 22.0
+
+    @pytest.mark.asyncio
     async def test_async_set_temperature_on_with_different_hvac_mode_routes_through_set_mode(
         self, climate_entity, mock_appliance
     ):

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -2290,37 +2290,6 @@ class TestNumberMissingCoverage:
         with pytest.raises(HomeAssistantError, match="appliance is off"):
             await entity.async_set_native_value(24.0)
 
-    @pytest.mark.asyncio
-    async def test_set_native_value_target_temp_passes_guard_when_running(
-        self, mock_coordinator
-    ):
-        """Off-state guard must not raise when the appliance is running.
-
-        We don't assert all the way to _send_command — other gates (connection,
-        formatting, capability checks) may legitimately fail in the bare test
-        fixture. The point is: the off-state guard does not erroneously fire.
-        """
-        entity = self._make_entity(
-            mock_coordinator,
-            entity_attr="targetTemperatureC",
-            capability={"type": "temperature", "min": 16, "max": 30, "step": 1},
-        )
-        entity._is_locked_by_program = MagicMock(return_value=False)
-        entity._is_supported_by_program = MagicMock(return_value=True)
-        entity.reported_state = {
-            "connectivityState": "Connected",
-            "applianceState": "running",
-        }
-
-        try:
-            await entity.async_set_native_value(24.0)
-        except HomeAssistantError as ex:
-            # The off-state guard must not be the source of the error.
-            assert "appliance is off" not in str(ex)
-        except Exception:
-            # Other errors (e.g. test-fixture limitations) are out of scope.
-            pass
-
     # Line 798: available delegates to ElectroluxEntity.available (True)
     def test_available_delegates_to_entity_super_true(self, mock_coordinator):
         """available delegates to super().available (line 798) — returns True case."""

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -2290,6 +2290,37 @@ class TestNumberMissingCoverage:
         with pytest.raises(HomeAssistantError, match="appliance is off"):
             await entity.async_set_native_value(24.0)
 
+    @pytest.mark.asyncio
+    async def test_set_native_value_target_temp_passes_guard_when_running(
+        self, mock_coordinator
+    ):
+        """Off-state guard must not raise when the appliance is running.
+
+        We don't assert all the way to _send_command — other gates (connection,
+        formatting, capability checks) may legitimately fail in the bare test
+        fixture. The point is: the off-state guard does not erroneously fire.
+        """
+        entity = self._make_entity(
+            mock_coordinator,
+            entity_attr="targetTemperatureC",
+            capability={"type": "temperature", "min": 16, "max": 30, "step": 1},
+        )
+        entity._is_locked_by_program = MagicMock(return_value=False)
+        entity._is_supported_by_program = MagicMock(return_value=True)
+        entity.reported_state = {
+            "connectivityState": "Connected",
+            "applianceState": "running",
+        }
+
+        try:
+            await entity.async_set_native_value(24.0)
+        except HomeAssistantError as ex:
+            # The off-state guard must not be the source of the error.
+            assert "appliance is off" not in str(ex)
+        except Exception:
+            # Other errors (e.g. test-fixture limitations) are out of scope.
+            pass
+
     # Line 798: available delegates to ElectroluxEntity.available (True)
     def test_available_delegates_to_entity_super_true(self, mock_coordinator):
         """available delegates to super().available (line 798) — returns True case."""


### PR DESCRIPTION
Closes #71. Stacked on top of #63 — please merge #63 first or rebase this on main once #63 lands.

## Summary

`climate.set_temperature` accepts both `temperature` and an optional `hvac_mode` (the standard HA combined form). PR #63 honoured `hvac_mode` only in the off-state branch; on-device calls silently dropped it. This PR routes through `async_set_hvac_mode` whenever the requested mode differs from the current mode, so combined drag-temp-and-change-mode gestures from the climate card work correctly while the appliance is running.

## Behaviour matrix

| Pre-state | `hvac_mode` kwarg | Action |
|-----------|-------------------|--------|
| OFF | omitted or `OFF` | Raise `HomeAssistantError` |
| OFF | non-OFF mode | 3 commands: `executeCommand=ON`, `mode=X`, `targetTemperatureC=T` (PR #63) |
| ON, same mode | omitted or matches current | 1 command: `targetTemperatureC=T` |
| ON, different mode | provided | 3 commands: `executeCommand=ON`, `mode=Y`, `targetTemperatureC=T` (this PR) |

Cache pollution semantics from #63 are preserved — the pre-write + rollback wraps every mode-change path now, not just off→on.

## Tests

- `test_async_set_temperature_on_with_different_hvac_mode_routes_through_set_mode` — 3-command sequence, cache updated
- `test_async_set_temperature_on_with_same_hvac_mode_uses_simple_path` — 1 command, simple path
- `test_async_set_temperature_off_with_hvac_mode_off_raises` — OFF + `hvac_mode=OFF` does not slip through to the simple-set path
- `test_async_set_temperature_on_mode_change_failure_rolls_back_cache` — rollback contract on the on→on path
- All existing tests still pass (77 climate, 1469 total).

## Live verification (Bogong office, `3.6.7+pr71`)

| Step | Pre | Service call | Result |
|------|-----|--------------|--------|
| Mode change with new temp | running `cool 22` | `climate.set_temperature(temperature=28, hvac_mode=heat)` | 3 cmds (`executeCommand=ON` 200, `mode=HEAT` 200, `targetTemperatureC=28` 200); device cloud poll: `applianceState=running, mode=heat, targetC=28`; HA UI: `heat / 28 / heating` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)