### PR TITLE
feat(catalog/ac): add Telica-specific entities to AC catalog (#83)

### DIFF
--- a/custom_components/electrolux/catalogs/catalog_ac.py
+++ b/custom_components/electrolux/catalogs/catalog_ac.py
@@ -4,7 +4,13 @@ from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.number import NumberDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.switch import SwitchDeviceClass
-from homeassistant.const import EntityCategory, UnitOfTemperature, UnitOfTime
+from homeassistant.const import (
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    PERCENTAGE,
+    EntityCategory,
+    UnitOfTemperature,
+    UnitOfTime,
+)
 
 from ..model import ElectroluxDevice
 
@@ -589,6 +595,115 @@ CATALOG_AC: dict[str, ElectroluxDevice] = {
         unit=None,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_icon="mdi:transmission-tower",
+        entity_registry_enabled_default=False,
+    ),
+    # --- Telica (Electrolux 700 multifunctional AC / air purifier combo) ---
+    # Air quality sensors
+    "pm25": ElectroluxDevice(
+        capability_info={"access": "read", "type": "int"},
+        device_class=SensorDeviceClass.PM25,
+        unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        entity_category=None,
+        entity_icon="mdi:air-filter",
+        friendly_name="PM2.5",
+    ),
+    "pm10": ElectroluxDevice(
+        capability_info={"access": "read", "type": "int"},
+        device_class=SensorDeviceClass.PM10,
+        unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        entity_category=None,
+        entity_icon="mdi:air-filter",
+        friendly_name="PM10",
+    ),
+    "sensorHumidity": ElectroluxDevice(
+        capability_info={"access": "read", "type": "int"},
+        device_class=SensorDeviceClass.HUMIDITY,
+        unit=PERCENTAGE,
+        entity_category=None,
+        entity_icon="mdi:water-percent",
+    ),
+    # Read-only current operating mode (mirrors the writable `mode` field)
+    "modeState": ElectroluxDevice(
+        capability_info={
+            "access": "read",
+            "type": "string",
+            "values": {
+                "COOL": {},
+                "DRY": {},
+                "FANONLY": {},
+            },
+        },
+        device_class=None,
+        unit=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:fan",
+        entity_registry_enabled_default=False,
+    ),
+    # Sound volume (0 = silent, 1 = on; single-step boolean-style number)
+    "soundVolume": ElectroluxDevice(
+        capability_info={
+            "access": "readwrite",
+            "type": "number",
+            "min": 0,
+            "max": 1,
+            "step": 1,
+        },
+        device_class=None,
+        unit=None,
+        entity_category=EntityCategory.CONFIG,
+        entity_icon="mdi:volume-high",
+    ),
+    # UI lock (child lock)
+    "uiLockMode": ElectroluxDevice(
+        capability_info={"access": "readwrite", "type": "boolean"},
+        device_class=SwitchDeviceClass.SWITCH,
+        unit=None,
+        entity_category=EntityCategory.CONFIG,
+        entity_icon="mdi:lock",
+    ),
+    # Filter maintenance — main air filter
+    "filterRuntime": ElectroluxDevice(
+        capability_info={"access": "read", "type": "number"},
+        device_class=SensorDeviceClass.DURATION,
+        unit=UnitOfTime.SECONDS,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:air-filter",
+        entity_registry_enabled_default=False,
+    ),
+    "filterReset": ElectroluxDevice(
+        capability_info={"access": "write", "type": "string"},
+        device_class=None,
+        unit=None,
+        entity_category=EntityCategory.CONFIG,
+        entity_icon="mdi:air-filter",
+    ),
+    # HEPA filter
+    "hepaFilterInsertedState": ElectroluxDevice(
+        capability_info={
+            "access": "read",
+            "type": "string",
+            "values": {"ON": {}, "OFF": {}},
+        },
+        device_class=BinarySensorDeviceClass.PRESENCE,
+        unit=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:air-filter",
+        friendly_name="HEPA Filter Inserted",
+    ),
+    "hepaFilterReset": ElectroluxDevice(
+        capability_info={"access": "write", "type": "string"},
+        device_class=None,
+        unit=None,
+        entity_category=EntityCategory.CONFIG,
+        entity_icon="mdi:air-filter",
+    ),
+    # Air quality index (Telica-specific, state-only — not in capabilities)
+    "airQualityLevel": ElectroluxDevice(
+        capability_info={"access": "read", "type": "number"},
+        device_class=None,
+        unit=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:air-filter",
         entity_registry_enabled_default=False,
     ),
 }

--- a/custom_components/electrolux/catalogs/catalog_ac.py
+++ b/custom_components/electrolux/catalogs/catalog_ac.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     UnitOfTime,
 )
 
