### PR TITLE
feat(rvc): add Gordias/700series catalog entries

### DIFF
--- a/custom_components/electrolux/catalogs/catalog_rvc.py
+++ b/custom_components/electrolux/catalogs/catalog_rvc.py
@@ -738,7 +738,7 @@ CATALOG_RVC: dict[str, ElectroluxDevice] = {
         unit=None,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_icon="mdi:volume-high",
-        friendly_name="Voice Volume",
+        friendly_name="Voice Volume Level",
     ),
     # --- Pure i9 read-only map / cleaning-session data (#130) ---
     "persistentMapsCreated/mapId": ElectroluxDevice(

--- a/custom_components/electrolux/coordinator.py
+++ b/custom_components/electrolux/coordinator.py
@@ -153,6 +153,9 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
         )  # Track previous connectivity state per appliance
         self._last_sse_restart_time = 0.0  # Track when we last restarted SSE
         self._last_sse_message_time = 0.0  # Track last time any SSE event was received
+        self._sse_data_received_since_connect = (
+            False  # Track if data arrived on current connection
+        )
         self._sse_stall_monitor_task: Optional[asyncio.Task] = None
         self._consecutive_sse_restarts = (
             0  # Track consecutive watchdog restarts for backoff
@@ -443,6 +446,7 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
         # Track stream liveness for stalled-SSE watchdog logic.
         now = self.hass.loop.time()
         self._last_sse_message_time = now
+        self._sse_data_received_since_connect = True
 
         appliance_id_dbg = data.get(APPLIANCE_ID_KEY) or data.get(APPLIANCE_ID_ALT_KEY)
         property_dbg = data.get(PROPERTY_KEY)
@@ -894,14 +898,24 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
         # Seed watchdog timestamp at connection-open time so a fresh stream gets
         # a full quiet window before being considered stalled.
         self._last_sse_message_time = now
-        # Reset consecutive restart counter since we have a fresh connection
-        if self._consecutive_sse_restarts > 0:
+        # Only reset the consecutive restart counter if the previous connection
+        # actually received data.  If the stream was restarted by the watchdog
+        # but no data arrived (idle appliances + server keep-alives), the
+        # backoff should escalate to avoid a 15-minute restart loop.
+        if self._consecutive_sse_restarts > 0 and self._sse_data_received_since_connect:
             _LOGGER.debug(
-                "SSE connection established, resetting restart counter (was %d)",
+                "SSE connection established with data received, resetting restart counter (was %d)",
                 self._consecutive_sse_restarts,
             )
             self._consecutive_sse_restarts = 0
             self._last_sse_restart_log_count = 0
+        elif self._consecutive_sse_restarts > 0:
+            _LOGGER.debug(
+                "SSE reconnected but no data received on previous connection, "
+                "keeping restart counter at %d for backoff",
+                self._consecutive_sse_restarts,
+            )
+        self._sse_data_received_since_connect = False
         elapsed = now - self._last_sse_resync_time
 
         if elapsed >= SSE_RESYNC_DEBOUNCE:

--- a/custom_components/electrolux/select.py
+++ b/custom_components/electrolux/select.py
@@ -115,15 +115,16 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
                 if label is not None:
                     self.options_list[label] = value
 
-        # Track which values are discovered (not from catalog) so they survive
-        # program-constraint filtering in the options property (#65). Populated
-        # from the persistent store in async_added_to_hass — self.hass is not
-        # yet available during __init__ (HA assigns it after construction).
-        self._discovered_values: set[str] = set()
         # Persistent store for discovered programs (label -> value), backed by
         # homeassistant.helpers.storage so discoveries survive a full restart.
         self._discovered_store: Store | None = None
         self._discovered_data: dict[str, str] = {}
+        # Values that are truly "discovered" (not from catalog). Populated during
+        # restore (only for values not in options_list) and at runtime when new
+        # values are observed. This is a filtered subset of _discovered_data —
+        # the store may contain values later provided by catalog updates, which
+        # should NOT bypass program-constraint filtering.
+        self._discovered_values: set[str] = set()
 
     def _get_discovered_store(self) -> Store | None:
         """Return the per-entity Store for discovered programs, or None.
@@ -200,18 +201,6 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
         self._discovered_store.async_delay_save(
             lambda: self._discovered_data, DISCOVERED_SAVE_DELAY
         )
-
-        try:
-            store_key = f"{DISCOVERED_PROGRAMS_KEY}_{self.unique_id}"
-        except TypeError, AttributeError:
-            # Skip persistence if unique_id cannot be computed (e.g., in tests)
-            return
-
-        if store_key not in self.hass.data:
-            self.hass.data[store_key] = {}
-
-        # Store the discovery
-        self.hass.data[store_key][label] = value
 
         _LOGGER.info(
             "Discovered new program %s (%s) for %s on appliance %s. "
@@ -567,9 +556,11 @@ class ElectroluxSelect(ElectroluxEntity, SelectEntity):
                 # by the API). They are always selectable once discovered. (#65)
                 if self._discovered_values:
                     for label, value in self.options_list.items():
-                        if value in self._discovered_values:
-                            if label not in all_options:
-                                all_options.append(label)
+                        if (
+                            value in self._discovered_values
+                            and label not in all_options
+                        ):
+                            all_options.append(label)
 
         # Append the current label if it falls outside the persistent
         # options_list — currently only happens for disabled capability


### PR DESCRIPTION
Closes #149

## Summary

Add catalog support for Electrolux UltimateHome 700 Robotic Vac and Mop (Gordias).

### New catalog entries
- **binTank** — sensor (enum): None / Dust Box / Water Tank / Both
- **findMe** — button: locate robot action
- **setVoiceVolume** — select: mute / low / medium / high

### Updated entries
- **cleaningCommand** — added startMoppingClean, startEdgeClean, startPointClean
- **vacuumMode** — added quiet, standard, powerful (alongside existing energySaving, max)
- **waterPumpRate** — added off and max values
- **faultCode** — changed from number to string enum for named fault codes

### Not in scope
- `mapCommand`, `mapId`, `roomInfo/*`, `type` are `type: custom` capabilities — tracked separately in #131