### PR TITLE
fix(sensor): suggest minutes for duration sensors reporting in seconds

### DIFF
--- a/custom_components/electrolux/model.py
+++ b/custom_components/electrolux/model.py
@@ -36,8 +36,12 @@ class ElectroluxDevice:
         | None
     ) = None
 
-    # suggested unit of measurement
+    # native unit of measurement (matches what the API reports)
     unit: str | None = None
+
+    # suggested display unit override (e.g., suggest minutes while native is seconds)
+    # when None, the sensor platform applies a smart default for duration sensors
+    suggested_unit: str | None = None
 
     # Map the item to a HA category
     entity_category: EntityCategory | None = None

--- a/custom_components/electrolux/sensor.py
+++ b/custom_components/electrolux/sensor.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature, UnitOfTime, UnitOfVolume
 from homeassistant.core import HomeAssistant
@@ -302,7 +302,19 @@ class ElectroluxSensor(ElectroluxEntity, SensorEntity):
 
     @property
     def suggested_unit_of_measurement(self) -> str | None:
-        """Return suggested unit of measurement."""
+        """Return suggested unit of measurement.
+
+        Catalog entries can override via ``suggested_unit``.  For duration sensors
+        that report in seconds, suggest minutes so that e.g. 8820 s displays as
+        147 min by default (users can still change in the HA UI).
+        """
+        if self.catalog_entry and self.catalog_entry.suggested_unit:
+            return self.catalog_entry.suggested_unit
+        if (
+            self.device_class == SensorDeviceClass.DURATION
+            and self.unit == UnitOfTime.SECONDS
+        ):
+            return UnitOfTime.MINUTES
         return self.unit
 
     @property


### PR DESCRIPTION
## What changed
- Added `suggested_unit` field to `ElectroluxDevice`/catalog entry model (`model.py`)
- Updated `suggested_unit_of_measurement` property in `sensor.py` to return minutes for duration sensors reporting in seconds

## Why
Duration sensors that report in seconds are hard to read in the UI. Home Assistant supports `suggested_unit_of_measurement` to let the frontend convert to a more appropriate unit (minutes) while preserving the native unit.

## Verification
- `uv run ruff check custom_components/electrolux` — pass
- `uv run black --check custom_components/electrolux` — pass
- `uv run pytest` — pass

Closes #138