### PR TITLE
fix(vacuum): register zone cleaning with an entity service schema

### DIFF
--- a/custom_components/electrolux/vacuum.py
+++ b/custom_components/electrolux/vacuum.py
@@ -28,7 +28,7 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 SERVICE_START_ZONE_CLEANING = "start_zone_cleaning"
 
-SERVICE_START_ZONE_CLEANING_SCHEMA = vol.Schema(
+SERVICE_START_ZONE_CLEANING_SCHEMA = cv.make_entity_service_schema(
     {
         vol.Required("persistent_map_id"): vol.All(cv.string, vol.Length(min=1)),
         vol.Required("zones"): vol.All(

--- a/tests/test_vacuum_service.py
+++ b/tests/test_vacuum_service.py
@@ -1,0 +1,39 @@
+"""Tests for the vacuum zone cleaning service registration."""
+
+from __future__ import annotations
+
+import pytest
+import voluptuous as vol
+from homeassistant.helpers import config_validation as cv
+
+from custom_components.electrolux.vacuum import SERVICE_START_ZONE_CLEANING_SCHEMA
+
+
+def test_zone_cleaning_schema_is_an_entity_service_schema():
+    """Entity services must use an entity service schema.
+
+    A bare vol.Schema is rejected by async_register_entity_service, which aborts
+    setup of the whole vacuum platform.
+    """
+    assert cv.is_entity_service_schema(SERVICE_START_ZONE_CLEANING_SCHEMA)
+
+
+def test_zone_cleaning_schema_accepts_a_target():
+    """The schema must accept the entity target the service is called with."""
+    data = SERVICE_START_ZONE_CLEANING_SCHEMA(
+        {
+            "entity_id": "vacuum.robot",
+            "persistent_map_id": "map-1",
+            "zones": [{"zone_id": "zone-1", "power_mode": 2}],
+        }
+    )
+    assert data["persistent_map_id"] == "map-1"
+    assert data["zones"][0]["zone_id"] == "zone-1"
+
+
+def test_zone_cleaning_schema_still_validates_payload():
+    """Payload validation is unchanged: zones are required and non empty."""
+    with pytest.raises(vol.Invalid):
+        SERVICE_START_ZONE_CLEANING_SCHEMA(
+            {"entity_id": "vacuum.robot", "persistent_map_id": "map-1", "zones": []}
+        )


### PR DESCRIPTION
### What is wrong

On Home Assistant 2026.8.0 the vacuum platform does not load at all:

```
ERROR (MainThread) [homeassistant.components.vacuum] Error while setting up electrolux platform for vacuum:
The electrolux.start_zone_cleaning service registers an entity service with a non entity service schema
  File "/config/custom_components/electrolux/vacuum.py", line 162, in async_setup_entry
homeassistant.exceptions.HomeAssistantError: The electrolux.start_zone_cleaning service registers an entity service with a non entity service schema
```

`async_setup_entry` raises before it returns, so no vacuum entity is created for any appliance. Everything else in the integration is unaffected, which makes it easy to miss unless you own an RVC.

Introduced in #148 (zone cleaning service), so it affects `main` but no released version yet.

### Why

`async_register_entity_service` requires a schema that carries the entity target fields (`entity_id`, `device_id`, `area_id`). It accepts a plain dict, which it wraps itself, or a schema built with `cv.make_entity_service_schema`. A bare `vol.Schema` has no target fields, so it is rejected:

```python
>>> cv.is_entity_service_schema(vol.Schema({vol.Required("a"): str}))
False
>>> cv.is_entity_service_schema(cv.make_entity_service_schema({vol.Required("a"): str}))
True
```

`SERVICE_START_ZONE_CLEANING_SCHEMA` was a bare `vol.Schema`, so registration raised and took platform setup down with it.

### How

Build the constant with `cv.make_entity_service_schema` instead. The field validation inside is unchanged, the schema just gains the target fields it was missing. One line.

### Testing

`tests/test_vacuum_service.py` covers the schema being a valid entity service schema, accepting a call that targets an entity, and still rejecting an empty `zones` list.

- `uv run pytest`: 1640 passed, coverage 95.68%
- `uv run ruff check` and `black --check`: clean
- Reverting the one line fails 2 of the 3 new tests.
