### PR TITLE
fix(coordinator): poll REST state when timeToEnd goes stale mid-cycle (#104)

### DIFF
--- a/custom_components/electrolux/coordinator.py
+++ b/custom_components/electrolux/coordinator.py
@@ -105,6 +105,17 @@ TIME_ENTITY_THRESHOLD_HIGH = (
     60  # seconds (1 minute — covers minute-granularity appliances)
 )
 
+# Some appliance models stop pushing timeToEnd over the SSE stream entirely while
+# still pushing other properties (door, connectivity, etc.) normally — the stream
+# stays alive so the connection-level stall watchdog above never notices (#104).
+# This tracks timeToEnd freshness per appliance instead of per connection, and
+# forces a REST poll when it goes stale while the countdown is actually meaningful.
+ACTIVE_TIME_TO_END_STATES = {"RUNNING", "PAUSED", "DELAYED_START"}
+TIME_TO_END_STALE_THRESHOLD = (
+    240.0  # seconds without a timeToEnd refresh before polling
+)
+TIME_TO_END_STALL_CHECK_INTERVAL = 60.0  # seconds between staleness checks
+
 
 class ElectroluxCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the API."""
@@ -147,6 +158,10 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
         self._last_time_to_end: dict[str, float | None] = (
             {}
         )  # Track timeToEnd values to detect skipped updates (debug for Electrolux bug)
+        self._last_time_to_end_seen: dict[str, float] = (
+            {}
+        )  # Track when timeToEnd was last refreshed (SSE or REST) per appliance (#104)
+        self._time_to_end_monitor_task: Optional[asyncio.Task] = None
         self._consecutive_auth_failures = (
             0  # Track consecutive auth failures before creating repair
         )
@@ -330,6 +345,7 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
 
                 appliance.update(appliance_status)
                 self.async_set_updated_data(self.data)
+                self._mark_time_to_end_fresh(appliance_id)
         except asyncio.CancelledError:
             # Always re-raise cancellation
             raise
@@ -349,6 +365,10 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
                 f"Unexpected error during deferred update for {appliance_id}"
             )
             return
+
+    def _mark_time_to_end_fresh(self, appliance_id: str) -> None:
+        """Record that timeToEnd was just refreshed (via SSE or REST) for an appliance."""
+        self._last_time_to_end_seen[appliance_id] = self.hass.loop.time()
 
     def _schedule_state_refresh(self, appliance_id: str) -> None:
         """Schedule a deduped _refresh_after_appliance_state_change task.
@@ -403,6 +423,7 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
             status = await self.api.get_appliance_state(appliance_id)
             appliance.update(status)
             self.async_set_updated_data(self.data)
+            self._mark_time_to_end_fresh(appliance_id)
             _LOGGER.debug("State-change refresh completed for %s", appliance_id)
         except asyncio.CancelledError:
             raise
@@ -471,6 +492,7 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
         if data[PROPERTY_KEY] == "timeToEnd":
             new_value = data[VALUE_KEY]
             old_value = self._last_time_to_end.get(appliance_id)
+            self._mark_time_to_end_fresh(appliance_id)
 
             _LOGGER.debug(
                 "timeToEnd for %s: %s → %s",
@@ -818,6 +840,7 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
 
                 # Update last seen time
                 self._last_update_times[app_id] = self.hass.loop.time()
+                self._mark_time_to_end_fresh(app_id)
                 return True
             except Exception as ex:
                 _LOGGER.debug(f"Failed to refresh {app_id}: {ex}")
@@ -913,6 +936,7 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
                 on_connected=self._on_sse_connected,
             )
             self._ensure_sse_stall_monitor_started()
+            self._ensure_time_to_end_monitor_started()
             _LOGGER.debug(
                 f"Successfully started SSE listening for {len(ids)} appliances"
             )
@@ -976,6 +1000,101 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
         except Exception as ex:
             _LOGGER.warning("SSE watchdog monitor failed unexpectedly: %s", ex)
             raise
+
+    def _ensure_time_to_end_monitor_started(self) -> None:
+        """Ensure the timeToEnd staleness watchdog task is running."""
+        task = getattr(self, "_time_to_end_monitor_task", None)
+        if task is not None and not task.done():
+            return
+
+        self._time_to_end_monitor_task = self.hass.async_create_task(
+            self._monitor_time_to_end_staleness_loop()
+        )
+        _LOGGER.debug(
+            "timeToEnd staleness monitor started (interval=%.0fs threshold=%.0fs)",
+            TIME_TO_END_STALL_CHECK_INTERVAL,
+            TIME_TO_END_STALE_THRESHOLD,
+        )
+
+    async def _monitor_time_to_end_staleness_loop(self) -> None:
+        """Background loop that REST-polls actively-running appliances whose
+        timeToEnd hasn't been refreshed recently.
+
+        Some appliance models stop pushing timeToEnd over the SSE stream entirely
+        while still pushing other properties normally (#104). The connection-level
+        stall watchdog can't detect this — the stream stays alive and other
+        properties keep arriving — so this tracks timeToEnd freshness per appliance
+        instead of per connection.
+        """
+        try:
+            while True:
+                await asyncio.sleep(TIME_TO_END_STALL_CHECK_INTERVAL)
+
+                if not self.data:
+                    continue
+                appliances = self.data.get("appliances")
+                if not appliances:
+                    continue
+                app_dict = appliances.get_appliances()
+                if not app_dict:
+                    continue
+
+                now = self.hass.loop.time()
+                for appliance_id, appliance in app_dict.items():
+                    state = appliance.reported_state.get("applianceState")
+                    if isinstance(state, str):
+                        state = state.upper().replace(" ", "_")
+                    if state not in ACTIVE_TIME_TO_END_STATES:
+                        continue
+
+                    last_seen = self._last_time_to_end_seen.get(appliance_id)
+                    age = now - last_seen if last_seen else float("inf")
+                    if age <= TIME_TO_END_STALE_THRESHOLD:
+                        continue
+
+                    pending = self._pending_state_refresh_tasks.get(appliance_id)
+                    if pending and not pending.done():
+                        # Already being refreshed by the state-transition poll
+                        continue
+
+                    _LOGGER.debug(
+                        "timeToEnd stale for %s (%.1fs since last update, state=%s) "
+                        "— polling REST state",
+                        appliance_id,
+                        age,
+                        state,
+                    )
+                    await self._poll_time_to_end(appliance_id)
+        except asyncio.CancelledError:
+            _LOGGER.debug("timeToEnd staleness monitor cancelled")
+            raise
+        except Exception as ex:
+            _LOGGER.warning("timeToEnd staleness monitor failed unexpectedly: %s", ex)
+            raise
+
+    async def _poll_time_to_end(self, appliance_id: str) -> None:
+        """Refresh one appliance's REST state to recover a stale timeToEnd value."""
+        if self.data is None:
+            return
+        appliances: Any = self.data.get("appliances")
+        if not appliances:
+            return
+        appliance = appliances.get_appliance(appliance_id)
+        if not appliance:
+            return
+        try:
+            status = await self.api.get_appliance_state(appliance_id)
+            appliance.update(status)
+            self.async_set_updated_data(self.data)
+            self._mark_time_to_end_fresh(appliance_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception as ex:
+            _LOGGER.warning(
+                "timeToEnd staleness poll failed for %s — will retry next cycle: %s",
+                appliance_id,
+                ex,
+            )
 
     async def renew_websocket(self):
         """Renew SSE event stream."""
@@ -1098,6 +1217,12 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
             sse_monitor_task.cancel()
             await asyncio.gather(sse_monitor_task, return_exceptions=True)
         self._sse_stall_monitor_task = None
+
+        time_to_end_monitor_task = getattr(self, "_time_to_end_monitor_task", None)
+        if time_to_end_monitor_task and not time_to_end_monitor_task.done():
+            time_to_end_monitor_task.cancel()
+            await asyncio.gather(time_to_end_monitor_task, return_exceptions=True)
+        self._time_to_end_monitor_task = None
 
         # Close API connection - util.py handles SSE stream cleanup
         try:
@@ -2081,6 +2206,7 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
                         self._last_known_connectivity.pop(appliance_id, None)
                         # Clean up time tracking
                         self._last_time_to_end.pop(appliance_id, None)
+                        self._last_time_to_end_seen.pop(appliance_id, None)
                         # Clean up remote control tracking
                         self._last_remote_control.pop(appliance_id, None)
                         # Cancel and clean up any deferred tasks

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -36,6 +36,7 @@ def mock_coordinator(mock_api_client):
         coord._consecutive_auth_failures = 0
         coord._auth_failure_threshold = 3
         coord._last_time_to_end = {}
+        coord._last_time_to_end_seen = {}
         coord._deferred_tasks = set()
         coord._deferred_tasks_by_appliance = {}
         coord._pending_capability_retry = set()

--- a/tests/test_coordinator_advanced.py
+++ b/tests/test_coordinator_advanced.py
@@ -81,6 +81,7 @@ def coordinator(mock_hass, mock_api):
         coord._last_sse_restart_time = 0.0
         coord._last_manual_sync_time = 0.0
         coord._last_time_to_end = {}
+        coord._last_time_to_end_seen = {}
         coord._consecutive_auth_failures = 0
         coord._auth_failure_threshold = 3
         coord._last_token_update = 0.0

--- a/tests/test_coordinator_connectivity.py
+++ b/tests/test_coordinator_connectivity.py
@@ -77,6 +77,7 @@ def coordinator(mock_hass, mock_api_client, mock_config_entry):
         coord._consecutive_auth_failures = 0
         coord._auth_failure_threshold = 3
         coord._last_time_to_end = {}
+        coord._last_time_to_end_seen = {}
         coord._last_token_update = 0.0
         coord._appliances_cache = None
         coord._can_restart_sse = MagicMock(return_value=True)

--- a/tests/test_coordinator_coverage_gaps.py
+++ b/tests/test_coordinator_coverage_gaps.py
@@ -83,6 +83,7 @@ def coordinator(mock_hass, mock_api):
         coord._sse_stall_monitor_task = None
         coord._last_manual_sync_time = 0.0
         coord._last_time_to_end = {}
+        coord._last_time_to_end_seen = {}
         coord._consecutive_auth_failures = 0
         coord._auth_failure_threshold = 3
         coord._last_token_update = 0.0
@@ -113,6 +114,7 @@ def _make_appliances(appliance_ids_states: dict[str, dict]):
 
     appliances_mock.get_appliance_ids = MagicMock(return_value=list(app_dict.keys()))
     appliances_mock.get_appliances = MagicMock(return_value=app_dict)
+    appliances_mock.get_appliance = MagicMock(side_effect=app_dict.get)
     appliances_mock.appliances = app_dict
     return appliances_mock
 
@@ -185,6 +187,40 @@ class TestListenWebsocketGaps:
         await coordinator.listen_websocket()
 
         assert coordinator._sse_stall_monitor_task is started
+
+    async def test_listen_websocket_starts_time_to_end_monitor_task(
+        self, coordinator, mock_api
+    ):
+        """listen_websocket should also start the timeToEnd staleness monitor (#104)."""
+        appliances = _make_appliances({"APP001": {"connectivityState": "connected"}})
+        coordinator.data = {"appliances": appliances}
+
+        started = MagicMock()
+        coordinator._time_to_end_monitor_task = None
+        coordinator.hass.async_create_task = MagicMock(
+            side_effect=lambda coro, **kwargs: (
+                coro.close() if asyncio.iscoroutine(coro) else None
+            )
+            or started
+        )
+
+        await coordinator.listen_websocket()
+
+        assert coordinator._time_to_end_monitor_task is started
+
+    async def test_ensure_time_to_end_monitor_skips_when_already_running(
+        self, coordinator
+    ):
+        """A live monitor task should not be replaced by a new one."""
+        existing = MagicMock()
+        existing.done.return_value = False
+        coordinator._time_to_end_monitor_task = existing
+        coordinator.hass.async_create_task = MagicMock()
+
+        coordinator._ensure_time_to_end_monitor_started()
+
+        coordinator.hass.async_create_task.assert_not_called()
+        assert coordinator._time_to_end_monitor_task is existing
 
 
 class TestSseReconnectResync:
@@ -323,6 +359,135 @@ class TestSseStallWatchdog:
         await coordinator.close_websocket()
 
         assert coordinator._sse_stall_monitor_task is None
+
+
+class TestTimeToEndStalenessWatchdog:
+    """Tests for the per-appliance timeToEnd staleness watchdog (#104).
+
+    Some appliance models stop pushing timeToEnd over SSE entirely while still
+    pushing other properties normally, so the connection-level stall watchdog
+    never notices. This watchdog tracks timeToEnd freshness per appliance instead.
+    """
+
+    async def test_incoming_time_to_end_marks_fresh(self, coordinator):
+        appliances = _make_appliances({"APP001": {"connectivityState": "connected"}})
+        coordinator.data = {"appliances": appliances}
+        coordinator._appliances_cache = appliances
+        coordinator.hass.loop.time.return_value = 1_000_500.0
+
+        coordinator.incoming_data(
+            {"applianceId": "APP001", "property": "timeToEnd", "value": 120}
+        )
+
+        assert coordinator._last_time_to_end_seen["APP001"] == 1_000_500.0
+
+    async def test_monitor_polls_stale_running_appliance(self, coordinator):
+        appliances = _make_appliances({"APP001": {"applianceState": "RUNNING"}})
+        coordinator.data = {"appliances": appliances}
+        coordinator.hass.loop.time.return_value = 1_000_400.0
+        coordinator._last_time_to_end_seen = {"APP001": 1_000_000.0}
+        coordinator._poll_time_to_end = AsyncMock()
+
+        calls = {"n": 0}
+
+        async def _sleep(_secs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return
+            raise asyncio.CancelledError()
+
+        with patch("asyncio.sleep", side_effect=_sleep):
+            with pytest.raises(asyncio.CancelledError):
+                await coordinator._monitor_time_to_end_staleness_loop()
+
+        coordinator._poll_time_to_end.assert_awaited_once_with("APP001")
+
+    async def test_monitor_skips_when_recently_refreshed(self, coordinator):
+        appliances = _make_appliances({"APP001": {"applianceState": "RUNNING"}})
+        coordinator.data = {"appliances": appliances}
+        coordinator.hass.loop.time.return_value = 1_000_060.0
+        coordinator._last_time_to_end_seen = {"APP001": 1_000_000.0}
+        coordinator._poll_time_to_end = AsyncMock()
+
+        async def _sleep(_secs):
+            raise asyncio.CancelledError()
+
+        with patch("asyncio.sleep", side_effect=_sleep):
+            with pytest.raises(asyncio.CancelledError):
+                await coordinator._monitor_time_to_end_staleness_loop()
+
+        coordinator._poll_time_to_end.assert_not_awaited()
+
+    async def test_monitor_skips_inactive_appliance_state(self, coordinator):
+        appliances = _make_appliances({"APP001": {"applianceState": "END_OF_CYCLE"}})
+        coordinator.data = {"appliances": appliances}
+        coordinator.hass.loop.time.return_value = 1_000_400.0
+        coordinator._last_time_to_end_seen = {}
+        coordinator._poll_time_to_end = AsyncMock()
+
+        async def _sleep(_secs):
+            raise asyncio.CancelledError()
+
+        with patch("asyncio.sleep", side_effect=_sleep):
+            with pytest.raises(asyncio.CancelledError):
+                await coordinator._monitor_time_to_end_staleness_loop()
+
+        coordinator._poll_time_to_end.assert_not_awaited()
+
+    async def test_monitor_skips_when_state_refresh_already_pending(self, coordinator):
+        appliances = _make_appliances({"APP001": {"applianceState": "RUNNING"}})
+        coordinator.data = {"appliances": appliances}
+        coordinator.hass.loop.time.return_value = 1_000_400.0
+        coordinator._last_time_to_end_seen = {}
+        pending_task = MagicMock()
+        pending_task.done.return_value = False
+        coordinator._pending_state_refresh_tasks = {"APP001": pending_task}
+        coordinator._poll_time_to_end = AsyncMock()
+
+        async def _sleep(_secs):
+            raise asyncio.CancelledError()
+
+        with patch("asyncio.sleep", side_effect=_sleep):
+            with pytest.raises(asyncio.CancelledError):
+                await coordinator._monitor_time_to_end_staleness_loop()
+
+        coordinator._poll_time_to_end.assert_not_awaited()
+
+    async def test_poll_time_to_end_success_updates_state_and_marks_fresh(
+        self, coordinator, mock_api
+    ):
+        appliances = _make_appliances({"APP001": {"applianceState": "RUNNING"}})
+        coordinator.data = {"appliances": appliances}
+        coordinator.hass.loop.time.return_value = 1_000_999.0
+        mock_api.get_appliance_state = AsyncMock(
+            return_value={"applianceState": "RUNNING", "timeToEnd": 900}
+        )
+
+        await coordinator._poll_time_to_end("APP001")
+
+        appliances.get_appliance("APP001").update.assert_called_once_with(
+            {"applianceState": "RUNNING", "timeToEnd": 900}
+        )
+        coordinator.async_set_updated_data.assert_called_once_with(coordinator.data)
+        assert coordinator._last_time_to_end_seen["APP001"] == 1_000_999.0
+
+    async def test_poll_time_to_end_failure_is_logged_not_raised(
+        self, coordinator, mock_api
+    ):
+        appliances = _make_appliances({"APP001": {"applianceState": "RUNNING"}})
+        coordinator.data = {"appliances": appliances}
+        mock_api.get_appliance_state = AsyncMock(side_effect=ConnectionError("boom"))
+
+        await coordinator._poll_time_to_end("APP001")  # must not raise
+
+        assert "APP001" not in coordinator._last_time_to_end_seen
+
+    async def test_close_websocket_cancels_time_to_end_monitor_task(self, coordinator):
+        coordinator._time_to_end_monitor_task = asyncio.create_task(asyncio.sleep(3600))
+
+        await coordinator.close_websocket()
+
+        assert coordinator._time_to_end_monitor_task is None
 
 
 # ===========================================================================

--- a/tests/test_coordinator_methods.py
+++ b/tests/test_coordinator_methods.py
@@ -81,6 +81,7 @@ def coordinator(mock_hass, mock_api):
         coord._last_sse_restart_time = 0.0
         coord._last_manual_sync_time = 0.0
         coord._last_time_to_end = {}
+        coord._last_time_to_end_seen = {}
         coord._consecutive_auth_failures = 0
         coord._auth_failure_threshold = 3
         coord._last_token_update = 0.0

--- a/tests/test_coordinator_setup.py
+++ b/tests/test_coordinator_setup.py
@@ -50,6 +50,7 @@ def make_coordinator():
     coord._consecutive_auth_failures = 0
     coord._auth_failure_threshold = 3
     coord._last_time_to_end = {}
+    coord._last_time_to_end_seen = {}
     coord._pending_capability_retry = set()
     coord._capability_retry_task = None
     coord.renew_interval = 7200

--- a/tests/test_coordinator_update_paths.py
+++ b/tests/test_coordinator_update_paths.py
@@ -80,6 +80,7 @@ def coordinator(mock_hass, mock_api):
         coord._sse_stall_monitor_task = None
         coord._last_manual_sync_time = 0.0
         coord._last_time_to_end = {}
+        coord._last_time_to_end_seen = {}
         coord._consecutive_auth_failures = 0
         coord._auth_failure_threshold = 3
         coord._last_token_update = 0.0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -365,6 +365,7 @@ def _make_coordinator():
     coordinator._consecutive_auth_failures = 0
     coordinator._auth_failure_threshold = 3
     coordinator._last_time_to_end = {}
+    coordinator._last_time_to_end_seen = {}
     coordinator._deferred_tasks = set()
     coordinator._deferred_tasks_by_appliance = {}
     return coordinator

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -20,6 +20,7 @@ def mock_coordinator():
     coordinator._consecutive_auth_failures = 0
     coordinator._auth_failure_threshold = 3
     coordinator._last_time_to_end = {}
+    coordinator._last_time_to_end_seen = {}
     coordinator._deferred_tasks = set()
     coordinator._deferred_tasks_by_appliance = {}
     return coordinator


### PR DESCRIPTION
## Summary

Closes #104. Some appliance models (per the diagnostics @lenny-chem-dat shared — WM + TD units) stop pushing `timeToEnd` over the SSE stream entirely while still pushing other properties (door state, connectivity, lock state, etc.) completely normally. The oven models tested elsewhere keep getting live `timeToEnd` pushes, so this looks like a per-model/server-side behavior difference rather than a stream failure.

The existing SSE stall watchdog (#121) can't catch this: it tracks *connection*-level silence (no messages at all for 300s), but in the reported logs the connection stays alive and other properties keep arriving — only `timeToEnd` goes quiet, sometimes for the entire multi-hour cycle.

## How it works

Adds a second, independent watchdog that tracks `timeToEnd` freshness **per appliance** instead of per connection:

- `_mark_time_to_end_fresh()` stamps `_last_time_to_end_seen[appliance_id]` any time we get a current value for it — an incoming SSE `timeToEnd` event, or any REST poll that returns full state (deferred update, state-change refresh, SSE-reconnect resync, or the new poll itself).
- A background loop (`_monitor_time_to_end_staleness_loop`, 60s cadence) checks every appliance currently in `RUNNING`/`PAUSED`/`DELAYED_START` — the only states where the countdown is actually shown (see `sensor.py`'s existing `timeToEnd` display logic). If none of the above has refreshed `timeToEnd` in the last 4 minutes, it does a single REST `get_appliance_state` poll for just that appliance.
- Skips an appliance if a state-transition refresh (`_schedule_state_refresh`) is already in flight for it, to avoid duplicate REST calls.
- Started alongside the existing SSE stall monitor in `listen_websocket()`, cancelled alongside it in `close_websocket()`. Same lifecycle, no new setup/teardown surface.

This is deliberately conservative on API usage: REST polling only happens for appliances that are (a) actively running and (b) haven't produced a `timeToEnd` update through any channel in 4 minutes — appliances whose SSE stream works fine (e.g. ovens, per the issue thread) will essentially never trigger it, and idle/off appliances are never polled.

## Deliberately out of scope

- Investigating *why* Electrolux's API stops pushing `timeToEnd` for some models — that looks server-side and outside what the integration can control.
- The two-appliances-one-API-key 429 concern raised later in the thread — separate question, no reproduction yet.

## Testing

Full suite: 1606 passed (up from 1596 on base + 10 new tests for this watchdog: staleness detection, freshness marking from SSE, skip-when-fresh, skip-when-inactive-state, skip-when-refresh-already-pending, poll success/failure, and start/stop lifecycle wiring). `ruff`, `black`, and `mypy` clean.