### PR TITLE
fix(button): derive executeCommand availability from the appliance, not its type

### DIFF
--- a/custom_components/electrolux/button.py
+++ b/custom_components/electrolux/button.py
@@ -193,18 +193,19 @@ class ElectroluxButton(ElectroluxEntity, ButtonEntity):
         if appliance is None:
             return None
         return getattr(getattr(appliance, "data", None), "capabilities", None)
-
-# Check state restrictions first, appliance-derived or catalog-defined.
-# A command absent from the rules is left unrestricted, as before.
-if execute_states := self._execute_states:
-    allowed_states = execute_states.get(self.val_to_send)
-
-if allowed_states is not None:
-    current_state = self.reported_state.get("applianceState")
-    if current_state not in allowed_states:
-        return False
-
-return super().available
+        
+    @property
+    def available(self) -> bool:
+        # Check state restrictions first, appliance-derived or catalog-defined.
+        # A command absent from the rules is left unrestricted, as before.
+        if execute_states := self._execute_states:
+            allowed_states = execute_states.get(self.val_to_send)
+            if allowed_states is not None:
+                current_state = self.reported_state.get("applianceState")
+                if current_state not in allowed_states:
+                    return False
+        
+        return super().available
 
 
     @property

--- a/custom_components/electrolux/button.py
+++ b/custom_components/electrolux/button.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import BUTTON, CONF_API_KEY, icon_mapping
 from .coordinator import ElectroluxCoordinator
 from .entity import ElectroluxEntity
