### PR TITLE
fix(select): show read-only label for current value when capability marks it disabled (closes #58)

### DIFF
--- a/custom_components/electrolux/select.py
+++ b/custom_components/electrolux/select.py
@@ -192,9 +192,18 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
                 if label is not None and value is not None:
                     self.options_list[label] = str_value
             elif is_disabled_value:
+                # Disabled capability values (e.g. AC ``autoClean``, ``OFF``)
+                # are not user-selectable, but the device can be IN that
+                # state — show a read-only label so the UI does not display
+                # ``unknown`` (#58). The label is NOT persisted in
+                # options_list; the ``options`` property injects it
+                # transiently while the value is current.
+                label = self.format_label(value)
                 _LOGGER.debug(
-                    "Electrolux skipping disabled capability value %r for %s",
+                    "Electrolux disabled-value %r shown as transient "
+                    "read-only label %r for %s",
                     value,
+                    label,
                     self.entity_attr,
                 )
             else:
@@ -410,6 +419,11 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
         2. Check for program-specific value constraints
         3. Filter options to only include program-allowed values
         4. Fall back to all options if no program constraints exist
+        5. If ``current_option`` resolves to a label not in ``options_list``
+           (a disabled capability value reported by the device), append it
+           so ``SelectEntity``'s ``current_option in options`` invariant
+           holds (#58). Read-only by virtue of being absent from
+           ``options_list`` — the user can see the state but not select it.
 
         Returns:
             list[str]: Filtered list of selectable option labels
@@ -423,11 +437,18 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
             if isinstance(program_values, list):
                 # Filter options to only include those allowed by the program
                 allowed_values = set(str(v) for v in program_values)
-                filtered_options = []
-                for label, value in self.options_list.items():
-                    if str(value) in allowed_values:
-                        filtered_options.append(label)
-                return filtered_options
+                all_options = [
+                    label
+                    for label, value in self.options_list.items()
+                    if str(value) in allowed_values
+                ]
 
-        # No program constraints, return all options
+        # Append the current label if it falls outside the persistent
+        # options_list — currently only happens for disabled capability
+        # values (#58). Reusing ``current_option`` keeps the disabled-value
+        # detection in one place.
+        current = self.current_option
+        if current and current not in all_options:
+            all_options.append(current)
+
         return all_options

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -339,11 +339,16 @@ class TestElectroluxSelect:
         assert list(entity.options_list.values()).count("HEAT") == 1
         assert "heat" not in entity.options_list.values()
 
-    def test_current_option_disabled_value_not_added_to_options(self, mock_coordinator):
-        """Disabled capability value (mode=OFF when AC powered off) must not pollute options list.
+    def test_current_option_disabled_value_returns_readonly_label(
+        self, mock_coordinator
+    ):
+        """Disabled capability value (e.g. mode=OFF) returns a transient
+        read-only label, not the empty string. The label is NOT persisted
+        in ``options_list`` (#58).
 
-        Device sends mode=OFF when powered off. OFF is marked disabled in capabilities
-        and should be silently skipped, not added as a dynamic option.
+        Background: PR #57 made disabled values silently skipped, which
+        meant ``current_option`` returned ``""`` and HA UI rendered
+        ``unknown`` whenever the device entered such a state on its own.
         """
         capability = {
             "access": "readwrite",
@@ -377,9 +382,105 @@ class TestElectroluxSelect:
         entity.reported_state = {"mode": "OFF"}
 
         label = entity.current_option
-        assert label == ""
+        assert label == "Off"
+        # Persistent options list still excludes disabled values.
         assert "OFF" not in entity.options_list.values()
         assert "Off" not in entity.options_list
+        # The transient label appears in the on-the-fly options list
+        # so SelectEntity does not warn that current_option is missing.
+        assert "Off" in entity.options
+
+    def test_current_option_disabled_autoclean_returns_readonly_label(
+        self, mock_coordinator
+    ):
+        """``mode=autoClean`` is marked disabled in the Bogong AC catalog.
+
+        When the appliance enters autoClean on its own (e.g. user pressed
+        the panel button), HA must show ``Auto Clean`` as a read-only
+        label, not ``unknown``. The label is included in ``options`` only
+        while the value is current, then disappears.
+        """
+        capability = {
+            "access": "readwrite",
+            "type": "string",
+            "values": {
+                "AUTO": {},
+                "COOL": {},
+                "HEAT": {},
+                "DRY": {},
+                "FANONLY": {},
+                "AUTOCLEAN": {"disabled": True},
+            },
+        }
+        entity = ElectroluxSelect(
+            coordinator=mock_coordinator,
+            capability=capability,
+            name="Mode",
+            config_entry=mock_coordinator.config_entry,
+            pnc_id="TEST_PNC",
+            entity_type=SELECT,
+            entity_name="mode",
+            entity_attr="mode",
+            entity_source=None,
+            unit=None,
+            device_class="",
+            entity_category=EntityCategory.CONFIG,
+            icon="mdi:fan",
+        )
+        entity.hass = mock_coordinator.hass
+        entity.appliance_status = {
+            "properties": {"reported": {"mode": "autoClean"}}
+        }
+        entity.reported_state = {"mode": "autoClean"}
+
+        assert entity.current_option == "Autoclean"
+        assert "Autoclean" in entity.options
+        # No persistence in the catalog-derived options list.
+        assert "Autoclean" not in entity.options_list
+
+    def test_options_drops_transient_label_when_value_changes(
+        self, mock_coordinator
+    ):
+        """Transient label is included only while the device is in the
+        disabled state; switching to a normal value drops it."""
+        capability = {
+            "access": "readwrite",
+            "type": "string",
+            "values": {
+                "COOL": {},
+                "HEAT": {},
+                "AUTOCLEAN": {"disabled": True},
+            },
+        }
+        entity = ElectroluxSelect(
+            coordinator=mock_coordinator,
+            capability=capability,
+            name="Mode",
+            config_entry=mock_coordinator.config_entry,
+            pnc_id="TEST_PNC",
+            entity_type=SELECT,
+            entity_name="mode",
+            entity_attr="mode",
+            entity_source=None,
+            unit=None,
+            device_class="",
+            entity_category=EntityCategory.CONFIG,
+            icon="mdi:fan",
+        )
+        entity.hass = mock_coordinator.hass
+
+        # Start in autoClean → transient label present.
+        entity.appliance_status = {
+            "properties": {"reported": {"mode": "autoClean"}}
+        }
+        entity.reported_state = {"mode": "autoClean"}
+        assert "Autoclean" in entity.options
+
+        # Move to cool → transient gone.
+        entity.appliance_status = {"properties": {"reported": {"mode": "cool"}}}
+        entity.reported_state = {"mode": "cool"}
+        assert "Autoclean" not in entity.options
+        assert "Cool" in entity.options
 
 
 class TestSelectAvailableProperty:


### PR DESCRIPTION
Closes #58.

## Summary

Disabled capability values (e.g. AC `mode=autoClean`, `mode=OFF`) are intentionally excluded from `options_list` because the user cannot set them — but the device can enter such a state on its own (panel button, scheduled cycle, physical remote off). Before this patch, `current_option` returned `""` in that case, which HA UI rendered as `unknown` instead of telling the user what the appliance was actually doing.

## Two minimal changes

1. **`current_option`** now returns `self.format_label(value)` for a disabled capability value instead of dropping it. The persistent `options_list` is left untouched — disabled values remain non-selectable.
2. **`options`** appends the current label when it falls outside `options_list` so HA's `SelectEntity` invariant (`current_option in options`) holds while the device is in that state. The label disappears as soon as the value transitions away.

Reusing `current_option` as the canonical source keeps the disabled-value detection in one place — no helper, no duplicate iteration over `capability.values`.

## Tests

- `test_current_option_disabled_value_returns_readonly_label` — formerly the "_not_added_to_options" test; the contract has tightened from "blank" to "labelled, persistence still excluded".
- `test_current_option_disabled_autoclean_returns_readonly_label` — the Bogong AC scenario from #58.
- `test_options_drops_transient_label_when_value_changes` — verifies the label vanishes when the device returns to a normal mode.
- All 1476 tests pass.

## Live verification (Bogong office, `3.6.7+pr58`)

Triggered self-clean on a real unit:

| Step | `select.office_mode` | `options` |
|------|----------------------|-----------|
| Pre (`mode=dry`) | `Dry` | `[Auto, Cool, Heat, Dry, Fanonly]` |
| Toggle `switch.office_auto_clean_trigger` on → device reports `mode=autoClean`, force-poll | **`Autoclean`** (was `unknown`) | `[Auto, Cool, Heat, Dry, Fanonly, Autoclean]` |
| Toggle off → device returns to `mode=dry` | `Dry` | `[Auto, Cool, Heat, Dry, Fanonly]` (transient gone) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)