### PR TITLE
fix(coordinator): add SSE liveness watchdog (#104)

### DIFF
--- a/custom_components/electrolux/coordinator.py
+++ b/custom_components/electrolux/coordinator.py
@@ -142,7 +142,9 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
             {}
         )  # Track previous connectivity state per appliance
         self._last_sse_restart_time = 0.0  # Track when we last restarted SSE
-        self._last_sse_event_time = 0.0  # Track last received SSE event for watchdog
+        self._last_sse_event_time = (
+            hass.loop.time()
+        )  # Track last received SSE event for watchdog
         self._last_manual_sync_time = 0.0  # Track when we last performed manual sync
         self._last_time_to_end: dict[str, float | None] = (
             {}
@@ -1709,11 +1711,7 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
         # arrived within SSE_WATCHDOG_TIMEOUT. This catches the case where the SDK's
         # internal reconnect loop keeps the task alive but TransferEncodingErrors
         # (or other transient failures) prevent events from actually flowing.
-        if (
-            self.listen_task is not None
-            and not self.listen_task.done()
-            and self._last_sse_event_time > 0
-        ):
+        if self.listen_task is not None and not self.listen_task.done():
             silence = self.hass.loop.time() - self._last_sse_event_time
             if silence > SSE_WATCHDOG_TIMEOUT and self._can_restart_sse():
                 _LOGGER.warning(

--- a/custom_components/electrolux/coordinator.py
+++ b/custom_components/electrolux/coordinator.py
@@ -67,6 +67,9 @@ WEBSOCKET_DISCONNECT_TIMEOUT = 5.0  # seconds for websocket disconnect
 WEBSOCKET_BACKOFF_DELAY = 300  # 5 minutes in seconds for backoff
 API_DISCONNECT_TIMEOUT = 3.0  # seconds for API disconnect
 SSE_RESTART_COOLDOWN = 900  # 15 minutes: cooldown between SSE restart attempts
+SSE_WATCHDOG_TIMEOUT = (
+    600  # 10 minutes: restart SSE if no event received in this window
+)
 
 # String constants for data keys
 APPLIANCE_ID_KEY = "applianceId"
@@ -139,6 +142,7 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
             {}
         )  # Track previous connectivity state per appliance
         self._last_sse_restart_time = 0.0  # Track when we last restarted SSE
+        self._last_sse_event_time = 0.0  # Track last received SSE event for watchdog
         self._last_manual_sync_time = 0.0  # Track when we last performed manual sync
         self._last_time_to_end: dict[str, float | None] = (
             {}
@@ -475,6 +479,8 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
             # Track this value for next comparison
             self._last_time_to_end[appliance_id] = new_value
 
+        self._last_sse_event_time = self.hass.loop.time()
+
         _LOGGER.debug(
             "SSE update received for %s: %s",
             appliance_id,
@@ -680,6 +686,8 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
 
     def _process_bulk_update(self, data: dict[str, Any], appliances: Any) -> None:
         """Process a bulk appliance state update."""
+        self._last_sse_event_time = self.hass.loop.time()
+
         # Extract appliance ID from the SSE payload
         appliance_id = data.get(APPLIANCE_ID_KEY) or data.get(APPLIANCE_ID_ALT_KEY)
         if not appliance_id:
@@ -842,6 +850,9 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
     async def _on_sse_connected(self) -> None:
         """Handle actual SSE connection events, including internal SDK reconnects."""
         now = self.hass.loop.time()
+        # Seed the watchdog so a fresh connection gets a full quiet window before
+        # being considered stale.
+        self._last_sse_event_time = now
         elapsed = now - self._last_sse_resync_time
 
         if elapsed >= SSE_RESYNC_DEBOUNCE:
@@ -1693,6 +1704,33 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
             # so we don't hammer a still-unavailable API.
             if getattr(self, "_pending_capability_retry", None):
                 self._schedule_capability_retry()
+
+        # SSE liveness watchdog: restart if the task is running but no event has
+        # arrived within SSE_WATCHDOG_TIMEOUT. This catches the case where the SDK's
+        # internal reconnect loop keeps the task alive but TransferEncodingErrors
+        # (or other transient failures) prevent events from actually flowing.
+        if (
+            self.listen_task is not None
+            and not self.listen_task.done()
+            and self._last_sse_event_time > 0
+        ):
+            silence = self.hass.loop.time() - self._last_sse_event_time
+            if silence > SSE_WATCHDOG_TIMEOUT and self._can_restart_sse():
+                _LOGGER.warning(
+                    "SSE watchdog: no event received in %.0fs — restarting stream",
+                    silence,
+                )
+                try:
+                    await asyncio.wait_for(
+                        self.api.disconnect_websocket(),
+                        timeout=WEBSOCKET_DISCONNECT_TIMEOUT,
+                    )
+                    await asyncio.wait_for(
+                        self.listen_websocket(), timeout=UPDATE_TIMEOUT
+                    )
+                    _LOGGER.info("SSE watchdog: stream restarted successfully")
+                except Exception as ex:
+                    _LOGGER.warning("SSE watchdog: restart failed: %s", ex)
 
         # Trigger SSE restart if appliances came back online
         if newly_online_appliances and self._can_restart_sse():

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -33,7 +33,7 @@ def mock_coordinator(mock_api_client):
         coord._last_update_times = {}
         coord._last_known_connectivity = {}
         coord._last_sse_restart_time = 0
-        coord._last_sse_event_time = 0.0
+        coord._last_sse_event_time = 1000000.0  # matches mock hass.loop.time()
         coord.listen_task = None
         coord._consecutive_auth_failures = 0
         coord._auth_failure_threshold = 3

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -33,6 +33,8 @@ def mock_coordinator(mock_api_client):
         coord._last_update_times = {}
         coord._last_known_connectivity = {}
         coord._last_sse_restart_time = 0
+        coord._last_sse_event_time = 0.0
+        coord.listen_task = None
         coord._consecutive_auth_failures = 0
         coord._auth_failure_threshold = 3
         coord._last_time_to_end = {}
@@ -155,6 +157,73 @@ async def test_async_update_data_auth_error(mock_coordinator, mock_api_client):
 
     with pytest.raises(ConfigEntryAuthFailed):
         await mock_coordinator._async_update_data()
+
+
+@pytest.mark.asyncio
+async def test_sse_watchdog_triggers_restart(mock_coordinator, mock_api_client):
+    """SSE watchdog restarts stream when task is alive but no event in SSE_WATCHDOG_TIMEOUT."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    mock_state = {"properties": {"reported": {"powerState": "on"}}}
+    mock_api_client.get_appliance_state = AsyncMock(return_value=mock_state)
+
+    mock_appliance = MagicMock()
+    mock_appliance.update = MagicMock()
+    mock_appliance.state = {"connectivityState": "connected"}
+    mock_appliances = MagicMock()
+    mock_appliances.get_appliances.return_value = {"app1": mock_appliance}
+    mock_coordinator.data = {"appliances": mock_appliances}
+
+    # Simulate a running SSE task that hasn't delivered an event in >watchdog window (601s)
+    stale_task = MagicMock()
+    stale_task.done.return_value = False
+    mock_coordinator.listen_task = stale_task
+    mock_coordinator._last_sse_event_time = (
+        mock_coordinator.hass.loop.time.return_value - 601
+    )
+    mock_coordinator._last_sse_restart_time = 0.0  # allow restart
+
+    mock_api_client.disconnect_websocket = AsyncMock()
+    mock_coordinator.listen_websocket = AsyncMock()
+
+    await mock_coordinator._async_update_data()
+
+    mock_api_client.disconnect_websocket.assert_awaited_once()
+    mock_coordinator.listen_websocket.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sse_watchdog_no_restart_when_events_recent(
+    mock_coordinator, mock_api_client
+):
+    """SSE watchdog does not restart if an event arrived within the timeout window."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    mock_state = {"properties": {"reported": {"powerState": "on"}}}
+    mock_api_client.get_appliance_state = AsyncMock(return_value=mock_state)
+
+    mock_appliance = MagicMock()
+    mock_appliance.update = MagicMock()
+    mock_appliance.state = {"connectivityState": "connected"}
+    mock_appliances = MagicMock()
+    mock_appliances.get_appliances.return_value = {"app1": mock_appliance}
+    mock_coordinator.data = {"appliances": mock_appliances}
+
+    stale_task = MagicMock()
+    stale_task.done.return_value = False
+    mock_coordinator.listen_task = stale_task
+    # Event arrived 60s ago — well within the watchdog window
+    mock_coordinator._last_sse_event_time = (
+        mock_coordinator.hass.loop.time.return_value - 60
+    )
+
+    mock_api_client.disconnect_websocket = AsyncMock()
+    mock_coordinator.listen_websocket = AsyncMock()
+
+    await mock_coordinator._async_update_data()
+
+    mock_api_client.disconnect_websocket.assert_not_awaited()
+    mock_coordinator.listen_websocket.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Root cause

The SDK's `start_event_stream` runs an infinite `while True` reconnect loop with a flat 10-second sleep on any error. This means `listen_task` never completes, so `listen_task.done()` always returns `False` and the `_handle_sse_failure` done callback in `api_client.py` never fires.

When `TransferEncodingError` (or any other transient transport failure) repeatedly kills the inner read loop, the integration has no way to know: the task appears alive, the SDK logs `Connected to SSE stream` and the `on_connected` callback fires and refreshes state — but events never actually flow. The existing 6-hour health check interval is far too long to recover in any useful time.

This is exactly what the reporter in #104 observed: connected, refreshed, then silence.

## Fix

Track `_last_sse_event_time`, stamped on every incoming SSE event (both the incremental and bulk paths in `incoming_data` and `_process_bulk_update`). Seeded to the current time each time `_on_sse_connected` fires so a fresh connection gets a full quiet window before being considered stale.

The existing `_async_update_data` health check (already running every 6 hours) gains one extra check: if the stream task is running but no event has arrived in `SSE_WATCHDOG_TIMEOUT` (10 minutes), disconnect and reconnect. Reuses the existing `_can_restart_sse` 15-minute cooldown to prevent hammering.

No SDK changes. No new tasks. No new loops.

## Tests

- `test_sse_watchdog_triggers_restart` — task alive, event 601s ago → disconnect + reconnect called
- `test_sse_watchdog_no_restart_when_events_recent` — event 60s ago → no restart

Full suite: 1585 passed. `ruff` and `black` clean.

Closes #104