### PR TITLE
fix(number): keep delayed start adjustable when no programme declares it

### DIFF
--- a/custom_components/electrolux/number.py
+++ b/custom_components/electrolux/number.py
@@ -345,7 +345,7 @@ class ElectroluxNumber(ElectroluxEntity, NumberEntity):
             return False
 
         # Program and global duration/time entities are never locked
-        if self.entity_attr in ["program", "targetDuration", "startTime"]:
+        if self.entity_attr in ["program", "targetDuration", "startTime", "stopTime"]:
             return False
 
         # Food probe temperature locked when probe not inserted

--- a/tests/test_number_global_time.py
+++ b/tests/test_number_global_time.py
@@ -1,0 +1,60 @@
+"""Tests for global time entities that no programme declares."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.electrolux.const import NUMBER
+from custom_components.electrolux.number import ElectroluxNumber
+
+
+def _entity(entity_attr):
+    """Build a number entity whose programme does not declare it."""
+    coordinator = MagicMock()
+    coordinator.hass = MagicMock()
+    coordinator.config_entry = MagicMock()
+    entity = ElectroluxNumber(
+        coordinator=coordinator,
+        name="Test",
+        config_entry=coordinator.config_entry,
+        pnc_id="TEST_PNC",
+        entity_type=NUMBER,
+        entity_name="test",
+        entity_attr=entity_attr,
+        entity_source=None,
+        capability={
+            "access": "readwrite",
+            "type": "number",
+            "min": 0,
+            "max": 86400,
+            "step": 3600,
+        },
+        unit=None,
+        device_class=None,
+        entity_category=None,
+        icon="mdi:test",
+    )
+    entity.hass = coordinator.hass
+    # No programme declares these keys, so the programme lookup finds nothing.
+    entity._get_program_constraint = MagicMock(return_value=None)
+    entity._is_supported_by_program = MagicMock(return_value=False)
+    return entity
+
+
+@pytest.mark.parametrize(
+    "entity_attr", ["program", "targetDuration", "startTime", "stopTime"]
+)
+def test_global_time_entities_are_not_locked_by_program(entity_attr):
+    """Global entities stay adjustable even though no programme declares them.
+
+    stopTime is the delayed start. Appliances advertise it at the top level as
+    readwrite 0..86400, and it appears in no programme capability block, so the
+    "not in programme capabilities" rule would otherwise lock it to min=max=0
+    and make delayed start unusable from Home Assistant.
+    """
+    assert _entity(entity_attr)._is_locked_by_program() is False
+
+
+def test_delay_keeps_its_range_when_no_programme_declares_it():
+    """With the lock lifted, the capability range survives."""
+    assert _entity("stopTime").native_max_value > 0


### PR DESCRIPTION
### What is wrong

`number.*_finish_in_delay` (the `stopTime` capability, delayed start) is stuck at `min=0 max=0` and cannot be set, on an appliance whose vendor app offers delayed start in the same state.

Observed on a TD-916900511 tumble dryer, appliance state `Ready To Start`, `remoteControl: Enabled`. Attempting to set it raises `HomeAssistantError` from the locked-by-program branch of `async_set_native_value`.

### Why

The appliance advertises it at the top level as a global setting:

```json
"stopTime": {"access": "readwrite", "min": 0, "max": 86400, "step": 3600, "type": "number"}
```

but it appears in **no** programme capability block. Programme blocks under `userSelections/programUID` carry only per-programme keys, for example:

- `TOWELS_PR_TOWELS` -> `userSelections/antiCreaseValue`, `humidityTarget`, `memoryId`
- `TIMEDRY_PR_DRYINGRACK` -> `userSelections/dryingTime` (min 10, max 120)

`_is_locked_by_program()` treats "not in programme capabilities" as locked, so the entity collapses to `min=max=0`. The exemption list already recognises this class of entity, and `stopTime` was simply missing next to `startTime`:

```python
if self.entity_attr in ["program", "targetDuration", "startTime"]:
```

### How

Add `stopTime` to that list. One line.

Scoped deliberately: `dryingTime` shows the same symptom but is **not** the same bug. It genuinely is declared per programme (see `TIMEDRY_PR_DRYINGRACK` above), so locking it on programmes that do not offer it is correct behaviour. Only entities absent from every programme block are affected.

After the change the entity reports `min 0, max 1440, step 60` minutes, matching the advertised 0..86400 seconds in 3600 second steps.

### Testing

`tests/test_number_global_time.py`, parametrised across all four global time entities plus a range check.

- `uv run pytest`: 1642 passed, coverage 95.68%
- `uv run ruff check` and `black --check`: clean
- Reverting the one line fails 2 of the 5 new tests

Verified on a live appliance to the point that the entity becomes adjustable with the correct range. Sending an actual delay end to end was not tested, because the only appliance available was mid-schedule with a real load in it.
