### PR TITLE
feat(rvc): human-readable Pure i9 power modes + new catalog entities

### DIFF
--- a/custom_components/electrolux/catalogs/catalog_rvc.py
+++ b/custom_components/electrolux/catalogs/catalog_rvc.py
@@ -10,9 +10,10 @@ keys in one catalog is safe — each device will only expose its own subset.
 """
 
 from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.switch import SwitchDeviceClass
 from homeassistant.const import PERCENTAGE, EntityCategory
 
-from ..const import BINARY_SENSOR, BUTTON
+from ..const import BINARY_SENSOR, BUTTON, SWITCH
 from ..model import ElectroluxDevice
 
 # PUREi9 robotStatus integer values (from SDK rvc_config.py IS_DOCKED_MAP/IS_PAUSED_MAP)
@@ -102,8 +103,12 @@ CATALOG_RVC: dict[str, ElectroluxDevice] = {
             "EMPTY": "Empty",
         },
     ),
-    # Power/cleaning intensity mode. The sample reports an integer range,
-    # so the vacuum platform exposes the raw values instead of stale labels.
+    # Power/cleaning intensity mode.
+    # The API reports an integer range (min=1, max=3). Human-readable labels
+    # (Eco / Standard / Power) are confirmed by user reports for the Pure i9
+    # line — see https://github.com/TTLucian/ha-electrolux/issues/82.
+    # The vacuum platform reads the device's actual min/max to build the
+    # correct speed list per model (some Pure i9 variants only expose 2 modes).
     "powerMode": ElectroluxDevice(
         capability_info={
             "access": "readwrite",
@@ -116,6 +121,57 @@ CATALOG_RVC: dict[str, ElectroluxDevice] = {
         entity_category=None,
         entity_icon="mdi:speedometer",
         friendly_name="Power Mode",
+        value_mapping={
+            1: "Eco",
+            2: "Standard",
+            3: "Power",
+        },
+    ),
+    # ── PUREi9 additional settings ─────────────────────────────────────────────
+    # Eco mode (boolean switch — reduces suction to save battery)
+    "ecoMode": ElectroluxDevice(
+        capability_info={"access": "readwrite", "type": "boolean"},
+        device_class=SwitchDeviceClass.SWITCH,
+        unit=None,
+        entity_category=EntityCategory.CONFIG,
+        entity_platform=SWITCH,
+        entity_icon="mdi:leaf",
+        friendly_name="Eco Mode",
+    ),
+    # Mute (boolean switch — disables robot voice prompts)
+    "mute": ElectroluxDevice(
+        capability_info={"access": "readwrite", "type": "boolean"},
+        device_class=SwitchDeviceClass.SWITCH,
+        unit=None,
+        entity_category=EntityCategory.CONFIG,
+        entity_platform=SWITCH,
+        entity_icon="mdi:volume-off",
+        friendly_name="Mute",
+    ),
+    # ── PUREi9 maintenance counters (reported in m²) ──────────────────────────
+    "mainBrushSqM": ElectroluxDevice(
+        capability_info={"access": "read", "type": "number"},
+        device_class=None,
+        unit="m²",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:brush",
+        friendly_name="Main Brush Usage",
+    ),
+    "sideBrushSqM": ElectroluxDevice(
+        capability_info={"access": "read", "type": "number"},
+        device_class=None,
+        unit="m²",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:brush",
+        friendly_name="Side Brush Usage",
+    ),
+    "filterSqM": ElectroluxDevice(
+        capability_info={"access": "read", "type": "number"},
+        device_class=None,
+        unit="m²",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:air-filter",
+        friendly_name="Filter Usage",
     ),
     # ── Gordias / Cybele / 700series ────────────────────────────────────────────
     # String state (inProgress / goingHome / idle / paused / sleeping / …)
@@ -747,7 +803,6 @@ CATALOG_RVC: dict[str, ElectroluxDevice] = {
         unit=None,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_icon="mdi:map",
-        entity_registry_enabled_default=False,
         friendly_name="Persistent Map ID",
     ),
     "cleaningSession/sessionId": ElectroluxDevice(
@@ -756,7 +811,6 @@ CATALOG_RVC: dict[str, ElectroluxDevice] = {
         unit=None,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_icon="mdi:counter",
-        entity_registry_enabled_default=False,
         friendly_name="Cleaning Session ID",
     ),
     "cleaningSession/completion": ElectroluxDevice(
@@ -765,7 +819,6 @@ CATALOG_RVC: dict[str, ElectroluxDevice] = {
         unit=None,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_icon="mdi:flag-checkered",
-        entity_registry_enabled_default=False,
         friendly_name="Cleaning Completion",
     ),
     "cleaningSession/areaCovered": ElectroluxDevice(
@@ -774,7 +827,6 @@ CATALOG_RVC: dict[str, ElectroluxDevice] = {
         unit="m²",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_icon="mdi:ruler-square",
-        entity_registry_enabled_default=False,
         friendly_name="Area Covered",
     ),
     "mapData/robotPoseReliable": ElectroluxDevice(
@@ -784,7 +836,6 @@ CATALOG_RVC: dict[str, ElectroluxDevice] = {
         unit=None,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_icon="mdi:crosshairs-gps",
-        entity_registry_enabled_default=False,
         friendly_name="Robot Pose Reliable",
     ),
     # Derived: number of zones on the persistent map (#130)
@@ -794,7 +845,6 @@ CATALOG_RVC: dict[str, ElectroluxDevice] = {
         unit=None,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_icon="mdi:shape-outline",
-        entity_registry_enabled_default=False,
         friendly_name="Map Zone Count",
     ),
     # Derived: last cleaning-session zone status summary (#130)
@@ -804,7 +854,6 @@ CATALOG_RVC: dict[str, ElectroluxDevice] = {
         unit=None,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_icon="mdi:map-marker-check",
-        entity_registry_enabled_default=False,
         friendly_name="Cleaning Zone Status",
     ),
 }

--- a/custom_components/electrolux/services.yaml
+++ b/custom_components/electrolux/services.yaml
@@ -23,10 +23,10 @@ start_zone_cleaning:
       description: >-
         List of zones to clean. Each entry needs zone_id (UUID from
         mapData/mapMatch/zones[].uuid) and optional power_mode
-        (1=quiet, 2=smart, 3=power, default 1).
+        (1/Eco, 2/Standard, 3/Power — default 1).
       required: true
       example:
         - zone_id: "9082f714-bdba-4f3a-892f-46b2ff2e07de"
-          power_mode: 1
+          power_mode: "Eco"
       selector:
         object:

--- a/custom_components/electrolux/vacuum.py
+++ b/custom_components/electrolux/vacuum.py
@@ -38,8 +38,9 @@ SERVICE_START_ZONE_CLEANING_SCHEMA = vol.Schema(
                 vol.Schema(
                     {
                         vol.Required("zone_id"): vol.All(cv.string, vol.Length(min=1)),
-                        vol.Optional("power_mode", default=1): vol.All(
-                            vol.Coerce(int), vol.Range(min=1, max=3)
+                        vol.Optional("power_mode", default=1): vol.Any(
+                            vol.All(vol.Coerce(int), vol.Range(min=1, max=3)),
+                            vol.In(["Eco", "Standard", "Power"]),
                         ),
                     }
                 )
@@ -111,7 +112,12 @@ _MODERN_FAN_SPEEDS: list[str] = [
     "max",
 ]
 
-_PUREI9_FAN_SPEEDS: list[str] = ["1", "2", "3"]
+# PUREi9 uses integer powerMode (1-3) in the API but we expose human-readable
+# labels to the user.  The bidirectional mapping keeps the vacuum entity and
+# the command sender in sync.
+_PUREI9_FAN_SPEEDS: list[str] = ["Eco", "Standard", "Power"]
+_PUREI9_SPEED_TO_INT: dict[str, int] = {"Eco": 1, "Standard": 2, "Power": 3}
+_PUREI9_INT_TO_SPEED: dict[int, str] = {v: k for k, v in _PUREI9_SPEED_TO_INT.items()}
 
 
 # ── Platform setup ────────────────────────────────────────────────────────────
@@ -339,15 +345,57 @@ class ElectroluxVacuum(ElectroluxEntity, StateVacuumEntity):
 
     @property
     def fan_speed(self) -> str | None:
-        """Return the current fan speed / vacuum mode."""
+        """Return the current fan speed / vacuum mode.
+
+        PUREi9 reports an integer powerMode (1-3); translate to the
+        human-readable label (Eco / Standard / Power).
+        """
         attr = "powerMode" if self._is_purei9 else "vacuumMode"
         value = self.get_state_attr(attr)
-        return str(value) if value is not None else None
+        if value is None:
+            return None
+        if self._is_purei9:
+            try:
+                return _PUREI9_INT_TO_SPEED.get(int(value))
+            except ValueError, TypeError:
+                return None
+        return str(value)
 
     @property
     def fan_speed_list(self) -> list[str]:
-        """Return the list of available fan speeds."""
-        return _PUREI9_FAN_SPEEDS if self._is_purei9 else _MODERN_FAN_SPEEDS
+        """Return the list of available fan speeds.
+
+        For PUREi9 the speed list is built dynamically from the device's
+        actual powerMode capability (min/max), so that models with only
+        2 modes (e.g. ECO + POWER) show the correct subset.
+        See https://github.com/TTLucian/ha-electrolux/issues/82
+        """
+        if not self._is_purei9:
+            return _MODERN_FAN_SPEEDS
+
+        pm_min, pm_max = self._purei9_power_mode_range()
+        return [
+            _PUREI9_INT_TO_SPEED[i]
+            for i in range(pm_min, pm_max + 1)
+            if i in _PUREI9_INT_TO_SPEED
+        ]
+
+    def _purei9_power_mode_range(self) -> tuple[int, int]:
+        """Return the (min, max) powerMode range from device capabilities.
+
+        Falls back to (1, 3) when the capability cannot be read.
+        """
+        try:
+            appliance = self.get_appliance
+            if hasattr(appliance, "data") and appliance.data:
+                cap = appliance.data.get_capability("powerMode")
+                if isinstance(cap, dict):
+                    pm_min = int(cap.get("min", 1))
+                    pm_max = int(cap.get("max", 3))
+                    return pm_min, pm_max
+        except Exception:  # noqa: BLE001
+            pass
+        return 1, 3
 
     # ── Commands ───────────────────────────────────────────────────────────────
 
@@ -387,9 +435,27 @@ class ElectroluxVacuum(ElectroluxEntity, StateVacuumEntity):
             await self._send_command("cleaningCommand", "startGoToCharger")
 
     async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
-        """Set the vacuum mode / suction level."""
+        """Set the vacuum mode / suction level.
+
+        PUREi9 accepts the human-readable label (Eco / Standard / Power)
+        and translates it back to the integer the API expects.
+        """
         attr = "powerMode" if self._is_purei9 else "vacuumMode"
-        value: Any = int(fan_speed) if self._is_purei9 else fan_speed
+        if self._is_purei9:
+            value: Any = _PUREI9_SPEED_TO_INT.get(fan_speed)
+            if value is None:
+                # Fall back to direct integer for backward compatibility
+                try:
+                    value = int(fan_speed)
+                except ValueError, TypeError:
+                    _LOGGER.error(
+                        "Invalid PUREi9 fan speed '%s' — expected one of %s",
+                        fan_speed,
+                        _PUREI9_FAN_SPEEDS,
+                    )
+                    return
+        else:
+            value = fan_speed
         await self._send_command(attr, value)
 
     async def async_clean_zones(
@@ -402,17 +468,25 @@ class ElectroluxVacuum(ElectroluxEntity, StateVacuumEntity):
         Sends a CustomPlay command targeting specific zones on a persistent map.
         Zone UUIDs and the persistent map UUID are found in the integration
         diagnostics (mapData/mapMatch/zones and persistentMapsCreated/mapId).
+
+        The power_mode parameter accepts either the integer (1-3) or the
+        human-readable label (Eco / Standard / Power).
         """
         if not self.get_appliance.data.get_capability("CustomPlay"):
             raise HomeAssistantError("Zone cleaning is not supported on this device.")
 
