### PR TITLE
test: assert AC filter reset entities pin BUTTON platform

### DIFF
--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -431,6 +431,15 @@ class TestCatalogAirConditioner:
         for v in ("QUIET", "LOW", "MIDDLE", "HIGH"):
             assert v in values
 
+    def test_filter_reset_entities_are_buttons(self):
+        """filterReset/hepaFilterReset pin BUTTON explicitly, not via inference."""
+        from homeassistant.const import Platform
+
+        from custom_components.electrolux.catalogs.catalog_ac import CATALOG_AC
+
+        for key in ("filterReset", "hepaFilterReset"):
+            assert CATALOG_AC[key].entity_platform == Platform.BUTTON
+
     def test_new_switch_entities(self):
         """New switch entities exist with correct device_class and icon."""
         from homeassistant.components.switch import SwitchDeviceClass


### PR DESCRIPTION
## Summary
- filterReset/hepaFilterReset already declare entity_platform=BUTTON on main (merged via #120), but nothing asserted it
- Adds a regression test locking in the explicit BUTTON platform so future changes to the write/string inference logic can't silently regress these two entries

## Test plan
- [x] `pytest tests/test_catalog.py -q` — 62 passed