### PR TITLE
fix(sensor): filter 65535 sentinel for load weight sensors (closes #42)

### DIFF
--- a/custom_components/electrolux/sensor.py
+++ b/custom_components/electrolux/sensor.py
@@ -138,19 +138,17 @@ class ElectroluxSensor(ElectroluxEntity, SensorEntity):
                 get_capability(self.capability, "type"),
             )
 
-        # Special handling for load weight sensors: filter out error codes
-        if self.entity_attr == "fcOptisenseLoadWeight":
+        # Special handling for load weight sensors: filter out error/sentinel codes.
+        # 65535 (0xFFFF) = "not measured", 65408-65532 = error/status codes.
+        if self.entity_attr in ("fcOptisenseLoadWeight", "measuredLoadWeight"):
             if value is not None and isinstance(value, (int, float)):
-                # Values 65408-65532 are error/status codes, not actual weights
-                # Valid weight range is 0-20000 grams per API specification
-                if 65408 <= value <= 65532:
+                if value >= 65408:
                     _LOGGER.debug(
                         "Load weight sensor %s has error/status code: %s (hiding value)",
                         self.entity_attr,
                         value,
                     )
                     return None
-                # Also filter out string error codes
             elif isinstance(value, str) and value in [
                 "NOT_AVAILABLE",
                 "OVERLOAD",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -693,6 +693,24 @@ class TestSensorMissingCoverage:
         basic_sensor_entity.reported_state = {"fcOptisenseLoadWeight": "OVERLOAD"}
         assert basic_sensor_entity.native_value is None
 
+    def test_load_weight_filters_65535_sentinel(self, basic_sensor_entity):
+        """65535 (0xFFFF) is 'not measured' sentinel — return None."""
+        basic_sensor_entity.entity_attr = "fcOptisenseLoadWeight"
+        basic_sensor_entity.reported_state = {"fcOptisenseLoadWeight": 65535}
+        assert basic_sensor_entity.native_value is None
+
+    def test_measured_load_weight_filters_65535_sentinel(self, basic_sensor_entity):
+        """measuredLoadWeight 65535 = not measured — return None (issue #42)."""
+        basic_sensor_entity.entity_attr = "measuredLoadWeight"
+        basic_sensor_entity.reported_state = {"measuredLoadWeight": 65535}
+        assert basic_sensor_entity.native_value is None
+
+    def test_measured_load_weight_passes_valid_value(self, basic_sensor_entity):
+        """measuredLoadWeight valid reading passes through."""
+        basic_sensor_entity.entity_attr = "measuredLoadWeight"
+        basic_sensor_entity.reported_state = {"measuredLoadWeight": 3200}
+        assert basic_sensor_entity.native_value == 3200
+
     # ── watertankempty boolean type ───────────────────────────────────────────
 
     def test_watertankempty_boolean_capability_type_not_full(self, basic_sensor_entity):


### PR DESCRIPTION
## Summary

- `measuredLoadWeight` had no filter — 65535 passed through raw as "65535 g" when machine idle
- `fcOptisenseLoadWeight` filtered 65408–65532 but missed 65535 (0xFFFF = "not measured" sentinel)
- Both sensors now return `None` (unavailable) for `value >= 65408`
- `fCMiscellaneousState/optisenseResult` already catalogued as "Load Weight" — shows during cycle, unavailable when idle (correct, no change needed)

## Test plan

- [x] `test_load_weight_filters_65535_sentinel` — fcOptisenseLoadWeight 65535 → None
- [x] `test_measured_load_weight_filters_65535_sentinel` — measuredLoadWeight 65535 → None
- [x] `test_measured_load_weight_passes_valid_value` — measuredLoadWeight 3200 → 3200
- [x] Full suite: 1483 passed

Fixes #42