### PR TITLE
feat(dh): verify DH catalog against DH-950133061 diagnostics (closes #106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The table below lists all appliance types and the known-tested diagnostic sample
 | `DAM_AC` | DAM Air Conditioner | Catalog *(unverified)* | No samples — [submit yours](https://github.com/TTLucian/ha-electrolux/issues) |
 | `DW` | Dishwasher | Full | `DW-911434654`, `DW-911434834` |
 | `Muju` / `Verbier` / `PUREA9` / `Fuji` / `WELLA5` / `WELLA7` | Air Purifier | Full (Muju/Verbier verified) | UltimateHome 500 (EP53); Verbier — PUREA9/Fuji/WELLA5/WELLA7 unverified, [submit yours](https://github.com/TTLucian/ha-electrolux/issues) |
-| `DH` / `Husky` | Dehumidifier | Catalog *(unverified)* | No samples — [submit yours](https://github.com/TTLucian/ha-electrolux/issues) |
+| `DH` / `Husky` | Dehumidifier | Full (`DH` verified) | `DH-950133061` (Frigidaire FGAC5044W1) — `Husky` unverified, [submit yours](https://github.com/TTLucian/ha-electrolux/issues) |
 | `PUREi9` / `Gordias` / `Cybele` / `700series` | Robot Vacuum | Catalog *(unverified)* | No samples — [submit yours](https://github.com/TTLucian/ha-electrolux/issues) |
 | `HB` | Induction Hob | Catalog *(unverified)* | No samples — [submit yours](https://github.com/TTLucian/ha-electrolux/issues) |
 | `HD` | Hood / Extractor Fan | Catalog *(unverified)* | No samples — [submit yours](https://github.com/TTLucian/ha-electrolux/issues) |
@@ -84,7 +84,7 @@ If you own one of these appliances, please download your diagnostics from **Sett
 
 | Appliance | Issue title | Status |
 |-----------|-------------|--------|
-| 🌊 **Dehumidifier** (`DH`, `Husky`) | `DH diagnostics — [your model]` | Catalog added in v3.5.6, unverified |
+| 🌊 **Dehumidifier** (`Husky`) | `DH diagnostics — [your model]` | `DH` verified from `DH-950133061` (see above); `Husky` still unverified |
 | 🤖 **Robot Vacuum** (`PUREi9`, `Gordias`, `Cybele`, `700series`) | `RVC diagnostics — [your model]` | Catalog added in v3.5.6, unverified |
 | 🍳 **Induction Hob** (`HB`) | `HB diagnostics — [your model]` | Catalog added in v3.5.6, unverified |
 | 💨 **Hood / Extractor Fan** (`HD`) | `HD diagnostics — [your model]` | Catalog added in v3.5.6, unverified |

--- a/custom_components/electrolux/catalogs/catalog_dh.py
+++ b/custom_components/electrolux/catalogs/catalog_dh.py
@@ -1,13 +1,23 @@
-"""Defined catalog of entities for dehumidifier type devices (DH, Husky)."""
+"""Defined catalog of entities for dehumidifier type devices (DH, Husky).
+
+Verified against real diagnostics from DH-950133061_00 (Frigidaire
+FGAC5044W1, SRAC firmware v1.9.1_srac) — see issue #106.
+
+capability_info mirrors the device-reported capabilities so these entities
+are also created from reported state when the capabilities API call fails
+(the catalog fallback loop in models.setup). Live API values always
+override catalog values/min/max/step when capabilities ARE available.
+"""
 
 from homeassistant.components.number import NumberDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass
-from homeassistant.const import PERCENTAGE
+from homeassistant.components.switch import SwitchDeviceClass
+from homeassistant.const import PERCENTAGE, EntityCategory, Platform, UnitOfTime
 
 from ..model import ElectroluxDevice
 
 CATALOG_DH: dict[str, ElectroluxDevice] = {
-    # Power control — ON/OFF (button entity; SDK dh_config.py EXECUTE_COMMAND_ON/OFF)
+    # Power control — ON/OFF (write-only pair, surfaced as optimistic switch)
     "executeCommand": ElectroluxDevice(
         capability_info={
             "access": "write",
@@ -33,12 +43,14 @@ CATALOG_DH: dict[str, ElectroluxDevice] = {
         friendly_name="Humidity",
     ),
     # Target humidity setpoint (read-write number control)
+    # Device reports 35–85 % in 5 % steps; only adjustable in DRY mode
+    # (a capability trigger disables it in the other modes).
     "targetHumidity": ElectroluxDevice(
         capability_info={
             "access": "readwrite",
             "type": "number",
-            "min": 30,
-            "max": 80,
+            "min": 35,
+            "max": 85,
             "step": 5,
         },
         device_class=NumberDeviceClass.HUMIDITY,
@@ -47,19 +59,17 @@ CATALOG_DH: dict[str, ElectroluxDevice] = {
         entity_icon="mdi:water-percent",
         friendly_name="Target Humidity",
     ),
-    # Fan speed (select entity)
-    # NOTE: The SDK reads values dynamically from device capabilities.
-    # Placeholder values below will be replaced by whatever the device
-    # actually reports. Unverified until a real diagnostic is provided.
+    # Fan speed (select entity). Values verified from DH-950133061.
+    # A capability trigger makes this read-only while mode is AUTO or QUIET;
+    # the API rejects writes in those modes.
     "fanSpeedSetting": ElectroluxDevice(
         capability_info={
             "access": "readwrite",
             "type": "string",
             "values": {
                 "LOW": {},
-                "MEDIUM": {},
+                "MIDDLE": {},
                 "HIGH": {},
-                "TURBO": {},
             },
         },
         device_class=None,
@@ -67,11 +77,29 @@ CATALOG_DH: dict[str, ElectroluxDevice] = {
         entity_category=None,
         entity_icon="mdi:fan",
         friendly_name="Fan Speed",
+        entity_platform=Platform.SELECT,
     ),
-    # Operating mode (select entity)
-    # NOTE: The SDK reads values dynamically from device capabilities.
-    # Placeholder values below will be replaced by whatever the device
-    # actually reports. Unverified until a real diagnostic is provided.
+    # Actual fan speed reported by the appliance (read-only sensor)
+    "fanSpeedState": ElectroluxDevice(
+        capability_info={
+            "access": "read",
+            "type": "string",
+            "values": {
+                "LOW": {},
+                "MIDDLE": {},
+                "HIGH": {},
+            },
+        },
+        device_class=None,
+        unit=None,
+        entity_category=None,
+        entity_icon="mdi:fan",
+        friendly_name="Fan Speed State",
+    ),
+    # Operating mode (select entity). Values verified from DH-950133061.
+    # OFF is advertised disabled — it is reported as the current mode while
+    # the unit is powered down but is not selectable (power off goes through
+    # executeCommand); select.py shows it as a transient read-only label.
     "mode": ElectroluxDevice(
         capability_info={
             "access": "readwrite",
@@ -79,9 +107,9 @@ CATALOG_DH: dict[str, ElectroluxDevice] = {
             "values": {
                 "AUTO": {},
                 "CONTINUOUS": {},
-                "LAUNDRY": {},
-                "DRY_CLOTHES": {},
-                "SILENT": {},
+                "DRY": {},
+                "QUIET": {},
+                "OFF": {"disabled": True},
             },
         },
         device_class=None,
@@ -89,5 +117,153 @@ CATALOG_DH: dict[str, ElectroluxDevice] = {
         entity_category=None,
         entity_icon="mdi:water-sync",
         friendly_name="Mode",
+        entity_platform=Platform.SELECT,
+    ),
+    # Ionizer / air purification (read-write ON/OFF switch)
+    "cleanAirMode": ElectroluxDevice(
+        capability_info={
+            "access": "readwrite",
+            "type": "string",
+            "values": {
+                "ON": {},
+                "OFF": {},
+            },
+        },
+        device_class=SwitchDeviceClass.SWITCH,
+        unit=None,
+        entity_category=None,
+        entity_icon="mdi:air-filter",
+        friendly_name="Clean Air Mode",
+    ),
+    # Display brightness (select entity). A capability trigger makes this
+    # read-only while mode is CONTINUOUS or QUIET.
+    "displayLight": ElectroluxDevice(
+        capability_info={
+            "access": "readwrite",
+            "type": "string",
+            "values": {
+                "DISPLAY_LIGHT_0": {},
+                "DISPLAY_LIGHT_1": {},
+            },
+        },
+        device_class=None,
+        unit=None,
+        entity_category=EntityCategory.CONFIG,
+        entity_icon="mdi:lightbulb",
+        friendly_name="Display Light",
+        entity_platform=Platform.SELECT,
+    ),
+    # Filter maintenance status (read-only diagnostic sensor)
+    "filterState": ElectroluxDevice(
+        capability_info={
+            "access": "read",
+            "type": "string",
+            "values": {
+                "BUY": {},
+                "CHANGE": {},
+                "CLEAN": {},
+                "GOOD": {},
+            },
+        },
+        device_class=None,
+        unit=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:air-filter",
+        friendly_name="Filter State",
+    ),
+    # Water bucket fill level (read-only sensor; unit not reported by the
+    # API — raw number, 0 when empty). Pairs with the BUCKET_FULL alert.
+    "waterBucketLevel": ElectroluxDevice(
+        capability_info={"access": "read", "type": "number"},
+        device_class=None,
+        unit=None,
+        entity_category=None,
+        entity_icon="mdi:bucket-outline",
+        friendly_name="Water Bucket Level",
+    ),
+    # Timer controls (seconds, 30-minute steps; 86400 = 24h).
+    # The appliance reports -1 (INVALID_OR_NOT_SET_TIME) when no timer is set.
+    "startTime": ElectroluxDevice(
+        capability_info={
+            "access": "readwrite",
+            "type": "number",
+            "min": 0,
+            "max": 86400,
+            "step": 1800,
+            "unit": "s",
+        },
+        device_class=None,
+        unit=UnitOfTime.SECONDS,
+        entity_category=None,
+        entity_icon="mdi:timer",
+    ),
+    "stopTime": ElectroluxDevice(
+        capability_info={
+            "access": "readwrite",
+            "type": "number",
+            "min": 0,
+            "max": 86400,
+            "step": 1800,
+            "unit": "s",
+        },
+        device_class=None,
+        unit=UnitOfTime.SECONDS,
+        entity_category=None,
+        entity_icon="mdi:timer-off",
+    ),
+    # Network diagnostics (read-only, disabled by default)
+    "networkInterface/linkQualityIndicator": ElectroluxDevice(
+        capability_info={
+            "access": "read",
+            "type": "string",
+            "values": {
+                "EXCELLENT": {},
+                "GOOD": {},
+                "POOR": {},
+                "UNDEFINED": {},
+                "VERY_GOOD": {},
+                "VERY_POOR": {},
+            },
+        },
+        device_class=None,
+        unit=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:wifi",
+        entity_registry_enabled_default=False,
+    ),
+    "networkInterface/swVersion": ElectroluxDevice(
+        capability_info={"access": "read", "type": "string"},
+        device_class=None,
+        unit=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:chip",
+        entity_registry_enabled_default=False,
+    ),
+    "networkInterface/otaState": ElectroluxDevice(
+        capability_info={
+            "access": "read",
+            "type": "string",
+            "values": {
+                "DESCRIPTION_AVAILABLE": {},
+                "DESCRIPTION_DOWNLOADING": {},
+                "DESCRIPTION_READY": {},
+                "FW_DOWNLOADING": {},
+                "FW_DOWNLOAD_START": {},
+                "FW_SIGNATURE_CHECK": {},
+                "FW_UPDATE_IN_PROGRESS": {},
+                "IDLE": {},
+                "READY_TO_UPDATE": {},
+                "UPDATE_ABORT": {},
+                "UPDATE_CHECK": {},
+                "UPDATE_ERROR": {},
+                "UPDATE_OK": {},
+                "WAITINGFORAUTHORIZATION": {},
+            },
+        },
+        device_class=None,
+        unit=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:update",
+        entity_registry_enabled_default=False,
     ),
 }

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -250,6 +250,87 @@ class TestCatalogDishwasher:
         assert len(CATALOG_DW) > 0
 
 
+class TestCatalogDehumidifier:
+    """Tests for catalog_dh.py (verified against DH-950133061, #106)."""
+
+    def test_catalog_dehumidifier_loads(self):
+        """Dehumidifier catalog loads without error."""
+        from custom_components.electrolux.catalogs.catalog_dh import CATALOG_DH
+
+        assert isinstance(CATALOG_DH, dict)
+        assert len(CATALOG_DH) > 0
+        for key, value in CATALOG_DH.items():
+            assert isinstance(
+                value, ElectroluxDevice
+            ), f"Catalog entry '{key}' is {type(value)}, expected ElectroluxDevice"
+
+    def test_mode_values_verified(self):
+        """mode offers the verified DH modes; OFF is present but disabled."""
+        from custom_components.electrolux.catalogs.catalog_dh import CATALOG_DH
+
+        values = CATALOG_DH["mode"].capability_info["values"]
+        for v in ("AUTO", "CONTINUOUS", "DRY", "QUIET"):
+            assert v in values
+            assert not values[v].get("disabled")
+        assert values["OFF"]["disabled"] is True
+
+    def test_fan_speed_values_verified(self):
+        """fanSpeedSetting/fanSpeedState use LOW/MIDDLE/HIGH (no TURBO/MEDIUM)."""
+        from custom_components.electrolux.catalogs.catalog_dh import CATALOG_DH
+
+        for key in ("fanSpeedSetting", "fanSpeedState"):
+            values = CATALOG_DH[key].capability_info["values"]
+            assert set(values) == {"LOW", "MIDDLE", "HIGH"}
+
+    def test_selects_have_platform_override(self):
+        """Read-write string selects declare entity_platform so they are still
+        created from reported state when the capabilities fetch fails (#106)."""
+        from homeassistant.const import Platform
+
+        from custom_components.electrolux.catalogs.catalog_dh import CATALOG_DH
+
+        for key in ("mode", "fanSpeedSetting", "displayLight"):
+            assert CATALOG_DH[key].entity_platform == Platform.SELECT
+
+    def test_start_stop_time_use_seconds(self):
+        """startTime/stopTime use seconds (max=86400, step=1800), not minutes."""
+        from homeassistant.const import UnitOfTime
+
+        from custom_components.electrolux.catalogs.catalog_dh import CATALOG_DH
+
+        for key in ("startTime", "stopTime"):
+            entry = CATALOG_DH[key]
+            assert entry.capability_info["max"] == 86400
+            assert entry.capability_info["step"] == 1800
+            assert entry.capability_info["min"] == 0
+            assert entry.unit == UnitOfTime.SECONDS
+
+    def test_target_humidity_range_verified(self):
+        """targetHumidity fallback range matches the device (35–85 %, step 5)."""
+        from custom_components.electrolux.catalogs.catalog_dh import CATALOG_DH
+
+        entry = CATALOG_DH["targetHumidity"]
+        assert entry.capability_info["min"] == 35
+        assert entry.capability_info["max"] == 85
+        assert entry.capability_info["step"] == 5
+
+    def test_diagnostic_entries(self):
+        """filterState is diagnostic; network diagnostics are disabled by default."""
+        from homeassistant.const import EntityCategory
+
+        from custom_components.electrolux.catalogs.catalog_dh import CATALOG_DH
+
+        assert CATALOG_DH["filterState"].entity_category == EntityCategory.DIAGNOSTIC
+        for key in (
+            "networkInterface/linkQualityIndicator",
+            "networkInterface/swVersion",
+            "networkInterface/otaState",
+        ):
+            entry = CATALOG_DH[key]
+            assert entry.entity_category == EntityCategory.DIAGNOSTIC
+            assert entry.entity_registry_enabled_default is False
+
+
 class TestCatalogAirConditioner:
     """Tests for catalog_ac.py."""
 


### PR DESCRIPTION
## Summary

Verifies the dehumidifier catalog against the first real DH diagnostics, attached to #106 (`DH-950133061_00`, Frigidaire FGAC5044W1, SRAC firmware `v1.9.1_srac`). The DH catalog was SDK-derived and marked *unverified* until now.

### Findings from the diagnostics

- **Placeholder values corrected** (previous entries were flagged "unverified until a real diagnostic is provided"):
  - `mode`: `AUTO` / `CONTINUOUS` / `DRY` / `QUIET` — the SDK-guessed `LAUNDRY` / `DRY_CLOTHES` / `SILENT` don't exist on real hardware. `OFF` is advertised with `disabled: true` (it's the reported mode while powered down but not selectable), so it's included as a disabled value — `select.py` shows it as a transient read-only label (#58 mechanism).
  - `fanSpeedSetting`: `LOW` / `MIDDLE` / `HIGH` — no `MEDIUM` / `TURBO`.
  - `targetHumidity`: fallback range corrected to 35–85 % step 5 (was 30–80). Live API values still override.
- **Missing capabilities added**: `cleanAirMode` (switch), `displayLight` (select, `DISPLAY_LIGHT_0/1`), `fanSpeedState` (sensor), `filterState` (diagnostic sensor), `waterBucketLevel` (sensor, unitless — API reports a bare number), `startTime`/`stopTime` (numbers, seconds, 30-min steps), and the `networkInterface` diagnostics (disabled by default), mirroring the AC catalog conventions.
- **`entity_platform=Platform.SELECT` set on the read-write string selects.** This addresses the actual symptom reported in #106 ("only Manual Sync and Connectivity state show up"): when the capabilities fetch fails, catalog entries are created from reported state via the fallback loop in `models.setup()` — but `get_entity()`'s catalog-only type inference has no branch for readwrite strings, so selects silently fail the `entity_type in PLATFORMS` guard and vanish. The explicit platform override keeps them alive; with healthy capabilities the API-derived type is SELECT anyway, so behaviour is unchanged. Other type catalogs have the same latent gap — possible follow-up, out of scope here.
- **Intentionally not added**: reported-state-only cruft from the shared SRAC firmware — `verticalSwing` (not in capabilities; a dehumidifier has no swing louvre), `cleanFilterAlert` (reports `KEY_ERROR`), duplicate `FilterState` (capital F). Also `hMEPN_DHAlerts` (constant feature flag, sibling of the `fCPN_*` flags discussed in #113).
- `executeCommand` left byte-identical to main — #110 adds `state_mapping="applianceState"` to that entry; keeping it untouched avoids a conflict between the two PRs.
- README: DH marked verified with the known-tested sample; Diagnostics Wanted row updated (`Husky` still unverified).

### Testing

- New `TestCatalogDehumidifier` class covering the verified values, the select platform overrides, timer units, and diagnostic flags.
- Full suite: 1496 passed; ruff + black clean.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)