### PR TITLE
fix(climate): skip temperature re-apply when switching to FAN_ONLY or DRY mode

### DIFF
--- a/custom_components/electrolux/climate.py
+++ b/custom_components/electrolux/climate.py
@@ -475,7 +475,12 @@ class ElectroluxClimate(ElectroluxEntity, ClimateEntity, RestoreEntity):
             self._apply_optimistic_update("mode", mode_str)
 
         # Re-apply last user temperature — device resets to min on power-off.
-        if self._last_user_temperature is not None:
+        # Skip for modes where the API disables targetTemperatureC (FAN_ONLY, DRY).
+        _MODES_WITHOUT_TEMPERATURE = frozenset({HVACMode.FAN_ONLY, HVACMode.DRY})
+        if (
+            self._last_user_temperature is not None
+            and hvac_mode not in _MODES_WITHOUT_TEMPERATURE
+        ):
             temp_attr = f"targetTemperature{self._temp_suffix}"
             await self._send_command(temp_attr, self._last_user_temperature)
             self._apply_optimistic_update(temp_attr, self._last_user_temperature)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -689,6 +689,34 @@ class TestElectroluxClimate:
         assert calls[2][0] == ("targetTemperatureC", 22.0)
 
     @pytest.mark.asyncio
+    async def test_hvac_mode_fan_only_skips_temperature_resend(self, climate_entity):
+        """FAN_ONLY must not re-apply cached temperature — API returns 406 Capability disabled."""
+        climate_entity._send_command = AsyncMock()
+        climate_entity._apply_optimistic_update = MagicMock()
+        climate_entity._last_user_temperature = 22.0
+
+        await climate_entity.async_set_hvac_mode(HVACMode.FAN_ONLY)
+
+        assert climate_entity._send_command.call_count == 2
+        calls = climate_entity._send_command.call_args_list
+        assert calls[0][0] == ("executeCommand", "ON")
+        assert calls[1][0] == ("mode", "FANONLY")
+
+    @pytest.mark.asyncio
+    async def test_hvac_mode_dry_skips_temperature_resend(self, climate_entity):
+        """DRY must not re-apply cached temperature — API returns 406 Capability disabled."""
+        climate_entity._send_command = AsyncMock()
+        climate_entity._apply_optimistic_update = MagicMock()
+        climate_entity._last_user_temperature = 22.0
+
+        await climate_entity.async_set_hvac_mode(HVACMode.DRY)
+
+        assert climate_entity._send_command.call_count == 2
+        calls = climate_entity._send_command.call_args_list
+        assert calls[0][0] == ("executeCommand", "ON")
+        assert calls[1][0] == ("mode", "DRY")
+
+    @pytest.mark.asyncio
     async def test_hvac_mode_on_no_cached_temp_skips_resend(self, climate_entity):
         """No cached temperature → no extra temperature command on turn-on."""
         climate_entity._send_command = AsyncMock()


### PR DESCRIPTION
## Summary

`async_set_hvac_mode` unconditionally re-sent `targetTemperatureC` after powering on, even for modes where the Electrolux API disables that capability (`FAN_ONLY`, `DRY`). This caused HTTP 406 `COMMAND_VALIDATION_ERROR: Capability disabled`, which propagated as a service-call error to HA automations.

Observed in production logs:
```
ERROR [electrolux_group_developer_sdk] Error sending command: 406, COMMAND_VALIDATION_ERROR, Capability disabled
ERROR [custom_components.electrolux] Electrolux climate command failed for targetTemperatureC: Command not accepted: Capability disabled
ERROR [homeassistant.components.websocket_api] climate.set_hvac_mode: Command not accepted: Capability disabled
```

## Changes

- **`climate.py`** — guard `targetTemperatureC` re-apply in `async_set_hvac_mode` with a `frozenset` of modes that disable temperature capability (`FAN_ONLY`, `DRY`)
- **`tests/test_climate.py`** — two new tests verifying `FAN_ONLY` and `DRY` do not send temperature command when cached temp is set

## Related

- Closes #142
- Same `Capability disabled` 406 pattern as #72 / PR #75 (number entity fix)

## Test plan

- [ ] `uv run --with homeassistant --with pytest --with pytest-asyncio --with electrolux-group-developer-sdk pytest tests/test_climate.py -q` → 79 passed
- [ ] New tests: `test_hvac_mode_fan_only_skips_temperature_resend`, `test_hvac_mode_dry_skips_temperature_resend`
- [ ] Existing `test_hvac_mode_on_resends_last_temperature` (HEAT) still passes — confirms COOL/HEAT/AUTO unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)