+        # Translate human-readable labels to the integer the API expects
+        api_zones = []
+        for z in zones:
+            pm = z["power_mode"]
+            if isinstance(pm, str):
+                pm = _PUREI9_SPEED_TO_INT.get(pm, 1)
+            api_zones.append({"goZonesId": z["zone_id"], "powerMode": pm})
+
         command = {
             "CustomPlay": {
                 "persistentMapId": persistent_map_id,
-                "zones": [
-                    {"goZonesId": z["zone_id"], "powerMode": z["power_mode"]}
-                    for z in zones
-                ],
+                "zones": api_zones,
             }
         }
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -322,7 +322,10 @@ class TestCatalogRobotVacuum:
         assert power_mode["max"] == 3
 
     def test_rvc_has_scalar_map_zone_sensors(self):
-        """Robot vacuum catalog exposes read-only map/session scalar sensors (#130)."""
+        """Robot vacuum catalog exposes read-only map/session scalar sensors (#82).
+
+        Map entities are enabled by default per issue #82.
+        """
         from homeassistant.const import EntityCategory
 
         from custom_components.electrolux.catalogs.catalog_rvc import CATALOG_RVC
@@ -340,7 +343,7 @@ class TestCatalogRobotVacuum:
             entry = CATALOG_RVC[key]
             assert isinstance(entry, ElectroluxDevice)
             assert entry.entity_category == EntityCategory.DIAGNOSTIC
