### PR TITLE
fix(switch): show power switch for write-only executeCommand (closes …

### DIFF
--- a/custom_components/electrolux/catalogs/catalog_dh.py
+++ b/custom_components/electrolux/catalogs/catalog_dh.py
@@ -22,6 +22,7 @@ CATALOG_DH: dict[str, ElectroluxDevice] = {
         entity_category=None,
         entity_icon="mdi:power",
         friendly_name="Power",
+        state_mapping="applianceState",
     ),
     # Current humidity reading (read-only sensor)
     "sensorHumidity": ElectroluxDevice(

--- a/custom_components/electrolux/switch.py
+++ b/custom_components/electrolux/switch.py
@@ -46,15 +46,23 @@ async def async_setup_entry(
             for entity in entities:
                 # Filter out phantom/ghost capabilities (Issue #55)
                 # If a property path or capability key is absent from the reported state,
-                # the appliance hardware does not support it (e.g., Pod wash, AutoDose)
+                # the appliance hardware does not support it (e.g., Pod wash, AutoDose).
+                # Write-only caps (access == "write") are exempt: they never appear in
+                # reported state by design, so absence is not evidence of non-support.
                 if entity.json_path and entity.json_path not in reported_data:
                     if entity.entity_attr not in reported_data:
-                        _LOGGER.debug(
-                            "Skipping phantom switch entity %s for appliance %s (not present in reported state)",
-                            entity.entity_attr,
-                            appliance_id,
+                        cap_access = (
+                            entity.capability.get("access")
+                            if entity.capability
+                            else None
                         )
-                        continue
+                        if cap_access != "write":
+                            _LOGGER.debug(
+                                "Skipping phantom switch entity %s for appliance %s (not present in reported state)",
+                                entity.entity_attr,
+                                appliance_id,
+                            )
+                            continue
 
                 filtered_switches.append(entity)
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,8 @@
+# Test requirements
+homeassistant>=2026.1.0
+pytest>=8.0.0
+pytest-asyncio>=1.0.0
+pytest-cov>=4.0.0
+aiohttp>=3.12.2,<4.0.0
+pyjwt>=2.10.1,<3.0.0
+electrolux-group-developer-sdk

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -148,6 +148,36 @@ class TestElectroluxSwitch:
         entity.get_state_attr = MagicMock(return_value=True)
         assert entity.is_on is True
 
+    def test_async_setup_entry_keeps_write_only_switches(self, mock_coordinator):
+        """Write-only capabilities should stay available as switches even when absent from reported state."""
+        entity = MagicMock()
+        entity.entity_type = SWITCH
+        entity.json_path = "executeCommand"
+        entity.entity_attr = "executeCommand"
+        entity.capability = {"access": "write", "type": "string"}
+
+        appliance = MagicMock()
+        appliance.entities = [entity]
+        appliance.reported_state = {}
+
+        appliances = MagicMock()
+        appliances.appliances = {"TEST_PNC": appliance}
+
+        coordinator = MagicMock()
+        coordinator.data = {"appliances": appliances}
+
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+
+        add_entities = MagicMock()
+
+        import asyncio
+
+        asyncio.run(async_setup_entry(MagicMock(), entry, add_entities))
+
+        add_entities.assert_called_once()
+        assert add_entities.call_args[0][0][0] is entity
+
     @pytest.mark.asyncio
     async def test_async_turn_on(self, switch_entity):
         """Test turning switch on."""


### PR DESCRIPTION
…#96)

The dehumidifier's executeCommand (ON/OFF) was being inferred as a BUTTON entity because its capability access is "write". This created two separate press-buttons ("Power ON" / "Power OFF") with no visible on/off state.

Set entity_platform=Platform.SWITCH and state_mapping="applianceState" on the catalog entry. The switch now reads its state from applianceState (RUNNING → on, OFF → off) and writes ON/OFF via executeCommand, which is exactly what the device API expects.