### PR TITLE
fix(coordinator): resync appliance states on every SSE reconnection (closes #104)

### DIFF
--- a/custom_components/electrolux/coordinator.py
+++ b/custom_components/electrolux/coordinator.py
@@ -65,6 +65,9 @@ WEBSOCKET_DISCONNECT_TIMEOUT = 5.0  # seconds for websocket disconnect
 WEBSOCKET_BACKOFF_DELAY = 300  # 5 minutes in seconds for backoff
 API_DISCONNECT_TIMEOUT = 3.0  # seconds for API disconnect
 SSE_RESTART_COOLDOWN = 900  # 15 minutes: cooldown between SSE restart attempts
+SSE_RECONNECT_REFRESH_COOLDOWN = (
+    60.0  # seconds between full state resyncs triggered by SSE (re)connections
+)
 
 # String constants for data keys
 APPLIANCE_ID_KEY = "applianceId"
@@ -137,6 +140,12 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
             {}
         )  # Track previous connectivity state per appliance
         self._last_sse_restart_time = 0.0  # Track when we last restarted SSE
+        self._last_reconnect_refresh_time = (
+            0.0  # Track last full resync triggered by an SSE (re)connection
+        )
+        self._pending_reconnect_refresh_task: Optional[asyncio.Task] = (
+            None  # Deferred resync when reconnections happen within the cooldown
+        )
         self._last_manual_sync_time = 0.0  # Track when we last performed manual sync
         self._last_time_to_end: dict[str, float | None] = (
             {}
@@ -828,30 +837,69 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
 
         # watch_for_appliance_state_updates in util.py handles kill-before-restart safely
         try:
+            # on_connected fires every time the stream actually opens a connection,
+            # including SDK-internal reconnections after transport errors (e.g.
+            # TransferEncodingError), so states are resynced after every gap —
+            # not only when the coordinator itself restarts the stream.
             await self.api.watch_for_appliance_state_updates(
                 ids,
                 self.incoming_data,
+                on_connected=self._on_sse_connected,
             )
             _LOGGER.debug(
                 f"Successfully started SSE listening for {len(ids)} appliances"
             )
-
-            # Trigger full state refresh after SSE (re)connects
-            # This ensures we catch any state changes that occurred during disconnection
-            _LOGGER.info(
-                "SSE connected - refreshing all appliance states to sync after reconnection"
-            )
-            try:
-                await self._refresh_all_appliances()
-            except Exception as ex:
-                _LOGGER.warning(
-                    f"Failed to refresh appliance states after SSE reconnection: {ex}"
-                )
-                # Don't raise - SSE is connected and working, refresh failure is not critical
-
         except Exception as ex:
             _LOGGER.error(f"Failed to start SSE listening: {ex}")
             raise
+
+    async def _on_sse_connected(self) -> None:
+        """Resync appliance states after the SSE stream (re)opens a connection.
+
+        Runs inside the SDK's stream task, so it must never raise — an escaping
+        exception would tear down the freshly opened stream. Debounced so a
+        flapping stream doesn't hammer the API; when a refresh is skipped, a
+        trailing refresh is scheduled so the last reconnection still resyncs.
+        """
+        elapsed = self.hass.loop.time() - self._last_reconnect_refresh_time
+        if elapsed >= SSE_RECONNECT_REFRESH_COOLDOWN:
+            # Await inline so the resync completes before the SDK starts
+            # dispatching events — a concurrent refresh could overwrite a
+            # newer SSE event with an older API snapshot.
+            await self._reconnect_refresh()
+            return
+
+        if (
+            self._pending_reconnect_refresh_task
+            and not self._pending_reconnect_refresh_task.done()
+        ):
+            return
+        delay = SSE_RECONNECT_REFRESH_COOLDOWN - elapsed
+        _LOGGER.debug(
+            "SSE reconnected within refresh cooldown - scheduling resync in %.0fs",
+            delay,
+        )
+        self._pending_reconnect_refresh_task = self.hass.async_create_task(
+            self._delayed_reconnect_refresh(delay)
+        )
+
+    async def _delayed_reconnect_refresh(self, delay: float) -> None:
+        """Run a deferred post-reconnection resync once the cooldown expires."""
+        await asyncio.sleep(delay)
+        await self._reconnect_refresh()
+
+    async def _reconnect_refresh(self) -> None:
+        """Refresh all appliance states after an SSE (re)connection. Never raises."""
+        self._last_reconnect_refresh_time = self.hass.loop.time()
+        _LOGGER.info(
+            "SSE connected - refreshing all appliance states to sync after reconnection"
+        )
+        try:
+            await self._refresh_all_appliances()
+        except Exception as ex:
+            _LOGGER.warning(
+                f"Failed to refresh appliance states after SSE reconnection: {ex}"
+            )
 
     async def renew_websocket(self):
         """Renew SSE event stream."""
@@ -953,6 +1001,18 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
             await asyncio.gather(*all_deferred, return_exceptions=True)
         self._deferred_tasks.clear()
         self._deferred_tasks_by_appliance.clear()
+
+        # Cancel any deferred post-reconnection resync.
+        # _delayed_reconnect_refresh swallows everything but CancelledError,
+        # so that is the only thing this await can raise.
+        reconnect_refresh = getattr(self, "_pending_reconnect_refresh_task", None)
+        if reconnect_refresh and not reconnect_refresh.done():
+            reconnect_refresh.cancel()
+            try:
+                await reconnect_refresh
+            except asyncio.CancelledError:
+                pass
+        self._pending_reconnect_refresh_task = None
 
         # Cancel all pending state-refresh tasks (memory leak if left running)
         refresh_tasks = list(self._pending_state_refresh_tasks.values())

--- a/tests/test_coordinator_setup.py
+++ b/tests/test_coordinator_setup.py
@@ -50,6 +50,8 @@ def make_coordinator():
     coord.listen_task = None
     coord._last_remote_control = {}
     coord._pending_state_refresh_tasks = {}
+    coord._last_reconnect_refresh_time = 0.0
+    coord._pending_reconnect_refresh_task = None
 
     # API client mock
     coord.api = MagicMock()
@@ -413,6 +415,93 @@ class TestListenWebsocket:
         await coord.listen_websocket()
 
         coord.api.watch_for_appliance_state_updates.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sse_setup_passes_on_connected_callback(self):
+        """The on_connected hook is wired so SDK-internal reconnects resync state."""
+        coord = make_coordinator()
+        mock_appliances = MagicMock()
+        mock_appliances.get_appliance_ids.return_value = ["APPLIANCE_001"]
+        coord.data = {"appliances": mock_appliances}
+        coord.incoming_data = AsyncMock()
+
+        coord.api.watch_for_appliance_state_updates = AsyncMock(return_value=None)
+
+        await coord.listen_websocket()
+
+        kwargs = coord.api.watch_for_appliance_state_updates.call_args.kwargs
+        assert kwargs["on_connected"] == coord._on_sse_connected
+
+
+# ---------------------------------------------------------------------------
+# _on_sse_connected tests (post-reconnection state resync)
+# ---------------------------------------------------------------------------
+
+
+class TestOnSseConnected:
+    """Test the SSE (re)connection resync callback."""
+
+    @pytest.mark.asyncio
+    async def test_refreshes_immediately_outside_cooldown(self):
+        """First connection triggers an immediate full state refresh."""
+        coord = make_coordinator()
+        coord._refresh_all_appliances = AsyncMock()
+        coord.hass.loop.time = MagicMock(return_value=1000.0)
+
+        await coord._on_sse_connected()
+
+        coord._refresh_all_appliances.assert_awaited_once()
+        assert coord._last_reconnect_refresh_time == 1000.0
+
+    @pytest.mark.asyncio
+    async def test_refresh_exception_is_swallowed(self):
+        """Refresh failures must not propagate into the SDK stream task."""
+        coord = make_coordinator()
+        coord._refresh_all_appliances = AsyncMock(side_effect=RuntimeError("boom"))
+        coord.hass.loop.time = MagicMock(return_value=1000.0)
+
+        await coord._on_sse_connected()  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_reconnect_within_cooldown_schedules_trailing_refresh(self):
+        """A reconnect inside the cooldown defers the resync instead of skipping it."""
+        coord = make_coordinator()
+        coord._refresh_all_appliances = AsyncMock()
+        coord.hass.loop.time = MagicMock(return_value=1000.0)
+        coord._last_reconnect_refresh_time = 990.0  # 10s ago, inside 60s cooldown
+
+        created = []
+
+        def fake_create_task(coro):
+            task = asyncio.get_event_loop().create_task(coro)
+            created.append(task)
+            return task
+
+        coord.hass.async_create_task = fake_create_task
+
+        with patch("custom_components.electrolux.coordinator.asyncio.sleep"):
+            await coord._on_sse_connected()
+            coord._refresh_all_appliances.assert_not_awaited()
+            assert len(created) == 1
+            await created[0]
+
+        coord._refresh_all_appliances.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_pending_trailing_refresh_is_not_duplicated(self):
+        """Multiple reconnects inside the cooldown share one deferred resync."""
+        coord = make_coordinator()
+        coord._refresh_all_appliances = AsyncMock()
+        coord.hass.loop.time = MagicMock(return_value=1000.0)
+        coord._last_reconnect_refresh_time = 990.0
+        pending = MagicMock()
+        pending.done.return_value = False
+        coord._pending_reconnect_refresh_task = pending
+
+        await coord._on_sse_connected()
+
+        coord.hass.async_create_task.assert_not_called()
+        coord._refresh_all_appliances.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Fixes #104.

When the SSE stream drops with a transport error (e.g. `TransferEncodingError: Not enough data to satisfy transfer length header`), the SDK's `start_event_stream` loop reconnects internally after a 10s backoff. However, the coordinator never passed the `on_connected` hook to `watch_for_appliance_state_updates`, so the integration was unaware of these internal reconnections: any state changes that occurred during the disconnect gap were silently lost, and entities stayed stale until the 2-hour SSE renewal, the 6-hour health poll, or a manual reload — matching the reported "updates stop until reload" behaviour.

Additionally, the existing "SSE connected - refreshing all appliance states" step in `listen_websocket` fired when the background task was *created*, not when the stream actually connected (visible in the issue's log: refresh at 08:45:25, actual `Connected to SSE stream` at 08:45:38), so even coordinator-driven restarts could miss events between refresh and real connection.

## Fix

- Wire `on_connected=self._on_sse_connected` into `watch_for_appliance_state_updates`. The SDK invokes this every time the stream truly opens a connection — including its internal reconnections — so a full appliance state resync now runs after every gap.
- Remove the premature refresh from `listen_websocket` (replaced by the hook above, which fires at the correct moment).
- Debounce resyncs to one per 60s: a flapping stream (repeated `TransferEncodingError`) no longer hammers the API, and a trailing deferred refresh guarantees the last reconnection in a burst still resyncs.
- The callback runs inside the SDK's stream task, so it swallows refresh exceptions — an escaping exception would tear down the freshly opened stream.
- Clean up the deferred resync task in `close_websocket`.

## Testing

- `pytest`: 1494 passed (5 new tests covering the hook wiring, immediate resync, exception safety, trailing debounce, and dedup).
- `ruff check` and `black --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)