### PR TITLE
fix(select): remove discovered-programs Store on entity removal

### DIFF
--- a/custom_components/electrolux/select.py
+++ b/custom_components/electrolux/select.py
@@ -148,6 +148,13 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
         await super().async_added_to_hass()
         await self._async_restore_discovered_programs()
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Clean up persistent store when entity is removed."""
+        await super().async_will_remove_from_hass()
+        if self._discovered_store is not None:
+            await self._discovered_store.async_remove()
+            self._discovered_store = None
+
     async def _async_restore_discovered_programs(self) -> None:
         """Load persisted discovered programs and merge them into options.
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1653,6 +1653,69 @@ class TestDiscoveredPrograms:
         mock_restore.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_async_will_remove_from_hass_removes_store(self, mock_coordinator):
+        """Store is deleted and nulled when entity is removed from hass."""
+        capability = {
+            "access": "readwrite",
+            "type": "string",
+            "values": {"BAKE": {"label": "Bake"}},
+        }
+        entity = ElectroluxSelect(
+            coordinator=mock_coordinator,
+            capability=capability,
+            name="Program",
+            config_entry=mock_coordinator.config_entry,
+            pnc_id="OVEN_123",
+            entity_type=SELECT,
+            entity_name="program",
+            entity_attr="program",
+            entity_source=None,
+            unit=None,
+            device_class="",
+            entity_category=EntityCategory.CONFIG,
+            icon="mdi:chef-hat",
+        )
+        entity.hass = mock_coordinator.hass
+        mock_store = AsyncMock()
+        entity._discovered_store = mock_store
+
+        with patch.object(ElectroluxEntity, "async_will_remove_from_hass", new=AsyncMock()) as mock_super:
+            await entity.async_will_remove_from_hass()
+
+        mock_super.assert_awaited_once()
+        mock_store.async_remove.assert_awaited_once()
+        assert entity._discovered_store is None
+
+    @pytest.mark.asyncio
+    async def test_async_will_remove_from_hass_no_store_is_noop(self, mock_coordinator):
+        """No error when entity has no store (program-unaware entity)."""
+        capability = {
+            "access": "readwrite",
+            "type": "string",
+            "values": {"BAKE": {"label": "Bake"}},
+        }
+        entity = ElectroluxSelect(
+            coordinator=mock_coordinator,
+            capability=capability,
+            name="Program",
+            config_entry=mock_coordinator.config_entry,
+            pnc_id="OVEN_123",
+            entity_type=SELECT,
+            entity_name="program",
+            entity_attr="program",
+            entity_source=None,
+            unit=None,
+            device_class="",
+            entity_category=EntityCategory.CONFIG,
+            icon="mdi:chef-hat",
+        )
+        entity.hass = mock_coordinator.hass
+        entity._discovered_store = None
+
+        with patch.object(ElectroluxEntity, "async_will_remove_from_hass", new=AsyncMock()):
+            await entity.async_will_remove_from_hass()  # must not raise
+
+    @pytest.mark.asyncio
     async def test_async_added_to_hass_populates_from_store(self, mock_coordinator):
         """End-to-end: async_added_to_hass runs the real restore and populates state.
 


### PR DESCRIPTION
## Summary

Each program-capable select that discovers a value creates a persistent `Store` file under `config/.storage/electrolux_discovered_programs_<unique_id>`. When the appliance or config entry is removed, nothing called `Store.async_remove()`, leaving those files orphaned on disk.

## Fix

Add `async_will_remove_from_hass` to `ElectroluxSelect`:

```python
async def async_will_remove_from_hass(self) -> None:
    await super().async_will_remove_from_hass()
    if self._discovered_store is not None:
        await self._discovered_store.async_remove()
        self._discovered_store = None
```

## Tests

- `test_async_will_remove_from_hass_removes_store` — store deleted and field nulled
- `test_async_will_remove_from_hass_no_store_is_noop` — no error for entities without a store

1633 tests pass.

Closes #139