### PR TITLE
fix: blacklist constant feature-flag capabilities (fCPN_*, fCApplianceFeature_*, dummy_for_empty_cycle)

### DIFF
--- a/custom_components/electrolux/const.py
+++ b/custom_components/electrolux/const.py
@@ -79,6 +79,9 @@ ATTRIBUTES_BLACKLIST: list[str] = [
     "^applianceCareAndMaintenance",  # Internal maintenance counters/thresholds - cryptic names, no user value
     "^hideExecuteCommand$",  # Internal API trigger-control flag (governs executeCommand visibility via triggers)
     "^keyModel$",  # Hardware identity constant, no user-facing value
+    "^fCPN_",  # Push-notification feature flags (constants), no user-facing value
+    "^fCApplianceFeature_",  # Feature capability flags (constants), no user-facing value
+    "^dummy_for_empty_cycle$",  # Placeholder capability for programs with no options
 ]
 
 ATTRIBUTES_WHITELIST: list[str] = [".*waterUsage", ".*tankAReserve", ".*tankBReserve"]

--- a/tests/test_api_logic.py
+++ b/tests/test_api_logic.py
@@ -147,6 +147,48 @@ class TestKeepSourceLogic:
         assert "parent/child2" in result
         assert "fCMiscellaneous/blocked" not in result
 
+    def test_keep_source_constant_feature_flags_blacklisted(self):
+        """Test that constant feature flags are excluded from sources."""
+        entity = ElectroluxLibraryEntity(
+            name="test",
+            status="connected",
+            state={},
+            appliance_info={},
+            capabilities={
+                "fCPN_TDAlert": {"access": "constant", "default": 1, "type": "int"},
+                "fCPN_TDEndOfCycle": {
+                    "access": "constant",
+                    "default": 1,
+                    "type": "int",
+                },
+                "fCPN_TDMaintenances": {
+                    "access": "constant",
+                    "default": 1,
+                    "type": "int",
+                },
+                "fCApplianceFeature_EUDryWhatWashed": {
+                    "access": "constant",
+                    "default": 1,
+                    "type": "int",
+                },
+                "dummy_for_empty_cycle": {
+                    "access": "constant",
+                    "type": "enum",
+                    "values": {"0": {"disabled": True}},
+                },
+                "valid_source": {"type": "string", "access": "read"},
+            },
+        )
+
+        result = entity.sources_list()
+        assert result is not None
+        assert "fCPN_TDAlert" not in result
+        assert "fCPN_TDEndOfCycle" not in result
+        assert "fCPN_TDMaintenances" not in result
+        assert "fCApplianceFeature_EUDryWhatWashed" not in result
+        assert "dummy_for_empty_cycle" not in result
+        assert "valid_source" in result
+
     def test_sources_list_with_none_capabilities(self):
         """Test sources_list when capabilities is None."""
         entity = ElectroluxLibraryEntity(


### PR DESCRIPTION
## Summary

Follow-up to #113 (diagnostics from #67). Laundry appliances — both the TD and the WM in that diagnostics file — advertise constant feature flags in their capabilities:

- `fCPN_TDAlert`, `fCPN_TDEndOfCycle`, `fCPN_TDMaintenances` (and `fCPN_WM*` equivalents on washers) — push-notification feature markers
- `fCApplianceFeature_EUDryWhatWashed` — feature capability marker
- `dummy_for_empty_cycle` — placeholder capability for programs with no options

All have `access: constant`, no catalog entry, and no reported-state value, so today they get created as cryptic generic diagnostic sensors that sit at `unknown` forever. This adds them to `ATTRIBUTES_BLACKLIST`, following the precedent of `^applianceCareAndMaintenance` and `^keyModel$`.

## Changes

- `const.py`: three new `ATTRIBUTES_BLACKLIST` patterns (`^fCPN_`, `^fCApplianceFeature_`, `^dummy_for_empty_cycle$`)
- `tests/test_api_logic.py`: new test asserting `sources_list()` excludes these keys while keeping valid sources

## Testing

- `pytest`: 1490 passed
- `ruff check` and `black --check`: clean

Note for existing installs: these sensors will show as unavailable/orphaned after upgrade and can be removed from the entity registry; no functional entities are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)