### PR TITLE
fix(api): stop reporting command failures as authentication errors

### DIFF
--- a/custom_components/electrolux/api_client.py
+++ b/custom_components/electrolux/api_client.py
@@ -12,6 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers import issue_registry
 
+from .auth_errors import is_auth_error
 from .const import DOMAIN
 from .exceptions import NetworkError
 from .token_manager import ElectroluxTokenManager
@@ -134,17 +135,7 @@ async def safe_api_call(
         error_str = str(ex).lower()
 
         # Check for authentication errors
-        if any(
-            keyword in error_str
-            for keyword in [
-                "401",
-                "unauthorized",
-                "invalid grant",
-                "token",
-                "forbidden",
-                "auth",
-            ]
-        ):
+        if is_auth_error(ex):
             logger.warning("Authentication error during %s: %s", operation_name, ex)
             raise ConfigEntryAuthFailed(
                 "Authentication failed - please reauthenticate"
@@ -336,19 +327,9 @@ class ElectroluxApiClient:
             _LOGGER.debug("_handle_api_call: API call completed successfully")
             return result
         except Exception as ex:
-            error_msg = str(ex).lower()
             _LOGGER.debug(f"_handle_api_call: Exception caught: {ex}")
             # Check for authentication-related errors
-            if any(
-                keyword in error_msg
-                for keyword in [
-                    "401",
-                    "unauthorized",
-                    "invalid grant",
-                    "token",
-                    "forbidden",
-                ]
-            ):
+            if is_auth_error(ex):
                 # Trigger token refresh handler by logging the error
                 _LOGGER.error("API call failed with authentication error: %s", ex)
                 _LOGGER.debug(
@@ -548,16 +529,7 @@ class ElectroluxApiClient:
                     )
                     # Check if it's an auth error and trigger reauth
                     if self.hass and self.config_entry:
-                        error_msg = str(task.exception()).lower()
-                        auth_keywords = [
-                            "401",
-                            "unauthorized",
-                            "auth",
-                            "token",
-                            "invalid grant",
-                            "forbidden",
-                        ]
-                        if any(keyword in error_msg for keyword in auth_keywords):
+                        if is_auth_error(task.exception()):
                             _LOGGER.debug(
                                 f"SSE auth error detected: {task.exception()}"
                             )

--- a/custom_components/electrolux/auth_errors.py
+++ b/custom_components/electrolux/auth_errors.py
@@ -1,0 +1,91 @@
+"""Detection of genuine authentication failures.
+
+Command validation failures are a documented, expected part of the Electrolux
+API. Sending a command runs three validation phases and any of them can answer
+``406 Not Acceptable`` with a ``COMMAND_VALIDATION_ERROR`` body, for example
+``{"detail": "Remote control disabled"}`` or ``{"detail": "Appliance
+disconnected"}``. Those are ordinary rejections and the user has to change
+something on the appliance, not re-authenticate.
+
+Deciding this from the text of the exception is unsafe, because the string form
+of an aiohttp error embeds the request URL, and the request URL embeds the
+appliance id. Appliance ids are hex, so an id such as
+``916900511_01:54926920-443E07773401`` contains ``401`` and matches a bare
+``"401"`` substring on every failure that appliance ever produces.
+
+Prefer the HTTP status, and when a status is known treat it as authoritative.
+"""
+
+from __future__ import annotations
+
+import re
+
+AUTH_STATUS_CODES = (401, 403)
+
+# Phrases that unambiguously describe rejected credentials. Deliberately no bare
+# "401", "token" or "auth": all three match text that is not about
+# authentication, most importantly the request URL.
+AUTH_ERROR_PHRASES = (
+    "unauthorized",
+    "forbidden",
+    "invalid grant",
+    "invalid_grant",
+    "invalid_token",
+    "invalid refresh token",
+    "refresh token is invalid",
+    "refresh token expired",
+    "authentication failed",
+    "authentication error",
+    "authentication required",
+)
+
+# Wording around an expired token varies ("token expired", "token has
+# expired", "access token is expired"), so match the pair rather than a phrase.
+_EXPIRED_TOKEN = re.compile(
+    r"\btoken\b.{0,24}?\bexpired\b|\bexpired\b.{0,24}?\btoken\b"
+)
+
+# aiohttp renders its errors as "<prefix>: 406, message='...', url='...'".
+_STATUS_IN_MESSAGE = re.compile(r"\b(\d{3}),\s*message=")
+
+
+def get_error_status(ex: BaseException) -> int | None:
+    """Return the HTTP status behind an exception, if it can be determined."""
+    for attribute in ("status", "status_code"):
+        status = getattr(ex, attribute, None)
+        if isinstance(status, int):
+            return status
+
+    response = getattr(ex, "response", None)
+    if response is not None:
+        for attribute in ("status", "status_code"):
+            status = getattr(response, attribute, None)
+            if isinstance(status, int):
+                return status
+
+    match = _STATUS_IN_MESSAGE.search(str(ex))
+    if match:
+        return int(match.group(1))
+
+    return None
+
+
+def is_auth_error(
+    ex: BaseException, *, auth_statuses: tuple[int, ...] = AUTH_STATUS_CODES
+) -> bool:
+    """Return True only for failures that re-authenticating can fix.
+
+    A known status decides on its own, so a 406 command validation error, a 429
+    rate limit or a 500 are never reported as authentication problems. Phrase
+    matching is only a fallback for exceptions that carry no status at all.
+
+    Callers that give 403 its own meaning can narrow ``auth_statuses``.
+    """
+    status = get_error_status(ex)
+    if status is not None:
+        return status in auth_statuses
+
+    message = str(ex).lower()
+    if _EXPIRED_TOKEN.search(message):
+        return True
+    return any(phrase in message for phrase in AUTH_ERROR_PHRASES)

--- a/custom_components/electrolux/coordinator.py
+++ b/custom_components/electrolux/coordinator.py
@@ -17,6 +17,7 @@ from homeassistant.helpers import issue_registry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import ElectroluxLibraryEntity
+from .auth_errors import is_auth_error
 from .const import DOMAIN, TIME_ENTITIES_TO_UPDATE
 from .models import Appliance, Appliances, ApplianceState
 from .util import (
@@ -82,16 +83,6 @@ TIMESTAMP_KEY = "timestamp"
 # Connectivity states
 STATE_CONNECTED = "connected"
 STATE_DISCONNECTED = "disconnected"
-
-# Authentication error keywords
-AUTH_ERROR_KEYWORDS = [
-    "401",
-    "unauthorized",
-    "auth",
-    "token",
-    "invalid grant",
-    "forbidden",
-]
 
 # Time entity thresholds
 # NOTE: Appliances like dishwashers count time in minutes but the API reports
@@ -298,8 +289,7 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
         during command execution or other API calls outside the normal update cycle.
         """
         _LOGGER.debug("Handling authentication error: %s", exception)
-        error_msg = str(exception).lower()
-        if any(keyword in error_msg for keyword in AUTH_ERROR_KEYWORDS):
+        if is_auth_error(exception):
             _LOGGER.warning(f"Authentication failed during operation: {exception}")
             raise ConfigEntryAuthFailed(
                 "Token expired or invalid - please reauthenticate"
@@ -1837,9 +1827,8 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
             except asyncio.CancelledError:
                 raise
             except Exception as ex:
-                error_msg = str(ex).lower()
                 # Check if this is an authentication error - these should still fail the update
-                if any(keyword in error_msg for keyword in AUTH_ERROR_KEYWORDS):
+                if is_auth_error(ex):
                     _LOGGER.warning(
                         f"[AUTH-DEBUG] Authentication error during data update: {ex}"
                     )

--- a/custom_components/electrolux/util.py
+++ b/custom_components/electrolux/util.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 from .api_client import ElectroluxApiClient, get_electrolux_session  # noqa: F401
+from .auth_errors import is_auth_error
 from .const import (
     CONF_NOTIFICATION_DEFAULT,
     CONF_NOTIFICATION_DIAG,
@@ -376,18 +377,9 @@ def map_command_error_to_home_assistant_error(
     """
 
     # Check for authentication errors first - these should be handled differently
-    error_str = str(ex).lower()
-    if any(
-        keyword in error_str
-        for keyword in [
-            "401",
-            "unauthorized",
-            "forbidden",
-            "invalid grant",
-            "token",
-            "auth",
-        ]
-    ):
+    # Only 401 counts here: the command endpoint answers 403 with "remote
+    # control disabled", which the status mapping below reports properly.
+    if is_auth_error(ex, auth_statuses=(401,)):
         logger.warning(
             "Authentication error detected for %s: %s",
             entity_attr,

--- a/tests/test_auth_errors.py
+++ b/tests/test_auth_errors.py
@@ -1,0 +1,122 @@
+"""Tests for authentication error detection.
+
+The important case is a command validation failure: the API answers 406 with a
+COMMAND_VALIDATION_ERROR body, and that must never be treated as an
+authentication problem, no matter what the error text happens to contain.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.electrolux.auth_errors import get_error_status, is_auth_error
+
+# An appliance id containing "401", which is what made string matching unsafe.
+APPLIANCE_URL = (
+    "url='https://api.developer.electrolux.one/api/v1/appliances/"
+    "916900511_01:54926920-443E07773401/command'"
+)
+
+
+def api_error(status: int, detail: str) -> Exception:
+    """Build an exception shaped like the one the SDK raises."""
+    return Exception(
+        f"Failed to send command: {status}, "
+        f"message=\"{{'error': 'COMMAND_VALIDATION_ERROR', "
+        f"'message': 'Command validation failed', 'detail': '{detail}'}}\", "
+        f"{APPLIANCE_URL}"
+    )
+
+
+class StatusError(Exception):
+    """Exception exposing a status attribute, like aiohttp's."""
+
+    def __init__(self, message: str, status: int) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+class ResponseError(Exception):
+    """Exception exposing the status on a nested response object."""
+
+    def __init__(self, message: str, status: int) -> None:
+        super().__init__(message)
+        self.response = StatusError(message, status)
+
+
+class TestCommandValidationIsNotAuth:
+    """406 command validation errors are ordinary rejections."""
+
+    @pytest.mark.parametrize(
+        "detail",
+        [
+            "Remote control disabled",
+            "Appliance disconnected",
+            "String value not allowed",
+        ],
+    )
+    def test_406_is_not_an_auth_error(self, detail):
+        """A documented command validation failure is not an auth failure."""
+        assert is_auth_error(api_error(406, detail)) is False
+
+    def test_401_inside_the_appliance_id_does_not_count(self):
+        """The appliance id in the URL must not drive the decision."""
+        assert "401" in APPLIANCE_URL
+        assert is_auth_error(api_error(500, "Internal error")) is False
+
+    def test_rate_limit_is_not_an_auth_error(self):
+        """A 429 must not trigger reauthentication."""
+        assert is_auth_error(api_error(429, "Too Many Requests")) is False
+
+
+class TestGenuineAuthErrors:
+    """401 and 403 are the statuses that reauthentication can fix."""
+
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_auth_statuses_are_detected(self, status):
+        """Auth statuses are reported as auth errors."""
+        assert is_auth_error(api_error(status, "Unauthorized")) is True
+
+    def test_status_attribute_is_used(self):
+        """A status attribute is enough, with no parsable message."""
+        assert is_auth_error(StatusError("boom", 401)) is True
+        assert is_auth_error(StatusError("boom", 406)) is False
+
+    def test_nested_response_status_is_used(self):
+        """A status on a nested response object is enough."""
+        assert is_auth_error(ResponseError("boom", 403)) is True
+        assert is_auth_error(ResponseError("boom", 500)) is False
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "unauthorized access denied",
+            "invalid grant error",
+            "token expired",
+            "authentication failed",
+            "403 forbidden",
+        ],
+    )
+    def test_phrases_still_work_without_a_status(self, message):
+        """Exceptions carrying no status fall back to phrase matching."""
+        assert is_auth_error(Exception(message)) is True
+
+    def test_plain_network_error_is_not_auth(self):
+        """An ordinary connection failure is not an auth error."""
+        assert is_auth_error(Exception("Cannot connect to host")) is False
+
+
+class TestGetErrorStatus:
+    """Status extraction covers the shapes the SDK produces."""
+
+    def test_status_parsed_from_message(self):
+        """The status is read out of the aiohttp string form."""
+        assert get_error_status(api_error(406, "Remote control disabled")) == 406
+
+    def test_attribute_wins_over_message(self):
+        """An explicit attribute is preferred over the message text."""
+        assert get_error_status(StatusError("500, message='x'", 403)) == 403
+
+    def test_missing_status_returns_none(self):
+        """Nothing to parse means no status."""
+        assert get_error_status(Exception("no status here")) is None


### PR DESCRIPTION
### What is wrong

Any failed command on my dryer surfaces as:

```
Token expired or invalid - please reauthenticate
```

Reauthenticating does not help, because nothing is wrong with the token. The real error, logged one line earlier, is a documented command validation failure:

```
Error sending command: 406, message="{'error': 'COMMAND_VALIDATION_ERROR',
  'message': 'Command validation failed', 'detail': 'Remote control disabled'}",
  url='.../appliances/916900511_01:54926920-443E07773401/command'
```

Per the API reference, sending a command runs three validation phases and any of them can answer `406 Not Acceptable`, including `Appliance disconnected` and `Remote control disabled`. These are normal rejections that the user fixes at the appliance, not credential problems.

### Why

The decision was made by substring matching the stringified exception against `["401", "unauthorized", "invalid grant", "token", "forbidden", "auth"]`. The string form of an aiohttp error embeds the request URL, and the URL embeds the appliance id. Appliance ids are hex, and mine ends in `...443E07773401`, which contains `401`. So every failure that appliance ever produces matches, whatever the actual status was.

Two consequences beyond the wrong message: it raises `ConfigEntryAuthFailed`, which aborts the script or automation that issued the command, and a `429` on such an appliance is also read as an auth failure, so the integration responds to rate limiting by re-authenticating.

The same keyword list was copy pasted in four places, so this happens on the command path, the generic API path, the SSE failure path and the data update path.

### How

New `auth_errors.py` with `is_auth_error(ex)`:

1. Take the HTTP status from `.status`, `.status_code`, `.response.status`, or parse it out of the aiohttp string form `NNN, message=`.
2. If a status is known, it decides on its own. A 406, 429 or 500 is never an auth error regardless of the message text.
3. Only when no status can be found, fall back to phrases, with the ambiguous `401`, `token` and `auth` entries removed.

Wired into the four call sites. `map_command_error_to_home_assistant_error` passes `auth_statuses=(401,)` so the command path keeps its existing meaning for 403 ("remote control disabled"), which its tests cover.

`token_manager.py` has a similar list but sits on the token refresh path, where the URL carries no appliance id and 401 genuinely is the signal. Left alone to keep this to one concern.

### Testing

`tests/test_auth_errors.py`, 18 cases covering the documented 406 details, 429, a 500 on an id containing `401`, status via attribute and nested response, and the existing phrase fallbacks.

- `uv run pytest`: 1655 passed, coverage 95.70%
- `uv run ruff check` and `black --check`: clean
- Reverting `auth_errors.py` to the old substring logic fails 9 of the 18 new tests, including all three 406 cases.
