### PR TITLE
fix(climate): report correct hvac_action for non-cool modes (#102)

### DIFF
--- a/custom_components/electrolux/climate.py
+++ b/custom_components/electrolux/climate.py
@@ -23,6 +23,13 @@ from .util import execute_command_with_error_handling, format_command_for_applia
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
+_MODE_TO_ACTION: dict[HVACMode, HVACAction] = {
+    HVACMode.COOL: HVACAction.COOLING,
+    HVACMode.HEAT: HVACAction.HEATING,
+    HVACMode.DRY: HVACAction.DRYING,
+    HVACMode.FAN_ONLY: HVACAction.FAN,
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -299,20 +306,42 @@ class ElectroluxClimate(ElectroluxEntity, ClimateEntity, RestoreEntity):
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac operation."""
-        # Check appliance state
         state_value = self.get_state_attr("applianceState")
-        if state_value:
-            state_str = str(state_value).upper()
-            if state_str in ["RUNNING", "COOLING", "HEATING"]:
-                return (
-                    HVACAction.COOLING
-                    if self.hvac_mode == HVACMode.COOL
-                    else HVACAction.HEATING
-                )
-            elif state_str == "IDLE":
-                return HVACAction.IDLE
-            elif state_str == "OFF":
-                return HVACAction.OFF
+        if not state_value:
+            return None
+
+        state_str = str(state_value).upper()
+        if state_str == "OFF":
+            return HVACAction.OFF
+        if state_str == "IDLE":
+            return HVACAction.IDLE
+        # Some models report the action directly in applianceState
+        if state_str == "COOLING":
+            return HVACAction.COOLING
+        if state_str == "HEATING":
+            return HVACAction.HEATING
+        if state_str != "RUNNING":
+            return None
+
+        mode = self.hvac_mode
+        if mode in _MODE_TO_ACTION:
+            return _MODE_TO_ACTION[mode]
+
+        if mode == HVACMode.AUTO:
+            # The device decides between heating/cooling; infer from compressor
+            # telemetry when reported (Azul: compressorState + fourWayValveState,
+            # valve on means reversed refrigerant flow = heating).
+            compressor = self.get_state_attr("compressorState")
+            if compressor is not None:
+                if str(compressor).upper() == "OFF":
+                    return HVACAction.IDLE
+                valve = self.get_state_attr("fourWayValveState")
+                if valve is not None:
+                    return (
+                        HVACAction.HEATING
+                        if str(valve).upper() == "ON"
+                        else HVACAction.COOLING
+                    )
 
         return None
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -311,6 +311,48 @@ class TestElectroluxClimate:
         mock_appliance.reported_state["mode"] = "HEAT"
         assert climate_entity.hvac_action == HVACAction.HEATING
 
+    def test_hvac_action_drying(self, climate_entity, mock_appliance):
+        """DRY mode must report DRYING, not HEATING (#102)."""
+        mock_appliance.reported_state["applianceState"] = "RUNNING"
+        mock_appliance.reported_state["mode"] = "DRY"
+        assert climate_entity.hvac_action == HVACAction.DRYING
+
+    def test_hvac_action_fan(self, climate_entity, mock_appliance):
+        """FANONLY mode must report FAN, not HEATING (#102)."""
+        mock_appliance.reported_state["applianceState"] = "RUNNING"
+        mock_appliance.reported_state["mode"] = "FANONLY"
+        assert climate_entity.hvac_action == HVACAction.FAN
+
+    def test_hvac_action_auto_cooling(self, climate_entity, mock_appliance):
+        """AUTO mode with compressor on and four-way valve off means cooling."""
+        mock_appliance.reported_state["applianceState"] = "running"
+        mock_appliance.reported_state["mode"] = "auto"
+        mock_appliance.reported_state["compressorState"] = "on"
+        mock_appliance.reported_state["fourWayValveState"] = "off"
+        assert climate_entity.hvac_action == HVACAction.COOLING
+
+    def test_hvac_action_auto_heating(self, climate_entity, mock_appliance):
+        """AUTO mode with compressor on and four-way valve on means heating."""
+        mock_appliance.reported_state["applianceState"] = "running"
+        mock_appliance.reported_state["mode"] = "auto"
+        mock_appliance.reported_state["compressorState"] = "on"
+        mock_appliance.reported_state["fourWayValveState"] = "on"
+        assert climate_entity.hvac_action == HVACAction.HEATING
+
+    def test_hvac_action_auto_compressor_off(self, climate_entity, mock_appliance):
+        """AUTO mode with compressor off means the unit is idling."""
+        mock_appliance.reported_state["applianceState"] = "running"
+        mock_appliance.reported_state["mode"] = "auto"
+        mock_appliance.reported_state["compressorState"] = "off"
+        assert climate_entity.hvac_action == HVACAction.IDLE
+
+    def test_hvac_action_auto_no_telemetry(self, climate_entity, mock_appliance):
+        """AUTO mode without compressor telemetry cannot determine the action."""
+        mock_appliance.reported_state["applianceState"] = "RUNNING"
+        mock_appliance.reported_state["mode"] = "AUTO"
+        mock_appliance.reported_state.pop("compressorState", None)
+        assert climate_entity.hvac_action is None
+
     def test_hvac_action_idle(self, climate_entity, mock_appliance):
         """Test HVAC action returns IDLE."""
         mock_appliance.reported_state["applianceState"] = "IDLE"


### PR DESCRIPTION
## Summary

Fixes the "every mode shows as Heating" report in #102 (Azul / AEG Comfort 6000).

`hvac_action` treated every running state as a binary cooling/heating choice:

```python
return HVACAction.COOLING if self.hvac_mode == HVACMode.COOL else HVACAction.HEATING
```

so AUTO, DRY and FANONLY all rendered as **Heating** in the dashboard. The reporter guessed it was a dashboard issue — it isn't; the integration was reporting the wrong action.

## Changes

- Map the action from the active hvac mode: COOL → COOLING, HEAT → HEATING, DRY → DRYING, FANONLY → FAN.
- AUTO: the device decides heating vs cooling itself, so infer from compressor telemetry when reported — `compressorState` off → IDLE, otherwise `fourWayValveState` on → HEATING, off → COOLING. Both fields are present in the Azul diagnostics attached to #102. Without telemetry, return `None` (unknown) instead of guessing HEATING.
- Explicit `COOLING`/`HEATING` `applianceState` values are still honoured directly, and OFF/IDLE behave as before.

## Testing

- 6 new tests covering DRY, FANONLY, and AUTO (cooling / heating / compressor-off / no-telemetry), using the lowercase state values the Azul actually reports (`running`, `auto`, `on`).
- Full suite: 1589 passed. `ruff` and `black` clean.

Closes #102