+from ..const import BUTTON
 from ..model import ElectroluxDevice
 
 CATALOG_AC: dict[str, ElectroluxDevice] = {
@@ -653,6 +654,7 @@ CATALOG_AC: dict[str, ElectroluxDevice] = {
         device_class=None,
         unit=None,
         entity_category=EntityCategory.CONFIG,
+        entity_platform=BUTTON,
         entity_icon="mdi:air-filter",
     ),
     # HEPA filter
@@ -690,6 +692,7 @@ CATALOG_AC: dict[str, ElectroluxDevice] = {
         device_class=None,
         unit=None,
         entity_category=EntityCategory.CONFIG,
+        entity_platform=BUTTON,
         entity_icon="mdi:air-filter",
     ),
     # Air quality index (Telica-specific, state-only — not in capabilities)

--- a/custom_components/electrolux/catalogs/catalog_ac.py
+++ b/custom_components/electrolux/catalogs/catalog_ac.py
@@ -639,14 +639,6 @@ CATALOG_AC: dict[str, ElectroluxDevice] = {
         entity_category=EntityCategory.CONFIG,
         entity_icon="mdi:volume-high",
     ),
-    # UI lock (child lock)
-    "uiLockMode": ElectroluxDevice(
-        capability_info={"access": "readwrite", "type": "boolean"},
-        device_class=SwitchDeviceClass.SWITCH,
-        unit=None,
-        entity_category=EntityCategory.CONFIG,
-        entity_icon="mdi:lock",
-    ),
     # Filter maintenance — main air filter
     "filterRuntime": ElectroluxDevice(
         capability_info={"access": "read", "type": "number"},
@@ -664,6 +656,23 @@ CATALOG_AC: dict[str, ElectroluxDevice] = {
         entity_icon="mdi:air-filter",
     ),
     # HEPA filter
+    "hepaFilterState": ElectroluxDevice(
+        capability_info={
+            "access": "read",
+            "type": "string",
+            "values": {
+                "GOOD": {},
+                "BUY": {},
+                "CHANGE": {},
+            },
+        },
+        device_class=None,
+        unit=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:air-filter",
+        entity_registry_enabled_default=False,
+        friendly_name="HEPA Filter State",
+    ),
     "hepaFilterInsertedState": ElectroluxDevice(
         capability_info={
             "access": "read",

--- a/custom_components/electrolux/catalogs/catalog_ac.py
+++ b/custom_components/electrolux/catalogs/catalog_ac.py
@@ -624,31 +624,17 @@ CATALOG_AC: dict[str, ElectroluxDevice] = {
     ),
     # Read-only current operating mode (mirrors the writable `mode` field)
     "modeState": ElectroluxDevice(
-        capability_info={
-            "access": "read",
-            "type": "string",
-            "values": {
-                "COOL": {},
-                "DRY": {},
-                "FANONLY": {},
-            },
-        },
+        capability_info={"access": "read", "type": "string"},
         device_class=None,
         unit=None,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_icon="mdi:fan",
         entity_registry_enabled_default=False,
     ),
-    # Sound volume (0 = silent, 1 = on; single-step boolean-style number)
+    # Sound volume: 0 = silent, 1 = on — binary, modeled as a switch
     "soundVolume": ElectroluxDevice(
-        capability_info={
-            "access": "readwrite",
-            "type": "number",
-            "min": 0,
-            "max": 1,
-            "step": 1,
-        },
-        device_class=None,
+        capability_info={"access": "readwrite", "type": "boolean"},
+        device_class=SwitchDeviceClass.SWITCH,
         unit=None,
         entity_category=EntityCategory.CONFIG,
         entity_icon="mdi:volume-high",


### PR DESCRIPTION
## Summary

Closes #83 (Electrolux ECU7678CSW / Telica-950011775).

Telica is already routed to `catalog_ac`, but the catalog only covers plain AC capabilities. This device is a 7-in-1 unit that also includes PM2.5/PM10 sensors, ambient humidity, HEPA filter management, and sound control — none of which had catalog entries.

All entries verified against the diagnostics JSON attached to #83.

## New entities

| Key | Type | Notes |
|-----|------|-------|
| `pm25` | Sensor (PM2.5, µg/m³) | Air quality |
| `pm10` | Sensor (PM10, µg/m³) | Air quality |
| `sensorHumidity` | Sensor (humidity, %) | Ambient |
| `soundVolume` | Switch | 0 = silent, 1 = audible |
| `filterReset` | Button (write) | Reset main filter counter |
| `filterRuntime` | Sensor (duration, s) | Main filter runtime; diagnostic, disabled by default |
| `hepaFilterState` | Sensor (string) | GOOD / BUY / CHANGE; diagnostic, disabled by default |
| `hepaFilterInsertedState` | Binary sensor (presence) | HEPA presence |
| `hepaFilterReset` | Button (write) | Reset HEPA filter counter |
| `modeState` | Sensor (string) | Read-only current mode; diagnostic, disabled by default |
| `airQualityLevel` | Sensor (number) | State-only (no capability); diagnostic, disabled by default |

## Testing

Full suite: 1583 passed. `ruff` and `black` clean.