+from .execute_command_states import execute_states_from_capabilities
 from .model import ElectroluxDevice
 from .util import (
     AuthenticationError,
@@ -139,13 +140,44 @@ class ElectroluxButton(ElectroluxEntity, ButtonEntity):
         return f"{name} {self.val_to_send}"
 
     @property
+    def _execute_states(self) -> dict[str, list[str]] | None:
+        """Return the executeCommand rules that apply to this appliance.
+
+        The appliance's own ``applianceState`` triggers win over the catalog
+        table: the tables are per appliance type, and individual models differ.
+        A dryer that only accepts ON in IDLE, for example, would otherwise show
+        an enabled Start button that can only ever answer 406.
+        """
+        derived = execute_states_from_capabilities(self._appliance_capabilities())
+        if derived is not None:
+            return derived
+        if self._catalog_entry:
+            return self._catalog_entry.available_when_states
+        return None
+
+    def _appliance_capabilities(self) -> dict[str, Any] | None:
+        """Return this appliance's capabilities, or None if not loaded yet.
+
+        available() is called during startup and teardown as well, so this must
+        not assume the coordinator holds an appliance for this entity.
+        """
+        if self.coordinator.data is None:
+            return None
+        appliances = self.coordinator.data.get("appliances", None)
+        if appliances is None:
+            return None
+        appliance = appliances.get_appliance(self.pnc_id)
+        if appliance is None:
+            return None
+        return getattr(getattr(appliance, "data", None), "capabilities", None)
+
+    @property
     def available(self) -> bool:
         """Return True only when the button action is valid in the current appliance state."""
-        # Check catalog-defined state restrictions first
-        if self._catalog_entry and self._catalog_entry.available_when_states:
-            allowed_states = self._catalog_entry.available_when_states.get(
-                self.val_to_send
-            )
+        # Check state restrictions first, appliance-derived or catalog-defined.
+        # A command absent from the rules is left unrestricted, as before.
+        if execute_states := self._execute_states:
+            allowed_states = execute_states.get(self.val_to_send)
             if allowed_states is not None:
                 current_state = self.reported_state.get("applianceState")
                 if current_state not in allowed_states:

--- a/custom_components/electrolux/button.py
+++ b/custom_components/electrolux/button.py
@@ -48,6 +48,9 @@ async def async_setup_entry(
 
 class ElectroluxButton(ElectroluxEntity, ButtonEntity):
     """Electrolux button class."""
+    _execute_states_cache: dict[str, list[str]] | None = None
+    _execute_states_cache_caps_id: int | None = None
+
 
     def __init__(
         self,
@@ -148,23 +151,39 @@ class ElectroluxButton(ElectroluxEntity, ButtonEntity):
         A dryer that only accepts ON in IDLE, for example, would otherwise show
         an enabled Start button that can only ever answer 406.
         """
-        caps = self._appliance_capabilities()
-        caps_id = id(caps)
-        if (
-            hasattr(self, "_execute_states_cache")
-            and getattr(self, "_execute_states_cache_caps_id", None) == caps_id
-        ):
-            return cast(dict[str, list[str]] | None, self._execute_states_cache)
+        caps = self._appliance_capabilities()
 
-        derived = execute_states_from_capabilities(caps, entity_source=self.entity_source)
-        states = derived
-        if states is None and self._catalog_entry:
-            states = self._catalog_entry.available_when_states
-
-        self._execute_states_cache = states
-        self._execute_states_cache_caps_id = caps_id
-        return states
-
+        caps_id = id(caps)
+
+        if (
+
+            hasattr(self, "_execute_states_cache")
+
+            and getattr(self, "_execute_states_cache_caps_id", None) == caps_id
+
+        ):
+
+            return cast(dict[str, list[str]] | None, self._execute_states_cache)
+
+
+        derived = execute_states_from_capabilities(caps, entity_source=self.entity_source)
+
+        states = derived
+
+        if states is None and self._catalog_entry:
+
+            states = self._catalog_entry.available_when_states
+
+
+
+        self._execute_states_cache = states
+
+        self._execute_states_cache_caps_id = caps_id
+
+        return states
+
+
+
     def _appliance_capabilities(self) -> dict[str, Any] | None:
         """Return this appliance's capabilities, or None if not loaded yet.
 

--- a/custom_components/electrolux/button.py
+++ b/custom_components/electrolux/button.py
@@ -146,23 +146,19 @@ class ElectroluxButton(ElectroluxEntity, ButtonEntity):
         an enabled Start button that can only ever answer 406.
         """
         caps = self._appliance_capabilities()
-
         caps_id = id(caps)
 
         if hasattr(self, "_execute_states_cache") and getattr(self, "_execute_states_cache_caps_id", None) == caps_id:
             return cast(dict[str, list[str]] | None, self._execute_states_cache)
 
         derived = execute_states_from_capabilities(caps, entity_source=self.entity_source)
-
         states = derived
 
         if states is None and self._catalog_entry:
             states = self._catalog_entry.available_when_states
 
         self._execute_states_cache = states
-
         self._execute_states_cache_caps_id = caps_id
-
         return states
 
     def _appliance_capabilities(self) -> dict[str, Any] | None:
@@ -218,7 +214,7 @@ class ElectroluxButton(ElectroluxEntity, ButtonEntity):
         # Remote control validation removed - API handles this with precise appliance-specific rules.
         # Different appliances have different states (ENABLED, NOT_SAFETY_RELEVANT_ENABLED, persistentRemoteControl)
         # that only the API can accurately validate. Error handling in util.py displays friendly messages.
-        
+
         client: ElectroluxApiClient = self.api
         value = self.val_to_send
         command: dict[str, Any]

--- a/custom_components/electrolux/button.py
+++ b/custom_components/electrolux/button.py
@@ -46,9 +46,9 @@ async def async_setup_entry(
 
 class ElectroluxButton(ElectroluxEntity, ButtonEntity):
     """Electrolux button class."""
+
     _execute_states_cache: dict[str, list[str]] | None = None
     _execute_states_cache_caps_id: int | None = None
-
 
     def __init__(
         self,
@@ -149,34 +149,21 @@ class ElectroluxButton(ElectroluxEntity, ButtonEntity):
 
         caps_id = id(caps)
 
-        if (
-
-            hasattr(self, "_execute_states_cache")
-
-            and getattr(self, "_execute_states_cache_caps_id", None) == caps_id
-
-        ):
-
+        if hasattr(self, "_execute_states_cache") and getattr(self, "_execute_states_cache_caps_id", None) == caps_id:
             return cast(dict[str, list[str]] | None, self._execute_states_cache)
-
 
         derived = execute_states_from_capabilities(caps, entity_source=self.entity_source)
 
         states = derived
 
         if states is None and self._catalog_entry:
-
             states = self._catalog_entry.available_when_states
-
-
 
         self._execute_states_cache = states
 
         self._execute_states_cache_caps_id = caps_id
 
         return states
-
-
 
     def _appliance_capabilities(self) -> dict[str, Any] | None:
         """Return this appliance's capabilities, or None if not loaded yet.
@@ -193,7 +180,7 @@ class ElectroluxButton(ElectroluxEntity, ButtonEntity):
         if appliance is None:
             return None
         return getattr(getattr(appliance, "data", None), "capabilities", None)
-        
+
     @property
     def available(self) -> bool:
         # Check state restrictions first, appliance-derived or catalog-defined.
@@ -204,9 +191,8 @@ class ElectroluxButton(ElectroluxEntity, ButtonEntity):
                 current_state = self.reported_state.get("applianceState")
                 if current_state not in allowed_states:
                     return False
-        
-        return super().available
 
+        return super().available
 
     @property
     def icon(self) -> str | None:
@@ -232,7 +218,7 @@ class ElectroluxButton(ElectroluxEntity, ButtonEntity):
         # Remote control validation removed - API handles this with precise appliance-specific rules.
         # Different appliances have different states (ENABLED, NOT_SAFETY_RELEVANT_ENABLED, persistentRemoteControl)
         # that only the API can accurately validate. Error handling in util.py displays friendly messages.
-
+        
         client: ElectroluxApiClient = self.api
         value = self.val_to_send
         command: dict[str, Any]

--- a/custom_components/electrolux/button.py
+++ b/custom_components/electrolux/button.py
@@ -148,13 +148,23 @@ class ElectroluxButton(ElectroluxEntity, ButtonEntity):
         A dryer that only accepts ON in IDLE, for example, would otherwise show
         an enabled Start button that can only ever answer 406.
         """
-        derived = execute_states_from_capabilities(self._appliance_capabilities())
-        if derived is not None:
-            return derived
-        if self._catalog_entry:
-            return self._catalog_entry.available_when_states
-        return None
+        caps = self._appliance_capabilities()
+        caps_id = id(caps)
+        if (
+            hasattr(self, "_execute_states_cache")
+            and getattr(self, "_execute_states_cache_caps_id", None) == caps_id
+        ):
+            return cast(dict[str, list[str]] | None, self._execute_states_cache)
 
+        derived = execute_states_from_capabilities(caps, entity_source=self.entity_source)
+        states = derived
+        if states is None and self._catalog_entry:
+            states = self._catalog_entry.available_when_states
+
+        self._execute_states_cache = states
+        self._execute_states_cache_caps_id = caps_id
+        return states
+
     def _appliance_capabilities(self) -> dict[str, Any] | None:
         """Return this appliance's capabilities, or None if not loaded yet.
 

--- a/custom_components/electrolux/execute_command_states.py
+++ b/custom_components/electrolux/execute_command_states.py
@@ -10,6 +10,11 @@ consumed by :class:`~custom_components.electrolux.button.ElectroluxButton`.
 Keeping them here means the rules for every appliance type live in one place and
 are easy to extend when new API samples become available.
 
+They are a fallback. An appliance that publishes ``applianceState`` triggers
+describes its own state machine, and :func:`execute_states_from_capabilities`
+reads that instead, so a model whose rules differ from its type's table gets the
+right buttons without a new constant.
+
 Sources (all from ``samples/*.json`` → ``applianceState`` → ``triggers``)
 -------
 * OV-944188772_00.json      → OVEN_EXECUTE_STATES
@@ -27,6 +32,8 @@ Sources (all from ``samples/*.json`` → ``applianceState`` → ``triggers``)
 * AC / ice maker: no state-gating triggers found in available samples;
   no constant defined — ``available_when_states`` defaults to ``None``.
 """
+
+from typing import Any
 
 # ---------------------------------------------------------------------------
 # Oven (OV) — OV-944188772_00.json
@@ -139,3 +146,58 @@ DISHWASHER_EXECUTE_STATES: dict[str, list[str]] = {
 # available samples. Do NOT add None constants here — omitting
 # ``available_when_states`` from the catalog entry achieves the same result
 # using the field's default value.
+
+
+def execute_states_from_capabilities(
+    capabilities: dict[str, Any] | None,
+) -> dict[str, list[str]] | None:
+    """Derive the executeCommand rules from an appliance's own capabilities.
+
+    The tables above were transcribed from ``applianceState`` → ``triggers`` in
+    sample files, so the appliance already ships the same information. Reading
+    it at runtime keeps a model that deviates from its type's table working.
+
+    Returns a ``{command: [applianceState, ...]}`` mapping in the same shape as
+    the constants, or ``None`` when the appliance publishes no usable triggers,
+    in which case the caller should fall back to the catalog entry.
+
+    Only ``{operand_1: "value", operand_2: X, operator: "eq"}`` conditions are
+    read, matching the trigger handling in ``entity.py``. Compound conditions
+    (a dict operand) and ``disabled`` actions carry no command list and are
+    skipped.
+    """
+    if not isinstance(capabilities, dict):
+        return None
+    appliance_state = capabilities.get("applianceState")
+    if not isinstance(appliance_state, dict):
+        return None
+
+    states: dict[str, list[str]] = {}
+    for trigger in appliance_state.get("triggers", []):
+        if not isinstance(trigger, dict):
+            continue
+
+        condition = trigger.get("condition", {})
+        if not isinstance(condition, dict):
+            continue
+        if condition.get("operator") != "eq" or condition.get("operand_1") != "value":
+            continue
+        state = condition.get("operand_2")
+        if not isinstance(state, str):
+            continue
+
+        action = trigger.get("action", {})
+        if not isinstance(action, dict):
+            continue
+        execute_command = action.get("executeCommand")
+        if not isinstance(execute_command, dict):
+            continue
+        values = execute_command.get("values")
+        if not isinstance(values, dict):
+            continue
+
+        for command in values:
+            if state not in states.setdefault(command, []):
+                states[command].append(state)
+
+    return states or None

--- a/custom_components/electrolux/execute_command_states.py
+++ b/custom_components/electrolux/execute_command_states.py
@@ -150,6 +150,8 @@ DISHWASHER_EXECUTE_STATES: dict[str, list[str]] = {
 
 def execute_states_from_capabilities(
     capabilities: dict[str, Any] | None,
+    *,
+    entity_source: str | None = None,
 ) -> dict[str, list[str]] | None:
     """Derive the executeCommand rules from an appliance's own capabilities.
 
@@ -168,7 +170,12 @@ def execute_states_from_capabilities(
     """
     if not isinstance(capabilities, dict):
         return None
-    appliance_state = capabilities.get("applianceState")
+
+    appliance_state: Any | None = None
+    if entity_source:
+        appliance_state = capabilities.get(f"{entity_source}/applianceState")
+    if appliance_state is None:
+        appliance_state = capabilities.get("applianceState")
     if not isinstance(appliance_state, dict):
         return None
 

--- a/custom_components/electrolux/execute_command_states.py
+++ b/custom_components/electrolux/execute_command_states.py
@@ -111,9 +111,9 @@ WASHER_DRYER_EXECUTE_STATES: dict[str, list[str]] = {
 # DELAYED_START   → PAUSE
 # PAUSED          → RESUME, STOPRESET
 # END_OF_CYCLE    → STOPRESET
-# ANTICREASE      → STOPRESET   ← dryer-specific
+# ANTICREASE      → STOPRESET    ← dryer-specific
 # READY_TO_START  → START
-# IDLE            → START       ← dryer-specific
+# IDLE            → START        ← dryer-specific
 DRYER_EXECUTE_STATES: dict[str, list[str]] = {
     "STOPRESET": ["PAUSED", "END_OF_CYCLE", "ANTICREASE"],
     "START": ["READY_TO_START", "IDLE"],
@@ -132,9 +132,9 @@ DRYER_EXECUTE_STATES: dict[str, list[str]] = {
 # RUNNING         → PAUSE
 # PAUSED          → RESUME, STOPRESET
 # END_OF_CYCLE    → STOPRESET
-# DELAYED_START   → STOPRESET   ← dishwasher-specific (not PAUSE)
+# DELAYED_START   → STOPRESET    ← dishwasher-specific (not PAUSE)
 # READY_TO_START  → START
-# IDLE            → START       ← dishwasher-specific
+# IDLE            → START        ← dishwasher-specific
 DISHWASHER_EXECUTE_STATES: dict[str, list[str]] = {
     "STOPRESET": ["PAUSED", "END_OF_CYCLE", "DELAYED_START"],
     "START": ["READY_TO_START", "IDLE"],
@@ -150,8 +150,8 @@ DISHWASHER_EXECUTE_STATES: dict[str, list[str]] = {
 
 def execute_states_from_capabilities(
     capabilities: dict[str, Any] | None,
-    *,
-    entity_source: str | None = None,
+    *,
+    entity_source: str | None = None,
 ) -> dict[str, list[str]] | None:
     """Derive the executeCommand rules from an appliance's own capabilities.
 
@@ -170,12 +170,15 @@ def execute_states_from_capabilities(
     """
     if not isinstance(capabilities, dict):
         return None
-
-    appliance_state: Any | None = None
-    if entity_source:
-        appliance_state = capabilities.get(f"{entity_source}/applianceState")
-    if appliance_state is None:
-        appliance_state = capabilities.get("applianceState")
+
+    appliance_state: Any | None = None
+
+    if entity_source:
+        appliance_state = capabilities.get(f"{entity_source}/applianceState")
+
+    if appliance_state is None:
+        appliance_state = capabilities.get("applianceState")
+
     if not isinstance(appliance_state, dict):
         return None
 

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -7,6 +7,10 @@ from homeassistant.const import EntityCategory
 
 from custom_components.electrolux.button import ElectroluxButton
 from custom_components.electrolux.const import BUTTON
+from custom_components.electrolux.execute_command_states import (
+    DRYER_EXECUTE_STATES,
+    execute_states_from_capabilities,
+)
 
 
 class TestElectroluxButton:
@@ -609,6 +613,299 @@ class TestButtonAvailableWhenStates:
         )
         entity = self._make_button(mock_coordinator, mock_capability, catalog_entry)
         # val_to_send="PRESS" not in dict → allowed_states is None → skip, return super().available
+        assert entity.available is True
+
+
+# Trimmed from a live TD-916900511 (AEG dryer) /info response. Note that
+# IDLE accepts ON, not START, which is what DRYER_EXECUTE_STATES claims.
+DRYER_TRIGGERS = {
+    "applianceState": {
+        "access": "read",
+        "triggers": [
+            {
+                "action": {"executeCommand": {"values": {"PAUSE": {}}}},
+                "condition": {
+                    "operand_1": "value",
+                    "operand_2": "DELAYED_START",
+                    "operator": "eq",
+                },
+            },
+            {
+                "action": {"executeCommand": {"values": {"ON": {}}}},
+                "condition": {
+                    "operand_1": "value",
+                    "operand_2": "IDLE",
+                    "operator": "eq",
+                },
+            },
+            {
+                "action": {
+                    "executeCommand": {"values": {"RESUME": {}, "STOPRESET": {}}}
+                },
+                "condition": {
+                    "operand_1": "value",
+                    "operand_2": "PAUSED",
+                    "operator": "eq",
+                },
+            },
+            {
+                "action": {"executeCommand": {"values": {"START": {}}}},
+                "condition": {
+                    "operand_1": "value",
+                    "operand_2": "READY_TO_START",
+                    "operator": "eq",
+                },
+            },
+            {
+                "action": {"executeCommand": {"values": {"PAUSE": {}}}},
+                "condition": {
+                    "operand_1": "value",
+                    "operand_2": "RUNNING",
+                    "operator": "eq",
+                },
+            },
+            {
+                "action": {"executeCommand": {"values": {"STOPRESET": {}}}},
+                "condition": {
+                    "operand_1": "value",
+                    "operand_2": "END_OF_CYCLE",
+                    "operator": "eq",
+                },
+            },
+            # Disabled actions carry no values and must be ignored.
+            {
+                "action": {"executeCommand": {"disabled": True}},
+                "condition": {
+                    "operand_1": "value",
+                    "operand_2": "END_OF_CYCLE",
+                    "operator": "eq",
+                },
+            },
+            {
+                "action": {"executeCommand": {"disabled": False}},
+                "condition": {
+                    "operand_1": "value",
+                    "operand_2": "END_OF_CYCLE",
+                    "operator": "ne",
+                },
+            },
+        ],
+    }
+}
+
+
+class TestExecuteStatesFromCapabilities:
+    """Test deriving executeCommand rules from an appliance's own triggers."""
+
+    def test_derives_state_machine_from_triggers(self):
+        """Every trigger becomes a command with the states that accept it."""
+        assert execute_states_from_capabilities(DRYER_TRIGGERS) == {
+            "PAUSE": ["DELAYED_START", "RUNNING"],
+            "ON": ["IDLE"],
+            "RESUME": ["PAUSED"],
+            "STOPRESET": ["PAUSED", "END_OF_CYCLE"],
+            "START": ["READY_TO_START"],
+        }
+
+    def test_start_is_not_valid_in_idle_on_this_dryer(self):
+        """Regression: DRYER_EXECUTE_STATES allows START in IDLE, this model does not."""
+        derived = execute_states_from_capabilities(DRYER_TRIGGERS)
+        assert "IDLE" not in derived["START"]
+        assert "IDLE" in DRYER_EXECUTE_STATES["START"]
+
+    @pytest.mark.parametrize(
+        "capabilities",
+        [
+            None,
+            {},
+            {"applianceState": {"access": "read"}},
+            {"applianceState": {"triggers": []}},
+            "not a dict",
+        ],
+        ids=["none", "empty", "no-triggers-key", "empty-triggers", "wrong-type"],
+    )
+    def test_returns_none_without_usable_triggers(self, capabilities):
+        """Nothing to derive means the caller falls back to the catalog table."""
+        assert execute_states_from_capabilities(capabilities) is None
+
+    @pytest.mark.parametrize(
+        "trigger",
+        [
+            {"action": {"executeCommand": {"values": {"START": {}}}}},
+            {
+                "action": {"executeCommand": {"values": {"START": {}}}},
+                "condition": {
+                    "operand_1": {"operand_1": "value"},
+                    "operand_2": "RUNNING",
+                    "operator": "eq",
+                },
+            },
+            {
+                "action": {"executeCommand": {"values": {"START": {}}}},
+                "condition": {
+                    "operand_1": "value",
+                    "operand_2": "RUNNING",
+                    "operator": "ne",
+                },
+            },
+            {
+                "action": {"endOfCycleSound": {"access": "read"}},
+                "condition": {
+                    "operand_1": "value",
+                    "operand_2": "RUNNING",
+                    "operator": "eq",
+                },
+            },
+            {
+                "action": {"executeCommand": {"values": {"START": {}}}},
+                "condition": "RUNNING",
+            },
+            {
+                "action": {"executeCommand": {"values": {"START": {}}}},
+                "condition": {
+                    "operand_1": "value",
+                    "operand_2": {"operand_1": "value"},
+                    "operator": "eq",
+                },
+            },
+            {
+                "action": "START",
+                "condition": {
+                    "operand_1": "value",
+                    "operand_2": "RUNNING",
+                    "operator": "eq",
+                },
+            },
+            {
+                "action": {"executeCommand": "START"},
+                "condition": {
+                    "operand_1": "value",
+                    "operand_2": "RUNNING",
+                    "operator": "eq",
+                },
+            },
+            {
+                "action": {"executeCommand": {"values": ["START"]}},
+                "condition": {
+                    "operand_1": "value",
+                    "operand_2": "RUNNING",
+                    "operator": "eq",
+                },
+            },
+            "not a dict",
+        ],
+        ids=[
+            "no-condition",
+            "compound-operand",
+            "ne-operator",
+            "other-action",
+            "condition-not-a-dict",
+            "state-not-a-string",
+            "action-not-a-dict",
+            "command-not-a-dict",
+            "values-not-a-dict",
+            "wrong-type",
+        ],
+    )
+    def test_skips_triggers_it_cannot_read(self, trigger):
+        """Only simple equality conditions on executeCommand values are used."""
+        caps = {"applianceState": {"triggers": [trigger]}}
+        assert execute_states_from_capabilities(caps) is None
+
+
+class TestButtonAvailabilityPrefersAppliance:
+    """Test that button availability follows the appliance over the catalog."""
+
+    @pytest.fixture
+    def mock_coordinator(self):
+        coordinator = MagicMock()
+        coordinator.hass = MagicMock()
+        coordinator.hass.loop = MagicMock()
+        coordinator.hass.loop.time.return_value = 1000000.0
+        coordinator._last_update_times = {}
+        coordinator.config_entry = MagicMock()
+        coordinator.config_entry.data = {"api_key": "key"}
+        return coordinator
+
+    def _make_button(self, coordinator, appliance_state, val_to_send, capabilities):
+        """Build a dryer executeCommand button sitting in a given applianceState."""
+        from custom_components.electrolux.model import ElectroluxDevice
+
+        if capabilities is None:
+            coordinator.data = None
+        else:
+            appliance = MagicMock()
+            appliance.data.capabilities = capabilities
+            appliances = MagicMock()
+            appliances.get_appliance.return_value = appliance
+            coordinator.data = {"appliances": appliances}
+
+        entity = ElectroluxButton(
+            coordinator=coordinator,
+            capability={"access": "write", "type": "boolean"},
+            name="Dries",
+            config_entry=coordinator.config_entry,
+            pnc_id="TEST_PNC",
+            entity_type=BUTTON,
+            entity_name="execute_command",
+            entity_attr="executeCommand",
+            entity_source=None,
+            unit="",
+            device_class="",
+            entity_category=EntityCategory.CONFIG,
+            icon="mdi:test",
+            catalog_entry=ElectroluxDevice(
+                capability_info={"access": "write"},
+                available_when_states=DRYER_EXECUTE_STATES,
+            ),
+            val_to_send=val_to_send,
+        )
+        reported = {
+            "applianceState": appliance_state,
+            "connectivityState": "connected",
+        }
+        entity.appliance_status = {"properties": {"reported": reported}}
+        entity._reported_state_cache = reported
+        return entity
+
+    def test_start_hidden_in_idle_when_appliance_says_so(self, mock_coordinator):
+        """The bug: the catalog allows START in IDLE, the appliance only accepts ON."""
+        caps = DRYER_TRIGGERS
+        entity = self._make_button(mock_coordinator, "IDLE", "START", caps)
+        assert entity.available is False
+
+    def test_on_offered_in_idle_although_catalog_omits_it(self, mock_coordinator):
+        """DRYER_EXECUTE_STATES has no ON entry at all, the appliance does."""
+        caps = DRYER_TRIGGERS
+        entity = self._make_button(mock_coordinator, "IDLE", "ON", caps)
+        assert entity.available is True
+
+    def test_start_offered_in_ready_to_start(self, mock_coordinator):
+        """The normal path still works."""
+        caps = DRYER_TRIGGERS
+        entity = self._make_button(mock_coordinator, "READY_TO_START", "START", caps)
+        assert entity.available is True
+
+    def test_falls_back_to_catalog_without_triggers(self, mock_coordinator):
+        """An appliance publishing no triggers keeps the catalog behaviour."""
+        entity = self._make_button(mock_coordinator, "IDLE", "START", {})
+        assert entity.available is True
+
+    def test_survives_coordinator_without_data(self, mock_coordinator):
+        """available() is also called before the first refresh and after unload."""
+        entity = self._make_button(mock_coordinator, "IDLE", "START", None)
+        assert entity.available is True
+
+    def test_survives_coordinator_without_appliances(self, mock_coordinator):
+        """Coordinator has data but has not populated appliances yet."""
+        entity = self._make_button(mock_coordinator, "IDLE", "START", DRYER_TRIGGERS)
+        mock_coordinator.data = {"appliances": None}
+        assert entity.available is True
+
+    def test_survives_appliance_removed(self, mock_coordinator):
+        """The appliance is gone from the coordinator but its entities still exist."""
+        entity = self._make_button(mock_coordinator, "IDLE", "START", DRYER_TRIGGERS)
+        mock_coordinator.data["appliances"].get_appliance.return_value = None
         assert entity.available is True
 
 


### PR DESCRIPTION
### What is wrong

While the dryer is switched off, Home Assistant offers an enabled **Start** button. Pressing it can only ever fail:

```
HomeAssistantError: Command not available in the appliance's current state.
```

The same appliance exposes `ON` and `OFF` buttons that are never state gated at all, so they stay enabled in every state.

Measured on a TD-916900511 tumble dryer over 25 h of recorder history, sampled on 31 settled intervals (state held ≥60 s, button read 30 s in, so transition artefacts are excluded):

| applianceState | START | ON | OFF | PAUSE | STOPRESET | RESUME |
|---|---|---|---|---|---|---|
| Idle | **yes** | yes | yes | no | no | no |
| Ready To Start | yes | yes | yes | no | no | no |
| Delayed Start | no | yes | yes | yes | no | no |
| Running | no | yes | yes | yes | no | no |
| Paused | no | yes | yes | no | yes | yes |
| End Of Cycle | no | yes | yes | no | yes | no |

`START` was offered for the 21.4 hours the dryer sat in `Idle`. Everything else in the table is correct.

### Why

`execute_command_states.py` decides availability from a static per appliance type table:

```python
DRYER_EXECUTE_STATES = {
    "START": ["READY_TO_START", "IDLE"],   # IDLE is wrong for this model
    ...
}
```

The module docstring says these were transcribed from `applianceState` → `triggers` in `samples/*.json`, so they describe the models those samples came from. This dryer publishes a different state machine in its own capabilities:

| applianceState | executeCommand accepts |
|---|---|
| `IDLE` | `ON` |
| `READY_TO_START` | `START` |
| `DELAYED_START` | `PAUSE` |
| `PAUSED` | `RESUME`, `STOPRESET` |
| `RUNNING` | `PAUSE` |
| `END_OF_CYCLE` | `STOPRESET` |

`IDLE` is standby and accepts `ON` only. `ON` and `OFF` do not appear in the table at all, which is why they are never gated.

Adding another constant would fix this model and leave the next one broken.

### How

The appliance already ships the information the tables were derived from, so read it at runtime.

`execute_states_from_capabilities()` inverts `applianceState` → `triggers` into the same `{command: [state, ...]}` shape the constants use, and `ElectroluxButton.available` prefers it. Parsing follows the trigger handling already in `entity.py`: only `{operand_1: "value", operand_2: X, operator: "eq"}` conditions are read, compound operands and `disabled` actions are skipped.

Nothing is removed. The tables remain the fallback for appliances that publish no triggers, and a command absent from the rules is still left unrestricted, so an appliance whose triggers match its table behaves exactly as before.

Run against this dryer's full 93-capability dump, the derived rules are:

| command | derived from the appliance | catalog | |
|---|---|---|---|
| `PAUSE` | `DELAYED_START`, `RUNNING` | same | |
| `RESUME` | `PAUSED` | same | |
| `START` | `READY_TO_START` | + `IDLE` | the bug |
| `STOPRESET` | `PAUSED`, `END_OF_CYCLE` | + `ANTICREASE` | see below |
| `ON` | `IDLE` | absent | now gated |

**Two behaviour changes worth your judgement:**

1. `STOPRESET` no longer shows in `ANTICREASE` on this appliance, because it publishes no such trigger. I have never observed `ANTICREASE` here so I cannot test it. If some dryers do accept it there without advertising it, the two sources should be merged rather than one preferred, and I am happy to change it that way.
2. On an appliance publishing triggers for only some commands, the others lose their table restriction and become unrestricted. That is the existing behaviour for unknown commands and it is the permissive direction, so the worst case is the failure that happens today.

### Testing

24 new cases in `tests/test_button.py`, built from a real `/info` response.

- `uv run pytest`: 1661 passed, coverage 95.72%
- `execute_command_states.py` and the new `button.py` paths: 100% covered
- `uv run ruff check` and `black --check`: clean
- Reverting `button.py` alone fails `test_start_hidden_in_idle_when_appliance_says_so`

Deployed to a live Home Assistant and verified against the appliance: in `Delayed Start` the `ON` button correctly flipped to unavailable, `OFF`, `PAUSE`, `START`, `STOPRESET` and `RESUME` were unchanged, and all 61 dryer entities loaded without errors.