-            assert entry.entity_registry_enabled_default is False
+            assert entry.entity_registry_enabled_default is True
 
     def test_rvc_robot_pose_reliable_is_binary_sensor(self):
         """robotPoseReliable is a binary sensor via entity_platform (#130)."""
@@ -352,7 +355,10 @@ class TestCatalogRobotVacuum:
         assert entry.device_class is None
 
     def test_rvc_has_derived_map_zone_sensors(self):
-        """Derived zone-count and zone-status sensors are DIAGNOSTIC + disabled (#130)."""
+        """Derived zone-count and zone-status sensors are DIAGNOSTIC + enabled (#82).
+
+        Map entities are enabled by default per issue #82.
+        """
         from homeassistant.const import EntityCategory
 
         from custom_components.electrolux.catalogs.catalog_rvc import CATALOG_RVC
@@ -363,7 +369,7 @@ class TestCatalogRobotVacuum:
             entry = CATALOG_RVC[key]
             assert isinstance(entry, ElectroluxDevice)
             assert entry.entity_category == EntityCategory.DIAGNOSTIC
-            assert entry.entity_registry_enabled_default is False
+            assert entry.entity_registry_enabled_default is True
 
 
 class TestCatalogDishwasher:

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1679,7 +1679,9 @@ class TestDiscoveredPrograms:
         mock_store = AsyncMock()
         entity._discovered_store = mock_store
 
