### PR TITLE
feat(td): verify TD-916098759 against catalog, add MY_DRY_PR_MYDRY program (closes #67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The table below lists all appliance types and the known-tested diagnostic sample
 | `CR` | Combi Refrigerator | Full | `CR-925060324` |
 | `WM` | Washing Machine | Full | `WM-914501128`, `WM-914915144` |
 | `WD` | Washer Dryer | Full | `WD-914611000`, `WD-914611500` |
-| `TD` | Tumble Dryer | Full | `TD-916098401`, `TD-916098618`, `TD-916099548`, `TD-916099949`, `TD-916099971` |
+| `TD` | Tumble Dryer | Full | `TD-916098401`, `TD-916098618`, `TD-916098759`, `TD-916099548`, `TD-916099949`, `TD-916099971` |
 | `AC` / `CA` / `Azul` / `Bogong` / `Panther` / `Telica` | Air Conditioner | Full (`AC` + `Bogong` verified) | `AC-910280820`; `Bogong` — `VM211_A_04.43.06_BOGONG` (3 units, AU) — see [Bogong device notes](docs/devices/bogong.md) — `CA`/`Azul`/`Panther`/`Telica` unverified, [submit yours](https://github.com/TTLucian/ha-electrolux/issues) |
 | `DAM_AC` | DAM Air Conditioner | Catalog *(unverified)* | No samples — [submit yours](https://github.com/TTLucian/ha-electrolux/issues) |
 | `DW` | Dishwasher | Full | `DW-911434654`, `DW-911434834` |

--- a/custom_components/electrolux/catalogs/catalog_td.py
+++ b/custom_components/electrolux/catalogs/catalog_td.py
@@ -328,6 +328,8 @@ CATALOG_TD: dict[str, ElectroluxDevice] = {
                 "UNIVERSAL_PR_MIXEDPLUS": {},
                 "UNIVERSAL_PR_MIXEDPLUSNOTXL": {},
                 "WORKINGCLOTHES_PR_WORKINGCLOTHES": {},
+                # Added from TD-916098759 (issue #67)
+                "MY_DRY_PR_MYDRY": {},
             },
         },
         device_class=None,
@@ -537,6 +539,8 @@ CATALOG_TD: dict[str, ElectroluxDevice] = {
                 "UNIVERSAL_PR_MIXEDPLUS": {},
                 "UNIVERSAL_PR_MIXEDPLUSNOTXL": {},
                 "WORKINGCLOTHES_PR_WORKINGCLOTHES": {},
+                # Added from TD-916098759 (issue #67)
+                "MY_DRY_PR_MYDRY": {},
             },
         },
         device_class=None,
@@ -796,6 +800,8 @@ CATALOG_TD: dict[str, ElectroluxDevice] = {
                 "UNIVERSAL_PR_MIXEDPLUS": {},
                 "UNIVERSAL_PR_MIXEDPLUSNOTXL": {},
                 "WORKINGCLOTHES_PR_WORKINGCLOTHES": {},
+                # Added from TD-916098759 (issue #67)
+                "MY_DRY_PR_MYDRY": {},
             },
         },
         device_class=None,


### PR DESCRIPTION
## Summary

Verifies the diagnostics attached to #67 (tumble dryer `TD-916098759_00`) against `CATALOG_TD` and the base catalog, and closes the one real gap found.

### Findings from the diagnostics

- **All capability keys and enum values on this model are already covered** by the existing TD + base catalogs, with one exception: the `MY_DRY_PR_MYDRY` program (enabled on this device, sibling of the existing `MY_DRY_PR_MIXCARE` / `MY_DRY_PR_MIXDRY`). Added to `userSelections/programUID`, `cyclePersonalization/programUID`, and `dwywDataToDryer/programUID`.
- `MACHINE_SETTINGS_HIDDEN_TEST` is also advertised in `userSelections/programUID` but is marked `disabled: true` on the device (hidden factory test program) — intentionally **not** added to the catalog.
- `applianceCareAndMaintenance0/*` keys are present in capabilities but already excluded via `ATTRIBUTES_BLACKLIST` by design.
- `userSelections/dryingTime` reports `max: 120` on this device vs `300` in the catalog — no change needed, live API values override catalog ranges.
- Reported-state-only fields on this model (`measuredLoadWeight`, `fcOptisenseLoadWeight`, `totalDryCyclesCount`, `totalDryingTime`, `applianceUiSwVersion`, `applianceMainBoardSwVersion`) all already have catalog entries.
- README: `TD-916098759` added to the TD known-tested samples row.

### Observation (possible follow-up, out of scope here)

The device (and the WM in the same diagnostics) exposes constant feature flags `fCPN_TDAlert`, `fCPN_TDEndOfCycle`, `fCPN_TDMaintenances`, `fCApplianceFeature_EUDryWhatWashed`, and `dummy_for_empty_cycle` (`access: constant`). These are not blacklisted and end up as cryptic generic sensors with no reported-state value. They may be worth adding to `ATTRIBUTES_BLACKLIST` in a separate PR, alongside `^applianceCareAndMaintenance` / `^keyModel$`.

## Testing

- `pytest`: 1489 passed
- `ruff check` and `black --check`: clean

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)