### PR TITLE
fix(number): derive targetTemperatureF from C when both are catalogued (closes #59)

### DIFF
--- a/custom_components/electrolux/number.py
+++ b/custom_components/electrolux/number.py
@@ -1,6 +1,7 @@
 """Number platform for Electrolux."""
 
 import logging
+from typing import Any
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
@@ -31,7 +32,9 @@ from .entity import ElectroluxEntity
 from .util import (
     AuthenticationError,
     ElectroluxApiClient,
+    celsius_to_fahrenheit,
     execute_command_with_error_handling,
+    fahrenheit_to_celsius,
     format_command_for_appliance,
     time_minutes_to_seconds,
     time_seconds_to_minutes,
@@ -223,6 +226,25 @@ class ElectroluxNumber(ElectroluxEntity, NumberEntity):
             if self.unit == UnitOfTime.SECONDS:
                 locked_value = time_seconds_to_minutes(locked_value) or 0
             return locked_value
+
+        # Derive ``targetTemperatureF`` from ``targetTemperatureC`` when the
+        # device populates only Celsius. Bogong AC catalogs both fields but
+        # the device reports only ``targetTemperatureC`` — without this the
+        # ``_f`` slider is stuck at the catalog default 16°F (#59).
+        # Devices that DO populate ``_f`` directly (e.g. F-locale ovens)
+        # bypass the derive and read their own field.
+        if (
+            self.entity_attr == "targetTemperatureF"
+            and self.reported_state.get("targetTemperatureF") is None
+        ):
+            c_value = self.reported_state.get("targetTemperatureC")
+            if c_value is not None:
+                try:
+                    derived = celsius_to_fahrenheit(float(c_value))
+                except (TypeError, ValueError):
+                    derived = None
+                if derived is not None:
+                    return derived
 
         value = self.extract_value()
 
@@ -665,6 +687,58 @@ class ElectroluxNumber(ElectroluxEntity, NumberEntity):
                 translation_key="appliance_offline",
                 translation_placeholders={"state": str(connectivity_state)},
             )
+
+        # Redirect ``targetTemperatureF`` writes to ``targetTemperatureC`` when
+        # the device populates only Celsius (Bogong AC). The signal is the
+        # same one the read-derive uses: live ``targetTemperatureC`` in
+        # reported state. Writing ``_f`` directly would be silently ignored
+        # by the device, leaving the slider stuck at the catalog default
+        # (#59). The off-guard above already covers both attrs, and the
+        # rate-limit + connectivity checks ran above this block.
+        if (
+            self.entity_attr == "targetTemperatureF"
+            and self.reported_state.get("targetTemperatureC") is not None
+            and self.reported_state.get("targetTemperatureF") is None
+        ):
+            try:
+                c_target = fahrenheit_to_celsius(float(value))
+            except (TypeError, ValueError):
+                c_target = None
+            if c_target is None:
+                return
+            appliance = self.get_appliance
+            c_capability: dict[str, Any] = self.capability
+            if hasattr(appliance, "data") and appliance.data:
+                caps = getattr(appliance.data, "capabilities", None) or {}
+                c_capability = caps.get("targetTemperatureC", self.capability)
+            formatted = format_command_for_appliance(
+                c_capability, "targetTemperatureC", c_target
+            )
+            _LOGGER.debug(
+                "Redirecting %s write %s°F → targetTemperatureC %s°C (#59)",
+                self.entity_attr,
+                value,
+                c_target,
+            )
+            # AC commands are wrapped under the literal ``airConditioner`` key
+            # for DAM appliances (matches climate.py's hard-coded wrapper).
+            command: dict[str, Any] = {"targetTemperatureC": formatted}
+            if self.is_dam_appliance:
+                command = {"commands": [{"airConditioner": command}]}
+            await execute_command_with_error_handling(
+                self.api,
+                self.pnc_id,
+                command,
+                "targetTemperatureC",
+                _LOGGER,
+                c_capability,
+            )
+            # Optimistically update ``targetTemperatureC`` so the read-derive
+            # picks up the new value before SSE confirms; otherwise the F
+            # slider snaps back to the previous derived value until the
+            # cloud event arrives.
+            self._apply_optimistic_update("targetTemperatureC", c_target)
+            return
 
         # Remote control validation removed - API handles this with precise appliance-specific rules.
         # Different appliances have different states (ENABLED, NOT_SAFETY_RELEVANT_ENABLED, persistentRemoteControl)

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -2235,6 +2235,162 @@ class TestNumberMissingCoverage:
         with pytest.raises(HomeAssistantError, match="offline"):
             await entity.async_set_native_value(100.0)
 
+    # Issue #59: targetTemperatureF derives from targetTemperatureC when both
+    # are catalogued (e.g. Bogong AC where the device populates only Celsius).
+    def test_native_value_target_temp_f_derives_from_c(self, mock_coordinator):
+        """``_f`` reads convert from the live ``_c`` value rather than the
+        catalog default. Without this the slider was stuck at 16°F (#59).
+        """
+        entity = self._make_entity(
+            mock_coordinator,
+            entity_attr="targetTemperatureF",
+            capability={
+                "type": "temperature",
+                "min": 60,
+                "max": 86,
+                "step": 1,
+                "default": 16,
+            },
+        )
+        entity._is_locked_by_program = MagicMock(return_value=False)
+        entity._is_disabled_by_trigger = MagicMock(return_value=False)
+        entity.reported_state = {
+            "connectivityState": "Connected",
+            "applianceState": "running",
+            "targetTemperatureC": 22,
+        }
+
+        # 22 °C → 71.6 °F
+        assert entity.native_value == 71.6
+
+    def test_native_value_target_temp_f_no_c_falls_through(self, mock_coordinator):
+        """When ``targetTemperatureC`` is absent from reported state (e.g.
+        an oven that catalogs only F), ``_f`` reads its own field as
+        before.
+        """
+        entity = self._make_entity(
+            mock_coordinator,
+            entity_attr="targetTemperatureF",
+            capability={
+                "type": "temperature",
+                "min": 60,
+                "max": 86,
+                "step": 1,
+            },
+        )
+        entity._is_locked_by_program = MagicMock(return_value=False)
+        entity._is_disabled_by_trigger = MagicMock(return_value=False)
+        entity.reported_state = {
+            "connectivityState": "Connected",
+            "applianceState": "running",
+            "targetTemperatureF": 72,
+        }
+
+        assert entity.native_value == 72
+
+    @pytest.mark.asyncio
+    async def test_set_native_value_target_temp_f_redirects_to_c(
+        self, mock_coordinator
+    ):
+        """Writing ``_f`` redirects to ``_c`` (F→C conversion) when the
+        device's reported state contains a live ``targetTemperatureC``.
+        Mirrors the read-derive contract — the device only honours ``_c``.
+        Optimistic update on ``targetTemperatureC`` keeps the slider stable
+        until SSE confirms.
+        """
+        from custom_components.electrolux import number as number_module
+
+        entity = self._make_entity(
+            mock_coordinator,
+            entity_attr="targetTemperatureF",
+            capability={
+                "type": "temperature",
+                "min": 60,
+                "max": 86,
+                "step": 1,
+            },
+        )
+        entity._is_locked_by_program = MagicMock(return_value=False)
+        entity._is_disabled_by_trigger = MagicMock(return_value=False)
+        entity._is_supported_by_program = MagicMock(return_value=True)
+        entity._apply_optimistic_update = MagicMock()
+        # Live C value in reported state is the production signal that
+        # triggers the redirect (mirrors the read-derive guard).
+        entity.reported_state = {
+            "connectivityState": "Connected",
+            "applianceState": "running",
+            "targetTemperatureC": 22,
+        }
+
+        sent: list = []
+
+        async def fake_execute(client, pnc_id, command, attr, logger, capability):
+            sent.append((attr, command))
+
+        with patch.object(
+            number_module,
+            "execute_command_with_error_handling",
+            side_effect=fake_execute,
+        ):
+            await entity.async_set_native_value(75.0)
+
+        assert len(sent) == 1
+        attr, command = sent[0]
+        assert attr == "targetTemperatureC"
+        # 75 °F → 23.89 °C (rounded to 2 dp)
+        assert command == {"targetTemperatureC": 23.89}
+        # Optimistic update on the canonical field so the read-derive
+        # picks up the new value before SSE confirms.
+        entity._apply_optimistic_update.assert_called_once_with(
+            "targetTemperatureC", 23.89
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_native_value_target_temp_f_no_c_falls_through(
+        self, mock_coordinator
+    ):
+        """When ``targetTemperatureC`` is absent from reported state, the
+        ``_f`` write does NOT redirect — the device populates F natively
+        (e.g. F-locale oven) and should be written directly."""
+        from custom_components.electrolux import number as number_module
+
+        entity = self._make_entity(
+            mock_coordinator,
+            entity_attr="targetTemperatureF",
+            capability={
+                "type": "temperature",
+                "min": 60,
+                "max": 86,
+                "step": 1,
+            },
+        )
+        entity._is_locked_by_program = MagicMock(return_value=False)
+        entity._is_disabled_by_trigger = MagicMock(return_value=False)
+        entity._is_supported_by_program = MagicMock(return_value=True)
+        # No targetTemperatureC in reported state → F entity is canonical.
+        entity.reported_state = {
+            "connectivityState": "Connected",
+            "applianceState": "running",
+            "targetTemperatureF": 70,
+        }
+
+        sent: list = []
+
+        async def fake_execute(client, pnc_id, command, attr, logger, capability):
+            sent.append((attr, command))
+
+        with patch.object(
+            number_module,
+            "execute_command_with_error_handling",
+            side_effect=fake_execute,
+        ):
+            await entity.async_set_native_value(75.0)
+
+        # Non-redirect path: F write goes through unchanged.
+        assert len(sent) == 1
+        attr, _ = sent[0]
+        assert attr == "targetTemperatureF"
+
     # Issue #72: number entity unavailable when current state disables it
     def test_available_false_when_disabled_by_trigger(self, mock_coordinator):
         """A trigger marking this attribute ``disabled: true`` means the API


### PR DESCRIPTION
Closes #59.

## Summary

Bogong AC catalogs both `targetTemperatureC` and `targetTemperatureF` but the device only populates `targetTemperatureC`. Without this patch, `number.<name>_target_temperature_f` was stuck at the catalog default 16°F (or 16 displayed via HA's locale conversion) regardless of the live setpoint, while `_c` correctly tracked the device.

## Read path

`native_value` for `targetTemperatureF` first looks for `targetTemperatureC` in the live reported state; if present, derives the F value via `C * 9/5 + 32`. When only `_f` is populated (e.g. an oven that catalogs Fahrenheit only), the existing extract-value path runs unchanged.

## Write path

`async_set_native_value` redirects `_f` writes to `_c` when both fields are catalogued. The user's F input is converted to Celsius and the resulting `targetTemperatureC` command is sent. Mirrors the read-derive contract and respects the device's actual storage shape. The off-state guard above the redirect already covers both attrs, so the early return is safe.

## Tests

- `test_native_value_target_temp_f_derives_from_c` — `_c=22` → `_f=71.6`
- `test_native_value_target_temp_f_no_c_falls_through` — when only `_f` exists in reported state, returns it directly
- `test_set_native_value_target_temp_f_redirects_to_c` — `set_native_value(75)` produces `{"targetTemperatureC": 23.89}`
- 1477 total tests pass

## Live verification (Bogong, `3.6.7+pr59`)

| Unit | Before this PR | After this PR |
|------|----------------|---------------|
| K (`_c=23, mode=heat`) | `number.k_target_temperature_f = 16.0` | `number.k_target_temperature_f = 23.0` (Celsius locale display of derived 73.4°F) |
| KSU (`_c=23`) | `16.0` | `23.0` |

`_c` and `_f` now represent the same temperature. F-locale users see `_f` in F directly; C-locale users see HA's auto-converted C equivalent — but both numbers are now live, not stuck.

## Notes

- For users on `main` with `_f` previously disabled as a workaround (#59 mitigation), they can re-enable the entity via the integration page after this lands.
- The redirect uses `execute_command_with_error_handling` directly with a minimal `{"targetTemperatureC": value}` payload (or DAM-wrapped), bypassing the longer `_f`-specific format/send block. Safe because the off-guard, range-check, and trigger-disabled checks fire before the redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)