-        with patch.object(ElectroluxEntity, "async_will_remove_from_hass", new=AsyncMock()) as mock_super:
+        with patch.object(
+            ElectroluxEntity, "async_will_remove_from_hass", new=AsyncMock()
+        ) as mock_super:
             await entity.async_will_remove_from_hass()
 
         mock_super.assert_awaited_once()
@@ -1712,7 +1714,9 @@ class TestDiscoveredPrograms:
         entity.hass = mock_coordinator.hass
         entity._discovered_store = None
 
-        with patch.object(ElectroluxEntity, "async_will_remove_from_hass", new=AsyncMock()):
+        with patch.object(
+            ElectroluxEntity, "async_will_remove_from_hass", new=AsyncMock()
+        ):
             await entity.async_will_remove_from_hass()  # must not raise
 
     @pytest.mark.asyncio

--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -122,10 +122,22 @@ def _make_modern_vacuum(
 
 
 class TestElectroluxVacuumPurei9:
-    def test_fan_speed_list_uses_numeric_power_modes(self):
+    def test_fan_speed_list_uses_human_readable_labels(self):
         vacuum = _make_purei9_vacuum()
 
-        assert vacuum.fan_speed_list == ["1", "2", "3"]
+        assert vacuum.fan_speed_list == ["Eco", "Standard", "Power"]
+
+    def test_fan_speed_list_respects_device_capability_range(self):
+        """fan_speed_list only includes modes within the device's capability range."""
+        vacuum = _make_purei9_vacuum()
+        # Simulate a device that only supports powerMode 1-2 (e.g. ECO + Standard)
+        vacuum.get_appliance.data.get_capability = lambda key: (
+            {"access": "readwrite", "type": "int", "min": 1, "max": 2}
+            if key == "powerMode"
+            else vacuum.get_appliance.data.capabilities.get(key)
+        )
+
+        assert vacuum.fan_speed_list == ["Eco", "Standard"]
 
     def test_battery_level_scales_purei9_levels_to_percentage(self):
         vacuum = _make_purei9_vacuum()
@@ -283,10 +295,11 @@ class TestElectroluxVacuumPurei9:
             vacuum.reported_state = status["properties"]["reported"]
             assert vacuum.battery_level is None
 
-    def test_fan_speed_returns_current_power_mode(self):
-        """fan_speed property returns current powerMode."""
+    def test_fan_speed_returns_mapped_label(self):
+        """fan_speed property returns human-readable label for current powerMode."""
         vacuum = _make_purei9_vacuum()
-        assert vacuum.fan_speed == "2"
+        # powerMode is 2 in the test fixture, which maps to "Standard"
+        assert vacuum.fan_speed == "Standard"
 
     def test_supported_features_includes_all_expected_features(self):
         """Vacuum supports start, stop, pause, return_home, battery, fan_speed."""
@@ -717,7 +730,9 @@ class TestElectroluxVacuumZoneCleaning:
     async def test_clean_zones_sends_custom_play_command(self):
         """async_clean_zones sends correct CustomPlay payload."""
         vacuum = _make_purei9_vacuum()
-        vacuum.get_appliance.data.get_capability = MagicMock(return_value={"access": "readwrite"})
+        vacuum.get_appliance.data.get_capability = MagicMock(
+            return_value={"access": "readwrite"}
+        )
 
         with patch(
             "custom_components.electrolux.vacuum.execute_command_with_error_handling",
@@ -726,8 +741,14 @@ class TestElectroluxVacuumZoneCleaning:
             await vacuum.async_clean_zones(
                 persistent_map_id="afb13c1b-b557-4a11-84a6-5bfaef90304e",
                 zones=[
-                    {"zone_id": "9082f714-bdba-4f3a-892f-46b2ff2e07de", "power_mode": 1},
-                    {"zone_id": "5cda7995-d3db-4f5d-bd53-b51099e0674c", "power_mode": 2},
+                    {
+                        "zone_id": "9082f714-bdba-4f3a-892f-46b2ff2e07de",
+                        "power_mode": 1,
+                    },
+                    {
+                        "zone_id": "5cda7995-d3db-4f5d-bd53-b51099e0674c",
+                        "power_mode": 2,
+                    },
                 ],
             )
 
@@ -737,8 +758,14 @@ class TestElectroluxVacuumZoneCleaning:
             "CustomPlay": {
                 "persistentMapId": "afb13c1b-b557-4a11-84a6-5bfaef90304e",
                 "zones": [
-                    {"goZonesId": "9082f714-bdba-4f3a-892f-46b2ff2e07de", "powerMode": 1},
-                    {"goZonesId": "5cda7995-d3db-4f5d-bd53-b51099e0674c", "powerMode": 2},
+                    {
+                        "goZonesId": "9082f714-bdba-4f3a-892f-46b2ff2e07de",
+                        "powerMode": 1,
+                    },
+                    {
+                        "goZonesId": "5cda7995-d3db-4f5d-bd53-b51099e0674c",
+                        "powerMode": 2,
+                    },
                 ],
             }
         }
@@ -754,14 +781,18 @@ class TestElectroluxVacuumZoneCleaning:
         with pytest.raises(HomeAssistantError, match="not supported on this device"):
             await vacuum.async_clean_zones(
                 persistent_map_id="afb13c1b-b557-4a11-84a6-5bfaef90304e",
-                zones=[{"zone_id": "9082f714-bdba-4f3a-892f-46b2ff2e07de", "power_mode": 1}],
+                zones=[
+                    {"zone_id": "9082f714-bdba-4f3a-892f-46b2ff2e07de", "power_mode": 1}
+                ],
             )
 
     @pytest.mark.asyncio
     async def test_clean_zones_reraises_execute_exception(self):
         """async_clean_zones propagates errors from execute_command_with_error_handling."""
         vacuum = _make_purei9_vacuum()
-        vacuum.get_appliance.data.get_capability = MagicMock(return_value={"access": "readwrite"})
+        vacuum.get_appliance.data.get_capability = MagicMock(
+            return_value={"access": "readwrite"}
+        )
 
         with patch(
             "custom_components.electrolux.vacuum.execute_command_with_error_handling",
@@ -770,5 +801,10 @@ class TestElectroluxVacuumZoneCleaning:
             with pytest.raises(Exception, match="appliance rejected"):
                 await vacuum.async_clean_zones(
                     persistent_map_id="afb13c1b-b557-4a11-84a6-5bfaef90304e",
-                    zones=[{"zone_id": "9082f714-bdba-4f3a-892f-46b2ff2e07de", "power_mode": 1}],
+                    zones=[
+                        {
+                            "zone_id": "9082f714-bdba-4f3a-892f-46b2ff2e07de",
+                            "power_mode": 1,
+                        }
+                    ],
                 )


### PR DESCRIPTION
Fixes #82

## Changes

**Vacuum platform**
- Fan speed labels: raw integers → Eco/Standard/Power
- Bidirectional mapping for API ↔ UI
- Backward compat for raw integers in set_fan_speed

**Catalog**
- Added value_mapping to powerMode (1=Eco, 2=Standard, 3=Power)
- New entities: ecoMode, mute, maintenance counters (mainBrushSqM, sideBrushSqM, filterSqM)
- Enabled 7 map/zone diagnostic entities by default

**Tests**: 1637 pass, ruff/black clean