### PR TITLE
feat(translations): extend and update translations

### DIFF
--- a/custom_components/electrolux/translations/bg.json
+++ b/custom_components/electrolux/translations/bg.json
@@ -3,7 +3,7 @@
         "step": {
             "user": {
                 "title": "Настройка на Electrolux",
-                "description": "Свържете вашите уреди Electrolux с помощта на API идентификационни данни от портала за разработчици на Electrolux.\n\n**За да получите идентификационни данни за API:**\n1. Посетете {url}\n2. Регистрирайте се и създайте приложение\n3. Получете вашия API ключ, токен за достъп и токен за обновяване\n\nАко имате нужда от помощ, посетете документацията за интегриране.",
+                "description": "Свържете вашите уреди Electrolux с помощта на идентификационни данни за API от портала за разработчици на Electrolux.\n\n**За да получите идентификационни данни за API:**\n1. Посетете {url}\n2. Регистрирайте се и създайте приложение\n3. Получете вашия API ключ, токен за достъп и токен за обновяване\n\nАко имате нужда от помощ, посетете документацията за интегриране.",
                 "data": {
                     "api_key": "API ключ",
                     "access_token": "Токен за достъп",
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Изпратени са твърде много команди. Моля, изчакайте малко и опитайте отново."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} не може да се коригира в текущия режим."
+        },
         "control_locked": {
             "message": "{attr} е заключен на {value} за програма {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "Скоростта на вентилатора не може да се регулира в режим {mode}. Първо превключете на ръчен режим, за да контролирате скоростта на вентилатора."
         },
         "food_probe_locked_by_program": {
             "message": "Температурата на сондата за храна е заключена на {value}°C за програма {program}."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "Стойността {value} е под минималната {min_val} за {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Стартирайте почистване на зоната",
+            "description": "Започнете сесия за почистване на базата на зони на робот-прахосмукачка PUREi9. UUID на зоните и UUID на постоянната карта се намират в диагностиката на интеграцията (mapData/mapMatch/zones и persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Постоянно ID на картата",
+                    "description": "UUID на постоянната карта за използване (от диагностика: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Зони",
+                    "description": "Списък на зоните за почистване. Всеки запис се нуждае от zone_id (UUID от mapData/mapMatch/zones[].uuid) и незадължителен power_mode (1=тих, 2=интелигентен, 3=мощен, по подразбиране 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -402,7 +426,7 @@
                 "name": "Позиция поддръжка 2 id"
             },
             "maint2_threshold": {
-                "name": "Праг на артикул 2 за поддръжка"
+                "name": "Праг на елемент за поддръжка 2"
             },
             "maint3_id": {
                 "name": "Позиция поддръжка 3 id"
@@ -625,7 +649,7 @@
                 "name": "Любим статус"
             },
             "activemessageindex": {
-                "name": "Активен индекс на съобщенията"
+                "name": "Активен индекс на съобщения"
             },
             "appliancemode": {
                 "name": "Режим на уреда"
@@ -745,7 +769,7 @@
                 "name": "Измерено тегло на товара"
             },
             "doorlock": {
-                "name": "Door lock"
+                "name": "Заключване на вратата"
             },
             "totalwashcyclescount": {
                 "name": "Общи цикли на пране"
@@ -928,10 +952,10 @@
                 "name": "Околна температура c"
             },
             "ambienttemperaturef": {
-                "name": "Околна температура f"
+                "name": "Ambient temperature f"
             },
             "fanmode": {
-                "name": "Режим вентилатор"
+                "name": "Fan mode"
             },
             "swingmode": {
                 "name": "Режим на люлеене"
@@ -940,7 +964,7 @@
                 "name": "Влажност на околната среда"
             },
             "filterstatus": {
-                "name": "Състояние на филтъра"
+                "name": "Filter status"
             },
             "powerconsumption": {
                 "name": "Консумирана мощност"
@@ -949,16 +973,16 @@
                 "name": "Консумация на енергия"
             },
             "fanspeedstate": {
-                "name": "Състояние на скоростта на вентилатора"
+                "name": "Fan speed state"
             },
             "filterstate": {
-                "name": "Състояние на филтъра"
+                "name": "Filter state"
             },
             "hepafilterlifetime": {
-                "name": "Живот на филтъра Hepa"
+                "name": "Hepa filter life time"
             },
             "appliancecategory": {
-                "name": "Категория на уреда"
+                "name": "Appliance category"
             },
             "vmno_niu": {
                 "name": "Версия на Ниу"
@@ -1524,7 +1548,7 @@
                 "name": "Ui светлина"
             },
             "safetylock": {
-                "name": "Предпазно заключване"
+                "name": "Предпазна ключалка"
             },
             "ionizer": {
                 "name": "Йонизатор"

--- a/custom_components/electrolux/translations/cs.json
+++ b/custom_components/electrolux/translations/cs.json
@@ -33,7 +33,7 @@
             }
         },
         "error": {
-            "invalid_auth": "Neplatné přihlašovací údaje rozhraní API. Zkontrolujte prosím svůj API klíč, přístupový token a obnovovací token z portálu Electrolux Developer Portal."
+            "invalid_auth": "Neplatné přihlašovací údaje rozhraní API. Zkontrolujte prosím svůj API klíč, přístupový token a obnovovací token na portálu Electrolux Developer Portal."
         },
         "abort": {
             "single_instance_allowed": "Je povolena pouze jedna konfigurace Electrolux.",
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Bylo odesláno příliš mnoho příkazů. Chvíli počkejte a zkuste to znovu."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} nelze v aktuálním režimu upravit."
+        },
         "control_locked": {
             "message": "{attr} je uzamčeno na {value} pro program {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "Rychlost ventilátoru nelze upravit v režimu {mode}. Chcete-li ovládat rychlost ventilátoru, nejprve přepněte do ručního režimu."
         },
         "food_probe_locked_by_program": {
             "message": "Teplota potravinové sondy je zablokována na {value}°C pro program {program}."
@@ -126,7 +132,7 @@
             "message": "Nelze změnit {attr}: není podporováno aktuálním programem {program}."
         },
         "remote_control_disabled": {
-            "message": "Dálkové ovládání je pro tento spotřebič deaktivováno. Aktivujte jej na ovládacím panelu spotřebiče."
+            "message": "Dálkové ovládání je pro tento spotřebič deaktivováno. Povolte jej na ovládacím panelu spotřebiče."
         },
         "service_temporarily_unavailable": {
             "message": "Služba Electrolux je dočasně nedostupná, zkuste to prosím znovu."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "Hodnota {value} je nižší než minimální hodnota {min_val} pro {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Spusťte čištění zóny",
+            "description": "Spusťte zónový úklid na robotickém vysavači PUREi9. Zónové UUID a trvalé mapové UUID se nacházejí v diagnostice integrace (mapData/mapMatch/zones a persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Trvalé ID mapy",
+                    "description": "UUID trvalé mapy, která se má použít (z diagnostiky: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "zóny",
+                    "description": "Seznam zón k čištění. Každý záznam potřebuje zone_id (UUID z mapData/mapMatch/zones[].uuid) a volitelný power_mode (1=tichý, 2=inteligentní, 3=výkon, výchozí 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -279,7 +303,7 @@
                 "name": "Nerušit povoleno"
             },
             "dnddisableairdry": {
-                "name": "Dnd zakázat sušení vzduchem"
+                "name": "Dnd disable air dry"
             },
             "isdndpausingairdry": {
                 "name": "Nepřestávejte sušit vzduchem"
@@ -288,7 +312,7 @@
                 "name": "Vícepatrová mapa"
             },
             "multifloormapautoswitch": {
-                "name": "Automatické přepínání vícepodlažních map"
+                "name": "Automatické přepínání vícepatrových map"
             },
             "robotposereliable": {
                 "name": "Spolehlivá pozice robota"
@@ -835,7 +859,7 @@
                 "name": "Minimální čas dokončení"
             },
             "ewx1493a_wmeconomy": {
-                "name": "Economy mode"
+                "name": "Ekonomický režim"
             },
             "adfinetunedetlevel": {
                 "name": "Jemné doladění automatického dávkování pracího prostředku"
@@ -1069,7 +1093,7 @@
                 "name": "Typ filtru 2"
             },
             "filteruid_1": {
-                "name": "Filtr 1 nfc tag uid"
+                "name": "Filter 1 nfc tag uid"
             },
             "filteruid_2": {
                 "name": "Filtr 2 nfc tag uid"
@@ -1365,7 +1389,7 @@
                 "name": "Noční cyklus"
             },
             "ewx1493a_wmeconomy": {
-                "name": "Economy mode"
+                "name": "Ekonomický režim"
             },
             "ewx1493a_rinsehold": {
                 "name": "Zastavení máchání"
@@ -1422,7 +1446,7 @@
                 "name": "Noční cyklus"
             },
             "wmeconomy": {
-                "name": "Economy mode"
+                "name": "Ekonomický režim"
             },
             "rinsehold": {
                 "name": "Zastavení máchání"
@@ -1512,7 +1536,7 @@
                 "name": "Spoušť automatického čištění"
             },
             "flappositionavoiduser": {
-                "name": "Poloha klapky se vyhněte uživateli"
+                "name": "Poloha klapky vyhněte se uživateli"
             },
             "horizontalswing": {
                 "name": "Horizontální houpačka"

--- a/custom_components/electrolux/translations/da.json
+++ b/custom_components/electrolux/translations/da.json
@@ -47,7 +47,7 @@
         "step": {
             "user": {
                 "title": "Electrolux optioner",
-                "description": "Opdater dine Electrolux API-legitimationsoplysninger, hvis de er udløbet.\n\n**Sådan genererer du nye legitimationsoplysninger:**\n1. Besøg {url}\n2. Generer ny API-nøgle, adgangstoken og opdateringstoken\n3. Opdater felterne nedenfor\n\n**Sikkerhedsbemærkning:** Felterne Adgangstoken og Opdater token efterlades med vilje tomme. Generer altid nye tokens fra portalen - genbrug eller del aldrig eksisterende tokens.",
+                "description": "Opdater dine Electrolux API-legitimationsoplysninger, hvis de er udløbet.\n\n**Sådan genererer du nye legitimationsoplysninger:**\n1. Besøg {url}\n2. Generer ny API-nøgle, adgangstoken og opdateringstoken\n3. Opdater felterne nedenfor\n\n**Sikkerhedsnote:** Felterne Adgangstoken og Opdater Token efterlades med vilje tomme. Generer altid friske tokens fra portalen - genbrug eller del aldrig eksisterende tokens.",
                 "data": {
                     "api_key": "API nøgle",
                     "access_token": "Adgangstoken",
@@ -93,7 +93,7 @@
             "message": "Apparatet er afbrudt eller ikke tilgængeligt. Kontroller apparatets netværksforbindelse."
         },
         "appliance_offline": {
-            "message": "Apparatet er offline (nuværende tilstand: {state}). Kontroller venligst, at apparatet er tilsluttet, har netværkstilslutning og er forbundet til skytjenester."
+            "message": "Apparatet er offline (nuværende tilstand: {state}). Tjek venligst, at apparatet er tilsluttet, har netværkstilslutning og er forbundet til skytjenester."
         },
         "appliance_state_incomplete": {
             "message": "Kan ikke ændre indstilling: Apparatets tilstand er ufuldstændig. Vent venligst på, at apparatet initialiseres."
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Der er sendt for mange kommandoer. Vent et øjeblik, og prøv igen."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} kan ikke justeres i den aktuelle tilstand."
+        },
         "control_locked": {
             "message": "{attr} er låst på {value} for program {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "Blæserhastigheden kan ikke justeres i tilstanden {mode}. Skift til manuel tilstand først for at styre blæserhastigheden."
         },
         "food_probe_locked_by_program": {
             "message": "Madsondetemperaturen er låst til {value}°C for program {program}."
@@ -114,7 +120,7 @@
             "message": "Madsonde skal indsættes for at indstille måltemperaturen."
         },
         "food_probe_not_supported_by_program": {
-            "message": "Madsondetemperaturen understøttes ikke af program {program}."
+            "message": "Madsondetemperatur understøttes ikke af program {program}."
         },
         "invalid_option": {
             "message": "Ugyldig indstilling valgt."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "Værdien {value} er under minimum {min_val} for {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Start zonerensning",
+            "description": "Start en zonebaseret rengøringssession på en PUREi9 robotstøvsuger. Zone-UUID'er og det vedvarende kort-UUID findes i integrationsdiagnostikken (mapData/mapMatch/zones og persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Vedvarende kort-id",
+                    "description": "UUID for det vedvarende kort, der skal bruges (fra diagnostik: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Zoner",
+                    "description": "Liste over zoner, der skal renses. Hver post skal bruge zone_id (UUID fra mapData/mapMatch/zones[].uuid) og valgfri power_mode (1=stille, 2=smart, 3=power, standard 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -240,7 +264,7 @@
                 "name": "Auto støvopsamling"
             },
             "automoparmextension": {
-                "name": "Auto mop arm forlængelse"
+                "name": "Automatisk moppearm forlængelse"
             },
             "automopdry": {
                 "name": "Tør automatisk moppe"
@@ -459,7 +483,7 @@
                 "name": "Hukommelsesplads"
             },
             "dryingtime": {
-                "name": "Tidsindstillet tørring (aktiv)"
+                "name": "Tidsstyret tørring (aktiv)"
             },
             "timetonotify": {
                 "name": "Tid til at give besked"
@@ -556,7 +580,7 @@
                 "name": "Vis kogetermometerets temperatur"
             },
             "displayfoodprobetemperaturec": {
-                "name": "Vis kogetermometerets temperatur c"
+                "name": "Vis kogetermometeret c"
             },
             "displayfoodprobetemperaturef": {
                 "name": "Vis kogetermometertemperatur f"
@@ -592,7 +616,7 @@
                 "name": "Øvre ovnmål for madsondetemperatur slutvirkning"
             },
             "watertanklevel": {
-                "name": "Øverste ovnvandbeholderniveau"
+                "name": "Øverste ovnvandsbeholderniveau"
             },
             "waterhardness": {
                 "name": "Vandets hårdhed"
@@ -655,7 +679,7 @@
                 "name": "Fryser temperatur"
             },
             "vacationholidaymode": {
-                "name": "Ferie ferietilstand"
+                "name": "Ferietilstand"
             },
             "sensorhumidity": {
                 "name": "Fugtighed"
@@ -709,7 +733,7 @@
                 "name": "Isdispensertilstand"
             },
             "icetraywaterfillsetting": {
-                "name": "Indstilling af isbakkefyld"
+                "name": "Fyldningsindstilling for isbakke"
             },
             "airfilterlifetimebuythreshold": {
                 "name": "Luftfilter købstærskel"
@@ -784,7 +808,7 @@
                 "name": "Temperatur"
             },
             "watersoftenermode": {
-                "name": "Vandblødgøringstilstand"
+                "name": "Vandblødgøringsfunktion"
             },
             "maint1_threshold": {
                 "name": "Vedligeholdelsestærskel"
@@ -1117,7 +1141,7 @@
                 "name": "Fejl: filter 1 nfc-tag ugyldigt"
             },
             "errnfctagpresnotvalid_2": {
-                "name": "Fejl: filter 2 nfc tag ugyldigt"
+                "name": "Fejl: filter 2 nfc-tag ugyldigt"
             },
             "errnfctransceiver_1": {
                 "name": "Fejl: filter 1 nfc transceiver"
@@ -1312,7 +1336,7 @@
                 "name": "Probe Slut på madlavning"
             },
             "connectivitystate": {
-                "name": "Forbindelsestilstand"
+                "name": "Tilslutningstilstand"
             },
             "executionstate": {
                 "name": "Udførelsesstat"

--- a/custom_components/electrolux/translations/de.json
+++ b/custom_components/electrolux/translations/de.json
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Zu viele Befehle gesendet. Bitte warten Sie einen Moment und versuchen Sie es erneut."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} kann im aktuellen Modus nicht angepasst werden."
+        },
         "control_locked": {
             "message": "{attr} ist bei {value} für Programm {program} gesperrt."
+        },
+        "fanspeed_disabled": {
+            "message": "Die Lüftergeschwindigkeit kann im {mode}-Modus nicht angepasst werden. Wechseln Sie zunächst in den manuellen Modus, um die Lüftergeschwindigkeit zu steuern."
         },
         "food_probe_locked_by_program": {
             "message": "Die Temperatur des Lebensmittelfühlers ist für Programm {program} auf {value}°C gesperrt."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "Der Wert {value} liegt unter dem Mindestwert {min_val} für {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Zonenreinigung starten",
+            "description": "Starten Sie eine zonenbasierte Reinigungssitzung auf einem PUREi9-Roboterstaubsauger. Zonen-UUIDs und die persistente Karten-UUID finden Sie in der Integrationsdiagnose (mapData/mapMatch/zones und persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Persistente Karten-ID",
+                    "description": "UUID der zu verwendenden persistenten Karte (aus der Diagnose: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Zonen",
+                    "description": "Liste der zu reinigenden Zonen. Jeder Eintrag benötigt zone_id (UUID aus mapData/mapMatch/zones[].uuid) und optional power_mode (1=leise, 2=smart, 3=power, Standard 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -393,7 +417,7 @@
                 "name": "Feinabstimmung des Weichspülerniveaus"
             },
             "extrarinsenumber": {
-                "name": "Zusätzliche Spülungen"
+                "name": "Zusätzliche Spülgänge"
             },
             "maint1_id": {
                 "name": "Wartungselement 1-ID"
@@ -982,7 +1006,7 @@
                 "name": "Laufzeit der Kompressorheizung"
             },
             "mainunittemp": {
-                "name": "Haupteinheitstemperatur"
+                "name": "Temperatur der Haupteinheit"
             },
             "loge": {
                 "name": "Protokoll e"
@@ -1165,7 +1189,7 @@
                 "name": "Vakuummodus"
             },
             "cleaningtype": {
-                "name": "Reinigungsart"
+                "name": "Reinigungstyp"
             },
             "cleaningmode": {
                 "name": "Reinigungsmodus"

--- a/custom_components/electrolux/translations/el.json
+++ b/custom_components/electrolux/translations/el.json
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Στάλθηκαν πάρα πολλές εντολές. Περιμένετε λίγο και προσπαθήστε ξανά."
         },
+        "control_disabled_by_mode": {
+            "message": "Το {attr} δεν μπορεί να προσαρμοστεί στην τρέχουσα λειτουργία."
+        },
         "control_locked": {
             "message": "Το {attr} είναι κλειδωμένο στο {value} για το πρόγραμμα {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "Η ταχύτητα του ανεμιστήρα δεν μπορεί να ρυθμιστεί στη λειτουργία {mode}. Μεταβείτε πρώτα στη χειροκίνητη λειτουργία για να ελέγξετε την ταχύτητα του ανεμιστήρα."
         },
         "food_probe_locked_by_program": {
             "message": "Η θερμοκρασία του αισθητήρα τροφίμων είναι κλειδωμένη στους {value}°C για το πρόγραμμα {program}."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "Η τιμή {value} είναι κάτω από το ελάχιστο {min_val} για {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Έναρξη καθαρισμού ζώνης",
+            "description": "Ξεκινήστε μια συνεδρία καθαρισμού βάσει ζώνης σε ηλεκτρική σκούπα ρομπότ PUREi9. Τα UUID ζώνης και το UUID του μόνιμου χάρτη βρίσκονται στα διαγνωστικά ενσωμάτωσης (mapData/mapMatch/zones και persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Επίμονο αναγνωριστικό χάρτη",
+                    "description": "UUID του επίμονου χάρτη προς χρήση (από διαγνωστικά: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Ζώνες",
+                    "description": "Λίστα ζωνών προς καθαρισμό. Κάθε καταχώριση χρειάζεται zone_id (UUID από mapData/mapMatch/zones[].uuid) και προαιρετική λειτουργία power_mode (1=αθόρυβη, 2=έξυπνη, 3=ισχύς, προεπιλογή 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -195,7 +219,7 @@
                 "name": "Παρουσιάστηκε το στοιχείο συντήρησης 3"
             },
             "maint4_occured": {
-                "name": "Maintenance item 4 occurred"
+                "name": "Παρουσιάστηκε το στοιχείο συντήρησης 4"
             },
             "maint5_occured": {
                 "name": "Παρουσιάστηκε το στοιχείο συντήρησης 5"
@@ -204,7 +228,7 @@
                 "name": "Παρουσιάστηκε το στοιχείο συντήρησης 6"
             },
             "maint7_occured": {
-                "name": "Maintenance item 7 occurred"
+                "name": "Παρουσιάστηκε το στοιχείο συντήρησης 7"
             },
             "maint8_occured": {
                 "name": "Παρουσιάστηκε το στοιχείο συντήρησης 8"
@@ -1150,7 +1174,7 @@
                 "name": "Χρήση κύριας βούρτσας"
             },
             "sidebrushsqm": {
-                "name": "Χρήση πλαϊνής βούρτσας"
+                "name": "Χρήση πλευρικής βούρτσας"
             },
             "filtersqm": {
                 "name": "Χρήση φίλτρου"
@@ -1210,7 +1234,7 @@
                 "name": "Χρήση κύριας βούρτσας"
             },
             "sidebrushusage": {
-                "name": "Χρήση πλαϊνής βούρτσας"
+                "name": "Χρήση πλευρικής βούρτσας"
             },
             "mopusage": {
                 "name": "Χρήση σφουγγαρίστρας"

--- a/custom_components/electrolux/translations/es.json
+++ b/custom_components/electrolux/translations/es.json
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Se enviaron demasiados comandos. Espere un momento e inténtelo de nuevo."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} no se puede ajustar en el modo actual."
+        },
         "control_locked": {
             "message": "{attr} está bloqueado en {value} para el programa {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "La velocidad del ventilador no se puede ajustar en el modo {mode}. Cambie primero al modo Manual para controlar la velocidad del ventilador."
         },
         "food_probe_locked_by_program": {
             "message": "La temperatura de la sonda de alimentos está bloqueada en {value}°C para el programa {program}."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "El valor {value} está por debajo del mínimo {min_val} para {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Iniciar limpieza de zona",
+            "description": "Inicie una sesión de limpieza por zonas en un robot aspirador PUREi9. Los UUID de zona y el UUID del mapa persistente se encuentran en los diagnósticos de integración (mapData/mapMatch/zones y persistenteMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "ID de mapa persistente",
+                    "description": "UUID del mapa persistente a utilizar (de diagnóstico: persistenteMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Zonas",
+                    "description": "Listado de zonas a limpiar. Cada entrada necesita Zone_id (UUID de mapData/mapMatch/zones[].uuid) y power_mode opcional (1=silencioso, 2=inteligente, 3=encendido, predeterminado 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -396,13 +420,13 @@
                 "name": "enjuagues adicionales"
             },
             "maint1_id": {
-                "name": "Identificación del elemento de mantenimiento 1"
+                "name": "Identificación del artículo 1 de mantenimiento"
             },
             "maint2_id": {
                 "name": "Identificación del elemento de mantenimiento 2"
             },
             "maint2_threshold": {
-                "name": "Umbral del elemento 2 de mantenimiento"
+                "name": "Umbral del elemento de mantenimiento 2"
             },
             "maint3_id": {
                 "name": "Identificación del elemento de mantenimiento 3"
@@ -571,7 +595,7 @@
                 "name": "Temperatura de visualización f"
             },
             "processphase": {
-                "name": "Fase del proceso"
+                "name": "Fase de proceso"
             },
             "program": {
                 "name": "Programa"
@@ -721,7 +745,7 @@
                 "name": "Umbral de compra de filtro de agua (flujo)"
             },
             "waterfilterflowchangethreshold": {
-                "name": "Umbral de cambio de filtro de agua (caudal)"
+                "name": "Umbral de cambio de filtro de agua (flujo)"
             },
             "waterfilterlifetimebuythreshold": {
                 "name": "Umbral de compra de filtro de agua (tiempo)"

--- a/custom_components/electrolux/translations/et.json
+++ b/custom_components/electrolux/translations/et.json
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Saadeti liiga palju käske. Palun oodake veidi ja proovige uuesti."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} ei saa praeguses režiimis reguleerida."
+        },
         "control_locked": {
             "message": "{attr} on programmi {program} jaoks lukustatud aadressil {value}."
+        },
+        "fanspeed_disabled": {
+            "message": "Ventilaatori kiirust ei saa režiimis {mode} reguleerida. Ventilaatori kiiruse reguleerimiseks lülitage esmalt käsitsi režiimi."
         },
         "food_probe_locked_by_program": {
             "message": "Toidusondi temperatuur on programmi {program} jaoks lukustatud {value}°C juures."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "Väärtus {value} on madalam kui {attr} miinimum {min_val}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Alusta tsooni puhastamist",
+            "description": "Alustage tsoonipõhist puhastusseanssi PUREi9 robottolmuimejaga. Tsooni UUID-d ja püsikaardi UUID leiate integratsioonidiagnostikast (mapData/mapMatch/zones ja persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Püsiv kaardi ID",
+                    "description": "Kasutatava püsiva kaardi UUID (diagnostikast: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Tsoonid",
+                    "description": "Puhastatavate tsoonide loend. Iga kirje vajab tsooni_id (UUID alates mapData/mapMatch/zones[].uuid) ja valikulist power_mode (1 = vaikne, 2 = nutikas, 3 = võimsus, vaikeväärtus 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -249,7 +273,7 @@
                 "name": "Automaatne mopipesu"
             },
             "autodetergentusage": {
-                "name": "Automaatpesuvahendi kasutamine"
+                "name": "Automaatse pesuvahendi kasutamine"
             },
             "mopinstalled": {
                 "name": "Mop paigaldatud"
@@ -282,7 +306,7 @@
                 "name": "Dnd keelake õhukuivatus"
             },
             "isdndpausingairdry": {
-                "name": "Dnd õhukuivatamise peatamine"
+                "name": "Dnd õhukuivatuse peatamine"
             },
             "multifloormap": {
                 "name": "Mitme korruse kaart"
@@ -308,7 +332,7 @@
                 "name": "Võrgu käsk"
             },
             "startupcommand": {
-                "name": "Käivituskäsk"
+                "name": "Käivitamise käsk"
             },
             "manualsync": {
                 "name": "Käsitsi sünkroonimine"
@@ -456,7 +480,7 @@
                 "name": "Selge tsükli isikupärastamine"
             },
             "memoryid": {
-                "name": "Mälu pesa"
+                "name": "Mälupesa"
             },
             "dryingtime": {
                 "name": "Ajastatud kuivatamine (aktiivne)"
@@ -748,7 +772,7 @@
                 "name": "Ukse lukk"
             },
             "totalwashcyclescount": {
-                "name": "Pesutsüklid kokku"
+                "name": "Total wash cycles"
             },
             "totalwashingtime": {
                 "name": "Pesemise koguaeg"
@@ -799,7 +823,7 @@
                 "name": "Pehmendaja lisaannus"
             },
             "tankadetloadfornominalweight": {
-                "name": "Tankige nimikaalu jaoks ettenähtud koormus"
+                "name": "Paak tühikoormus nimikaalu jaoks"
             },
             "tankareserve": {
                 "name": "Tanki reservi"
@@ -946,7 +970,7 @@
                 "name": "Energiatarve"
             },
             "energyconsumption": {
-                "name": "Energiatarbimine"
+                "name": "Energy consumption"
             },
             "fanspeedstate": {
                 "name": "Ventilaatori kiiruse olek"
@@ -1177,7 +1201,7 @@
                 "name": "Veejaama tegevus"
             },
             "moproute": {
-                "name": "Mopi marsruut"
+                "name": "Mop route"
             },
             "notificationevent": {
                 "name": "Teavitussündmus"
@@ -1443,7 +1467,7 @@
                 "name": "Intensiivne"
             },
             "reverseplus": {
-                "name": "Tagurpidi pluss"
+                "name": "Vastupidine pluss"
             },
             "tdeconomy_eco": {
                 "name": "Ökorežiim"

--- a/custom_components/electrolux/translations/fi.json
+++ b/custom_components/electrolux/translations/fi.json
@@ -15,7 +15,7 @@
             },
             "reauth_validate": {
                 "title": "Todenna Electrolux uudelleen",
-                "description": "Electrolux API -tunnuksesi ovat vanhentuneet tai virheelliset. Päivitä ne uusilla Tokeneilla Electroluxin kehittäjäportaalista.\n\nVieraile osoitteessa {url} luodaksesi uusia tunnuksia.",
+                "description": "Electrolux API -tunnuksesi ovat vanhentuneet tai virheellisiä. Päivitä ne uusilla Tokeneilla Electroluxin kehittäjäportaalista.\n\nVieraile osoitteessa {url} luodaksesi uusia tunnuksia.",
                 "data": {
                     "api_key": "API-avain",
                     "access_token": "Käyttöoikeustunnus",
@@ -90,7 +90,7 @@
     },
     "exceptions": {
         "appliance_disconnected": {
-            "message": "Laite on irrotettu tai ei ole käytettävissä. Tarkista laitteen verkkoyhteys."
+            "message": "Appliance is disconnected or not available. Check the appliance's network connection."
         },
         "appliance_offline": {
             "message": "Laite on offline-tilassa (nykyinen tila: {state}). Tarkista, että laite on kytketty verkkovirtaan, verkkoyhteys ja pilvipalveluihin."
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Liian monta komentoa lähetetty. Odota hetki ja yritä uudelleen."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} ei voida säätää nykyisessä tilassa."
+        },
         "control_locked": {
             "message": "{attr} on lukittu osoitteessa {value} ohjelmalle {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "Tuulettimen nopeutta ei voi säätää tilassa {mode}. Vaihda ensin manuaaliseen tilaan ohjataksesi tuulettimen nopeutta."
         },
         "food_probe_locked_by_program": {
             "message": "Ruokaanturin lämpötila on lukittu {value}°C:een ohjelmalle {program}."
@@ -144,6 +150,24 @@
             "message": "Arvo {value} on alle vähimmäisarvon {min_val} kohteelle {attr}."
         }
     },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Aloita vyöhykkeen puhdistus",
+            "description": "Aloita vyöhykepohjainen puhdistusistunto PUREi9-robottiimurilla. Vyöhykkeen UUID:t ja pysyvä kartan UUID löytyvät integrointidiagnostiikasta (mapData/mapMatch/zones ja persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Pysyvä karttatunnus",
+                    "description": "Käytettävän pysyvän kartan UUID (diagnostiikasta: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Alueet",
+                    "description": "Luettelo puhdistettavista vyöhykkeistä. Jokainen merkintä tarvitsee zone_id:n (UUID kohteesta mapData/mapMatch/zones[].uuid) ja valinnaisen power_mode-arvon (1=hiljainen, 2=älykäs, 3=teho, oletusarvo 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
+        }
+    },
     "entity": {
         "binary_sensor": {
             "connectivitystate": {
@@ -156,7 +180,7 @@
                 "name": "Ruoka-anturi"
             },
             "foodprobesupported": {
-                "name": "Food Probe Support"
+                "name": "Ruokakoettimen tuki"
             },
             "watertrayinsertionstate": {
                 "name": "Vesisäiliö"
@@ -189,7 +213,7 @@
                 "name": "Huolto vaaditaan"
             },
             "maint2_occured": {
-                "name": "Huoltokohde 2 tapahtui"
+                "name": "Huoltokohta 2 tapahtui"
             },
             "maint3_occured": {
                 "name": "Huoltokohta 3 tapahtui"
@@ -411,7 +435,7 @@
                 "name": "Huoltokohteen 3 kynnys"
             },
             "maint4_id": {
-                "name": "Huoltokohteen 4 tunnus"
+                "name": "Huoltokohde 4 id"
             },
             "maint4_threshold": {
                 "name": "Huoltokohteen 4 kynnys"
@@ -432,7 +456,7 @@
                 "name": "Huoltokohde 7 id"
             },
             "maint7_threshold": {
-                "name": "Huoltokohteen 7 kynnys"
+                "name": "Maintenance item 7 threshold"
             },
             "maint8_id": {
                 "name": "Huoltokohde 8 id"
@@ -544,7 +568,7 @@
                 "name": "Kaukosäädin"
             },
             "totalcyclecounter": {
-                "name": "Total cycle counter"
+                "name": "Kokonaisjaksolaskuri"
             },
             "appliancetotalworkingtime": {
                 "name": "Laitteen kokonaistyöaika"
@@ -733,7 +757,7 @@
                 "name": "Emolevyn ohjelmistoversio"
             },
             "defaultextrarinse": {
-                "name": "Oletusarvoinen lisähuuhtelu"
+                "name": "Oletuslisähuuhtelu"
             },
             "cyclephase": {
                 "name": "Kiertovaihe"
@@ -832,7 +856,7 @@
                 "name": "Etäilmoitus odottaa"
             },
             "minfinishintime": {
-                "name": "Minimi viimeistely ajassa"
+                "name": "Minimum finish in time"
             },
             "ewx1493a_wmeconomy": {
                 "name": "Taloudellinen tila"
@@ -1177,7 +1201,7 @@
                 "name": "Vesiaseman toiminta"
             },
             "moproute": {
-                "name": "Moppireitti"
+                "name": "Mop reitti"
             },
             "notificationevent": {
                 "name": "Ilmoitustapahtuma"
@@ -1216,7 +1240,7 @@
                 "name": "Mopin käyttö"
             },
             "moparmextensionfreq": {
-                "name": "Moppivarren pidennystaajuus"
+                "name": "Moppivarren jatketaajuus"
             },
             "mopdrytime": {
                 "name": "Mopin kuivumisaika"
@@ -1356,7 +1380,7 @@
                 "name": "Esipesu"
             },
             "ewx1493a_anticreasenosteam": {
-                "name": "Rypistymisen esto (ei höyryä)"
+                "name": "Rypistymisenesto (ei höyryä)"
             },
             "ewx1493a_anticreasewsteam": {
                 "name": "Rypistymistä estävä höyryllä"
@@ -1476,7 +1500,7 @@
                 "name": "Ruiskutusalue"
             },
             "autodooropener": {
-                "name": "Automaattinen ovenavaaja"
+                "name": "Automaattinen oven avaaja"
             },
             "sanitizeoption": {
                 "name": "Puhdistaa"

--- a/custom_components/electrolux/translations/fr.json
+++ b/custom_components/electrolux/translations/fr.json
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Trop de commandes envoyées. Veuillez patienter un moment et réessayer."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} ne peut pas être ajusté dans le mode actuel."
+        },
         "control_locked": {
             "message": "{attr} est verrouillé à {value} pour le programme {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "La vitesse du ventilateur ne peut pas être réglée en mode {mode}. Passez d’abord en mode manuel pour contrôler la vitesse du ventilateur."
         },
         "food_probe_locked_by_program": {
             "message": "La température de la sonde alimentaire est verrouillée à {value}°C pour le programme {program}."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "La valeur {value} est inférieure au minimum {min_val} pour {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Démarrer le nettoyage de la zone",
+            "description": "Démarrez une session de nettoyage par zone sur un robot aspirateur PUREi9. Les UUID de zone et l'UUID de carte persistante se trouvent dans les diagnostics d'intégration (mapData/mapMatch/zones et persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "ID de carte persistant",
+                    "description": "UUID de la carte persistante à utiliser (à partir des diagnostics : persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Zones",
+                    "description": "Liste des zones à nettoyer. Chaque entrée nécessite zone_id (UUID de mapData/mapMatch/zones[].uuid) et power_mode facultatif (1=silencieux, 2=intelligent, 3=alimentation, 1 par défaut).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -399,7 +423,7 @@
                 "name": "Identifiant de l'élément d'entretien 1"
             },
             "maint2_id": {
-                "name": "Identifiant de l'élément d'entretien 2"
+                "name": "Identifiant de l'élément d'entretien 2"
             },
             "maint2_threshold": {
                 "name": "Seuil de l'élément de maintenance 2"
@@ -426,7 +450,7 @@
                 "name": "Identifiant de l'élément d'entretien 6"
             },
             "maint6_threshold": {
-                "name": "Seuil du point de maintenance 6"
+                "name": "Seuil du point d'entretien 6"
             },
             "maint7_id": {
                 "name": "Identifiant de l'élément d'entretien 7"
@@ -441,13 +465,13 @@
                 "name": "Seuil du point de maintenance 8"
             },
             "maint9_id": {
-                "name": "Identifiant de l'élément d'entretien 9"
+                "name": "Identifiant de l'élément d'entretien 9"
             },
             "maint9_threshold": {
                 "name": "Seuil du point d'entretien 9"
             },
             "maint10_id": {
-                "name": "Identifiant de l'élément d'entretien 10"
+                "name": "Identifiant de l'élément d'entretien 10"
             },
             "maint10_threshold": {
                 "name": "Seuil de l'élément d'entretien 10"

--- a/custom_components/electrolux/translations/hr.json
+++ b/custom_components/electrolux/translations/hr.json
@@ -15,7 +15,7 @@
             },
             "reauth_validate": {
                 "title": "Ponovno provjerite autentičnost Electroluxa",
-                "description": "Vaši Electrolux API tokeni su istekli ili su nevažeći. Ažurirajte ih novim tokenima s portala za razvojne programere Electrolux.\n\nPosjetite {url} za generiranje novih tokena.",
+                "description": "Vaši Electrolux API tokeni su istekli ili su nevažeći. Ažurirajte ih novim tokenima s Electroluxovog portala za razvojne programere.\n\nPosjetite {url} za generiranje novih tokena.",
                 "data": {
                     "api_key": "API ključ",
                     "access_token": "Pristupni token",
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Poslano je previše naredbi. Pričekajte trenutak i pokušajte ponovo."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} nije moguće prilagoditi u trenutnom načinu rada."
+        },
         "control_locked": {
             "message": "{attr} je zaključan na {value} za program {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "Brzina ventilatora ne može se podesiti u načinu rada {mode}. Najprije prijeđite na ručni način rada za kontrolu brzine ventilatora."
         },
         "food_probe_locked_by_program": {
             "message": "Temperatura sonde za hranu je zaključana na {value}°C za program {program}."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "Vrijednost {value} ispod je minimalne {min_val} za {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Pokrenite čišćenje zone",
+            "description": "Započnite sesiju čišćenja po zonama na robotskom usisavaču PUREi9. UUID-ovi zona i trajni UUID karte nalaze se u dijagnostici integracije (mapData/mapMatch/zones i persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Postojani ID karte",
+                    "description": "UUID trajne karte za korištenje (iz dijagnostike: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Zone",
+                    "description": "Popis zona za čišćenje. Svaki unos treba zone_id (UUID iz mapData/mapMatch/zones[].uuid) i izborni power_mode (1=tih, 2=pametan, 3=napajanje, zadano 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -192,7 +216,7 @@
                 "name": "Pojavila se stavka održavanja 2"
             },
             "maint3_occured": {
-                "name": "Pojavila se stavka održavanja 3"
+                "name": "Dogodila se stavka održavanja 3"
             },
             "maint4_occured": {
                 "name": "Pojavila se stavka održavanja 4"
@@ -255,7 +279,7 @@
                 "name": "Mop instaliran"
             },
             "incharger": {
-                "name": "In charger"
+                "name": "U punjaču"
             },
             "returntowash": {
                 "name": "Vratite se na pranje"
@@ -351,7 +375,7 @@
                 "name": "Ciljano trajanje"
             },
             "targetfoodprobetemperaturec": {
-                "name": "Target food probe temperature c"
+                "name": "Ciljana temperatura sonde za hranu c"
             },
             "targetfoodprobetemperaturef": {
                 "name": "Ciljana temperatura sonde za hranu f"
@@ -366,7 +390,7 @@
                 "name": "Vrijeme podsjetnika gornje pećnice"
             },
             "appliancelocaltimeoffset": {
-                "name": "Odmak lokalnog vremena uređaja"
+                "name": "Lokalni vremenski pomak uređaja"
             },
             "lightintensity": {
                 "name": "Intenzitet svjetlosti"
@@ -444,7 +468,7 @@
                 "name": "Stavka održavanja 9 id"
             },
             "maint9_threshold": {
-                "name": "Prag stavke održavanja 9"
+                "name": "Prag stavke 9 održavanja"
             },
             "maint10_id": {
                 "name": "Stavka održavanja 10 id"
@@ -673,7 +697,7 @@
                 "name": "Status zračnog filtra"
             },
             "airfilterlifetime": {
-                "name": "Životni vijek filtera za zrak"
+                "name": "Vijek trajanja zračnog filtra"
             },
             "coolingvalvestate": {
                 "name": "Stanje ventila za hlađenje"
@@ -991,7 +1015,7 @@
                 "name": "Log w"
             },
             "demandresponseau": {
-                "name": "Odgovor na potražnju au"
+                "name": "Odgovor na zahtjev au"
             },
             "pm25": {
                 "name": "Pm2,5"
@@ -1048,7 +1072,7 @@
                 "name": "Aqi svjetlo"
             },
             "louverswing": {
-                "name": "Ljuljačka žaluzine"
+                "name": "Ljuljačka žaluzina"
             },
             "quietfan": {
                 "name": "Tihi ventilator"
@@ -1129,7 +1153,7 @@
                 "name": "Greška: senzor temperature/vlažnosti ne reagira"
             },
             "errwatertrayremoved": {
-                "name": "Pogreška: posuda za vodu uklonjena"
+                "name": "Greška: posuda za vodu uklonjena"
             },
             "waterbucketlevel": {
                 "name": "Razina kante za vodu"

--- a/custom_components/electrolux/translations/hu.json
+++ b/custom_components/electrolux/translations/hu.json
@@ -59,7 +59,7 @@
             }
         },
         "error": {
-            "invalid_auth": "Érvénytelen API hitelesítési adatok. Kérjük, ellenőrizze API-kulcsát, hozzáférési tokent és frissítési tokent."
+            "invalid_auth": "Érvénytelen API hitelesítési adatok. Kérjük, ellenőrizze az API-kulcsot, a hozzáférési tokent és a frissítési tokent."
         }
     },
     "issues": {
@@ -69,7 +69,7 @@
                 "step": {
                     "confirm_repair": {
                         "title": "Frissítse az Electrolux API hitelesítő adatait",
-                        "description": "Electrolux API-tokenjei lejártak, és az automatikus frissítés nem sikerült. Kérjük, adja meg az új hitelesítő adatokat az Electrolux fejlesztői portálról a működés visszaállításához.\n\n**Új hitelesítő adatok létrehozása:**\n1. Látogassa meg a {url}\n2. Hozzon létre új API-kulcsot, hozzáférési tokent és frissítési tokent\n3. Írja be őket alább",
+                        "description": "Electrolux API-tokenjei lejártak, és az automatikus frissítés nem sikerült. Kérjük, adjon meg új hitelesítő adatokat az Electrolux fejlesztői portálról a működés visszaállításához.\n\n**Új hitelesítő adatok létrehozása:**\n1. Látogassa meg a {url}\n2. Hozzon létre új API-kulcsot, hozzáférési tokent és frissítési tokent\n3. Írja be őket alább",
                         "data": {
                             "api_key": "API kulcs",
                             "access_token": "Hozzáférési token",
@@ -78,7 +78,7 @@
                     }
                 },
                 "error": {
-                    "invalid_auth": "Érvénytelen API hitelesítési adatok. Kérjük, ellenőrizze API-kulcsát, hozzáférési tokent és frissítési tokent.",
+                    "invalid_auth": "Érvénytelen API hitelesítési adatok. Kérjük, ellenőrizze az API-kulcsot, a hozzáférési tokent és a frissítési tokent.",
                     "invalid_format": "Érvénytelen hitelesítő adatformátum. Kérjük, győződjön meg róla, hogy minden mezőt helyesen töltött ki.",
                     "entry_not_found": "A konfigurációs bejegyzés nem található."
                 },
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Túl sok parancs lett elküldve. Kérjük, várjon egy pillanatot, és próbálja újra."
         },
+        "control_disabled_by_mode": {
+            "message": "A {attr} nem állítható be az aktuális módban."
+        },
         "control_locked": {
             "message": "A {attr} zárolva van a {value} címen a {program} programhoz."
+        },
+        "fanspeed_disabled": {
+            "message": "A ventilátor sebessége nem állítható {mode} módban. A ventilátor sebességének szabályozásához először váltson kézi üzemmódba."
         },
         "food_probe_locked_by_program": {
             "message": "Az élelmiszerszonda hőmérséklete {value}°C-on zárva van a {program} programhoz."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "A {value} érték a {attr} minimális {min_val} értéke alatt van."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Indítsa el a zóna tisztítását",
+            "description": "Indítson el egy zónaalapú tisztítási munkamenetet egy PUREi9 robotporszívóval. A zóna UUID-k és a perzisztens leképezési UUID megtalálhatók az integrációs diagnosztikában (mapData/mapMatch/zones és persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Állandó térképazonosító",
+                    "description": "A használandó állandó térkép UUID-je (a diagnosztikából: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Zónák",
+                    "description": "A tisztítandó zónák listája. Minden bejegyzéshez szükséges a zone_id (UUID a mapData/mapMatch/zones[].uuid-ból) és az opcionális power_mode (1=csendes, 2=okos, 3=teljesítmény, alapértelmezett 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -243,7 +267,7 @@
                 "name": "Automatikus felmosókar hosszabbító"
             },
             "automopdry": {
-                "name": "Automatikus mop száraz"
+                "name": "Automatikus felmosószárító"
             },
             "automopwash": {
                 "name": "Automatikus mop mosás"
@@ -351,7 +375,7 @@
                 "name": "Cél időtartam"
             },
             "targetfoodprobetemperaturec": {
-                "name": "Az élelmiszerszonda célhőmérséklete c"
+                "name": "Ételszonda célhőmérséklete c"
             },
             "targetfoodprobetemperaturef": {
                 "name": "Élelmiszer-szonda célhőmérséklete f"
@@ -517,7 +541,7 @@
                 "name": "Niu sw frissítés leírása"
             },
             "otastate": {
-                "name": "Hálózati interfész ota állapot"
+                "name": "A hálózati interfész ota állapota"
             },
             "swancandrevision": {
                 "name": "Sw anc és revízió"
@@ -721,7 +745,7 @@
                 "name": "Vízszűrő vásárlási küszöb (áramlás)"
             },
             "waterfilterflowchangethreshold": {
-                "name": "Vízszűrő cseréjének küszöbértéke (áramlás)"
+                "name": "Vízszűrő csereküszöb (áramlás)"
             },
             "waterfilterlifetimebuythreshold": {
                 "name": "Vízszűrő vásárlási küszöb (idő)"
@@ -835,7 +859,7 @@
                 "name": "Minimális befejezési idő"
             },
             "ewx1493a_wmeconomy": {
-                "name": "Gazdaságos mód"
+                "name": "Gazdaságos üzemmód"
             },
             "adfinetunedetlevel": {
                 "name": "Automatikus adagoló mosószer finomhangolása"
@@ -1078,7 +1102,7 @@
                 "name": "Pm2,5 (hozzávetőleges)"
             },
             "uvruntime": {
-                "name": "UV futási idő"
+                "name": "UV futásidő"
             },
             "schedulingstate": {
                 "name": "Ütemezési állapot"
@@ -1114,7 +1138,7 @@
                 "name": "Hiba: a 2. szűrő nfc címke nincs jelen"
             },
             "errnfctagpresnotvalid_1": {
-                "name": "Hiba: 1. szűrő nfc címke érvénytelen"
+                "name": "Hiba: az 1. szűrő nfc címke érvénytelen"
             },
             "errnfctagpresnotvalid_2": {
                 "name": "Hiba: a filter 2 nfc címke érvénytelen"
@@ -1228,7 +1252,7 @@
                 "name": "Mopmosás gyakorisága"
             },
             "mopwashfreqtype": {
-                "name": "Mop wash frequency type"
+                "name": "Mop mosási gyakoriság típusa"
             },
             "numberofcleaningrepetitions": {
                 "name": "Tisztítási ismétlések"
@@ -1261,7 +1285,7 @@
                 "name": "Dnd befejezési idő"
             },
             "datamodelversion": {
-                "name": "Az adatmodell verziója"
+                "name": "Adatmodell verzió"
             },
             "basestationversion": {
                 "name": "Bázisállomás verzió"
@@ -1365,7 +1389,7 @@
                 "name": "Éjszakai ciklus"
             },
             "ewx1493a_wmeconomy": {
-                "name": "Gazdaságos mód"
+                "name": "Gazdaságos üzemmód"
             },
             "ewx1493a_rinsehold": {
                 "name": "Öblítő tartás"
@@ -1422,7 +1446,7 @@
                 "name": "Éjszakai ciklus"
             },
             "wmeconomy": {
-                "name": "Gazdaságos mód"
+                "name": "Gazdaságos üzemmód"
             },
             "rinsehold": {
                 "name": "Öblítő tartás"

--- a/custom_components/electrolux/translations/it.json
+++ b/custom_components/electrolux/translations/it.json
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Troppi comandi inviati. Attendi un attimo e riprova."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} non può essere regolato nella modalità corrente."
+        },
         "control_locked": {
             "message": "{attr} è bloccato su {value} per il programma {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "La velocità della ventola non può essere regolata in modalità {mode}. Passare prima alla modalità manuale per controllare la velocità della ventola."
         },
         "food_probe_locked_by_program": {
             "message": "La temperatura della sonda alimentare è bloccata a {value}°C per il programma {program}."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "Il valore {value} è inferiore al minimo {min_val} per {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Avvia la pulizia della zona",
+            "description": "Avvia una sessione di pulizia a zone su un robot aspirapolvere PUREi9. Gli UUID di zona e l'UUID della mappa persistente si trovano nella diagnostica di integrazione (mapData/mapMatch/zones e persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "ID mappa persistente",
+                    "description": "UUID della mappa persistente da utilizzare (dalla diagnostica: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Zone",
+                    "description": "Elenco delle zone da pulire. Ogni voce necessita di zone_id (UUID da mapData/mapMatch/zones[].uuid) e power_mode opzionale (1=silenzioso, 2=intelligente, 3=potenza, predefinito 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -390,7 +414,7 @@
                 "name": "Regolazione fine del livello del detersivo"
             },
             "adfinetunesoftlevel": {
-                "name": "Regolazione fine del livello dell'ammorbidente"
+                "name": "Regolazione fine del livello dell'addolcitore"
             },
             "extrarinsenumber": {
                 "name": "Risciacqui aggiuntivi"
@@ -426,7 +450,7 @@
                 "name": "Articolo di manutenzione 6 id"
             },
             "maint6_threshold": {
-                "name": "Soglia dell'elemento 6 della manutenzione"
+                "name": "Soglia dell'articolo 6 della manutenzione"
             },
             "maint7_id": {
                 "name": "Articolo di manutenzione 7 id"
@@ -709,7 +733,7 @@
                 "name": "Stato del distributore di ghiaccio"
             },
             "icetraywaterfillsetting": {
-                "name": "Ice tray fill setting"
+                "name": "Impostazione di riempimento della vaschetta del ghiaccio"
             },
             "airfilterlifetimebuythreshold": {
                 "name": "Soglia di acquisto del filtro dell'aria"
@@ -925,7 +949,7 @@
                 "name": "Stato vario"
             },
             "ambienttemperaturec": {
-                "name": "Temperatura ambientec"
+                "name": "Temperatura ambiente c"
             },
             "ambienttemperaturef": {
                 "name": "Temperatura ambiente f"
@@ -1069,7 +1093,7 @@
                 "name": "Tipo di filtro 2"
             },
             "filteruid_1": {
-                "name": "Filtra 1 uid tag NFC"
+                "name": "Filtra 1 uid del tag NFC"
             },
             "filteruid_2": {
                 "name": "Filtra 2 uid tag NFC"

--- a/custom_components/electrolux/translations/lb.json
+++ b/custom_components/electrolux/translations/lb.json
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Ze vill Kommandoen geschéckt. Waart e Moment a probéiert nach eng Kéier."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} kann net am aktuellen Modus ugepasst ginn."
+        },
         "control_locked": {
             "message": "{attr} ass um {value} fir de Programm {program} gespaart."
+        },
+        "fanspeed_disabled": {
+            "message": "Fan Vitesse kann net am Modus {mode} ugepasst ginn. Wiesselt als éischt op de manuelle Modus fir d'Fangeschwindegkeet ze kontrolléieren."
         },
         "food_probe_locked_by_program": {
             "message": "D'Liewensmëttelsondetemperatur ass bei {value}°C fir de Programm {program} gespaart."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "De Wäert {value} ass ënner dem Minimum {min_val} fir {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Start Zone Botzen",
+            "description": "Start eng Zone-baséiert Botzen Sessioun op engem PUREi9 Roboter Vakuum. Zone UUIDs an déi persistent Kaart UUID ginn an der Integratiounsdiagnostik fonnt (mapData/mapMatch/zones and persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Persistent Kaart ID",
+                    "description": "UUID vun der persistent Kaart ze benotzen (vun Diagnostik: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Zonen",
+                    "description": "Lëscht vun Zonen ze botzen. All Entrée brauch zone_id (UUID aus mapData/mapMatch/zones[].uuid) an optional power_mode (1 = roueg, 2 = Smart, 3 = Muecht, Standard 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -228,7 +252,7 @@
                 "name": "Ac Alarmer ënnerstëtzt"
             },
             "hepafilterinsertedstate": {
-                "name": "Hepa Filter agebaut"
+                "name": "Hepa Filter agesat"
             },
             "dooropen": {
                 "name": "Dier op"
@@ -243,7 +267,7 @@
                 "name": "Auto Mop Arm Extensioun"
             },
             "automopdry": {
-                "name": "Auto mop dréchen"
+                "name": "Automop dréchen"
             },
             "automopwash": {
                 "name": "Automatesch Wäschmaschinn"
@@ -390,7 +414,7 @@
                 "name": "Den Niveau vun der Wäschmëttelen finjustéieren"
             },
             "adfinetunesoftlevel": {
-                "name": "Fine Tune softener Niveau"
+                "name": "Fintune d'Weicherniveau"
             },
             "extrarinsenumber": {
                 "name": "Extra Spülen"
@@ -468,7 +492,7 @@
                 "name": "Anti-Kriibs (aktiv)"
             },
             "rinseaidlevel": {
-                "name": "Spullmëttel Niveau"
+                "name": "Spülmëttel Niveau"
             },
             "targethumidity": {
                 "name": "Zil Fiichtegkeet"
@@ -619,7 +643,7 @@
                 "name": "Léifsten Uerdnung Zuel"
             },
             "favoriteselect": {
-                "name": "Léifsten auswielen"
+                "name": "Léifsten wielt"
             },
             "favoritestatus": {
                 "name": "Léifsten Status"
@@ -700,7 +724,7 @@
                 "name": "Extra Kavitéit Upassung"
             },
             "defrosttemperaturec": {
-                "name": "Eis Hiersteller Entdeckungstemperatur"
+                "name": "D'Temperatur vun der Äismaschinn offrost"
             },
             "evaporatorfanstate": {
                 "name": "Eis Maker Fan Staat"
@@ -730,7 +754,7 @@
                 "name": "Waasserfilter änneren Schwell (Zäit)"
             },
             "appliancemainboardswversion": {
-                "name": "Haaptsäit Software Versioun"
+                "name": "Haaptplat Software Versioun"
             },
             "defaultextrarinse": {
                 "name": "Standard extra Spülen"
@@ -874,7 +898,7 @@
                 "name": "Total dréchen Zyklen"
             },
             "totaldryingtime": {
-                "name": "Total Trocknungszäit"
+                "name": "Total dréchen Zäit"
             },
             "totalwashdrycyclescount": {
                 "name": "Total wäschen + dréchen Zyklen"
@@ -1246,7 +1270,7 @@
                 "name": "Upgrade Staat"
             },
             "selectedroomid": {
-                "name": "Ausgewielten Zëmmer ID"
+                "name": "Ausgewielt Sall ID"
             },
             "maxusagedustbox": {
                 "name": "Max Stëbs Këscht Benotzung"
@@ -1338,7 +1362,7 @@
                 "name": "Fënster Notifikatioun"
             },
             "hoodfiltercharcenable": {
-                "name": "Holzkuel Filter aktivéieren"
+                "name": "Kuelfilter aktivéieren"
             },
             "fastmode": {
                 "name": "Frigo schnell Modus"
@@ -1404,7 +1428,7 @@
                 "name": "Automatesch Dosis lokal Fintuning"
             },
             "anticreasenosteam": {
-                "name": "Anti-Kreiz keen Damp"
+                "name": "Anti-Kriis keen Damp"
             },
             "anticreasewsteam": {
                 "name": "Anti-Kriibs mat Damp"
@@ -1473,7 +1497,7 @@
                 "name": "Glas Pfleeg"
             },
             "sprayzoneoption": {
-                "name": "Spray Zone"
+                "name": "Sprayzone"
             },
             "autodooropener": {
                 "name": "Auto Dierenöffner"

--- a/custom_components/electrolux/translations/lt.json
+++ b/custom_components/electrolux/translations/lt.json
@@ -3,7 +3,7 @@
         "step": {
             "user": {
                 "title": "„Electrolux“ sąranka",
-                "description": "Prijunkite savo Electrolux prietaisus naudodami API kredencialus iš Electrolux kūrėjų portalo.\n\n**Kad gautumėte API kredencialus:**\n1. Apsilankykite {url}\n2. Užsiregistruokite ir sukurkite programą\n3. Gaukite API raktą, prieigos prieigos raktą ir atnaujinimo prieigos raktą\n\nJei jums reikia pagalbos, apsilankykite integravimo dokumentacijoje.",
+                "description": "Prijunkite savo Electrolux prietaisus naudodami API kredencialus iš Electrolux kūrėjų portalo.\n\n**Kad gautumėte API kredencialus:**\n1. Apsilankykite {url}\n2. Užsiregistruokite ir sukurkite programą\n3. Gaukite API raktą, prieigos prieigos raktą ir atnaujinimo prieigos raktą\n\nJei reikia pagalbos, apsilankykite integravimo dokumentacijoje.",
                 "data": {
                     "api_key": "API raktas",
                     "access_token": "Prieigos prieigos raktas",
@@ -40,14 +40,14 @@
             "already_configured": "Šis įrenginys jau sukonfigūruotas.",
             "already_configured_account": "Šis API raktas jau sukonfigūruotas.",
             "entry_not_found": "Nepavyko rasti konfigūracijos įrašo.",
-            "reconfigure_successful": "Pakartotinis konfigūravimas buvo sėkmingas."
+            "reconfigure_successful": "Iš naujo konfigūruoti pavyko."
         }
     },
     "options": {
         "step": {
             "user": {
                 "title": "„Electrolux“ parinktys",
-                "description": "Atnaujinkite savo Electrolux API kredencialus, jei jų galiojimo laikas baigėsi.\n\n**Kad sugeneruotumėte naujus kredencialus:**\n1. Apsilankykite {url}\n2. Sugeneruokite naują API raktą, prieigos prieigos raktą ir atnaujinimo prieigos raktą\n3. Atnaujinkite toliau pateiktus laukus\n\n**Saugumo pastaba:** Prieigos prieigos rakto ir Atnaujinimo prieigos rakto laukai tyčia paliekami tušti. Visada generuokite naujus žetonus iš portalo – niekada nenaudokite pakartotinai ir nedalykite esamų žetonų.",
+                "description": "Atnaujinkite savo Electrolux API kredencialus, jei jų galiojimo laikas baigėsi.\n\n**Kad sugeneruotumėte naujus kredencialus:**\n1. Apsilankykite {url}\n2. Sugeneruokite naują API raktą, prieigos prieigos raktą ir atnaujinimo prieigos raktą\n3. Atnaujinkite toliau pateiktus laukus\n\n**Saugumo pastaba:** Prieigos prieigos rakto ir Atnaujinimo prieigos rakto laukai tyčia paliekami tušti. Visada generuokite naujus žetonus iš portalo – niekada nenaudokite ir nedalykite esamų žetonų.",
                 "data": {
                     "api_key": "API raktas",
                     "access_token": "Prieigos prieigos raktas",
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Išsiųsta per daug komandų. Šiek tiek palaukite ir bandykite dar kartą."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} negalima reguliuoti dabartiniu režimu."
+        },
         "control_locked": {
             "message": "{attr} yra užrakintas {value} programai {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "Ventiliatoriaus greičio negalima reguliuoti {mode} režimu. Norėdami valdyti ventiliatoriaus greitį, pirmiausia perjunkite į rankinį režimą."
         },
         "food_probe_locked_by_program": {
             "message": "Maisto zondo temperatūra užrakinta {value}°C programai {program}."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "Vertė {value} yra mažesnė už minimalią {min_val} {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Pradėkite zonos valymą",
+            "description": "Pradėkite zonoje pagrįstą valymo seansą naudodami PUREi9 robotą dulkių siurblį. Zonos UUID ir nuolatinis žemėlapio UUID randami integravimo diagnostikoje (mapData/mapMatch/zones ir persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Nuolatinis žemėlapio ID",
+                    "description": "Naudotino nuolatinio žemėlapio UUID (iš diagnostikos: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Zonos",
+                    "description": "Valytinų zonų sąrašas. Kiekvienam įrašui reikalingas zonos_id (UUID iš mapData/mapMatch/zones[].uuid) ir pasirenkamas power_mode (1 = tylus, 2 = išmanusis, 3 = galia, numatytasis 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -300,7 +324,7 @@
                 "name": "Valymo būsena"
             },
             "ovfood_probe_end_of_cooking": {
-                "name": "Gaminimo pabaigos zondas"
+                "name": "Probe End of Cooking"
             }
         },
         "button": {
@@ -351,7 +375,7 @@
                 "name": "Tikslinė trukmė"
             },
             "targetfoodprobetemperaturec": {
-                "name": "Tikslinė maisto zondo temperatūra c"
+                "name": "Target food probe temperature c"
             },
             "targetfoodprobetemperaturef": {
                 "name": "Tikslinė maisto zondo temperatūra f"
@@ -366,7 +390,7 @@
                 "name": "Viršutinės krosnies priminimo laikas"
             },
             "appliancelocaltimeoffset": {
-                "name": "Prietaiso vietos laiko nuokrypis"
+                "name": "Prietaiso vietinio laiko nuokrypis"
             },
             "lightintensity": {
                 "name": "Šviesos intensyvumas"
@@ -396,7 +420,7 @@
                 "name": "Papildomi skalavimai"
             },
             "maint1_id": {
-                "name": "Priežiūros prekės 1 id"
+                "name": "Maintenance item 1 id"
             },
             "maint2_id": {
                 "name": "Priežiūros elemento 2 id"
@@ -970,7 +994,7 @@
                 "name": "Planuotojo sesija"
             },
             "schedulermode": {
-                "name": "Planuoklio režimas"
+                "name": "Planavimo režimas"
             },
             "totalruntime": {
                 "name": "Bendras vykdymo laikas"
@@ -1276,7 +1300,7 @@
                 "name": "Standartinis laiko juostos pavadinimas"
             },
             "bintank": {
-                "name": "Šiukšlių bakas"
+                "name": "Šiukšliadėžės bakas"
             },
             "setvoicevolume": {
                 "name": "Balso garsumo lygis"
@@ -1309,7 +1333,7 @@
                 "name": "Valymo būsena"
             },
             "ovfood_probe_end_of_cooking": {
-                "name": "Gaminimo pabaigos zondas"
+                "name": "Probe End of Cooking"
             },
             "connectivitystate": {
                 "name": "Ryšio būsena"

--- a/custom_components/electrolux/translations/lv.json
+++ b/custom_components/electrolux/translations/lv.json
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Nosūtīts pārāk daudz komandu. Lūdzu, uzgaidiet brīdi un mēģiniet vēlreiz."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} nevar pielāgot pašreizējā režīmā."
+        },
         "control_locked": {
-            "message": "{attr} ir bloķēts {value} programmai {program}."
+            "message": "{attr} is locked at {value} for program {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "Ventilatora ātrumu nevar regulēt režīmā {mode}. Vispirms pārslēdzieties uz manuālo režīmu, lai kontrolētu ventilatora ātrumu."
         },
         "food_probe_locked_by_program": {
             "message": "Pārtikas zondes temperatūra programmai {program} ir bloķēta {value}°C."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "Vērtība {value} ir zemāka par minimālo {min_val} {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Sāciet zonas tīrīšanu",
+            "description": "Sāciet uz zonu balstītu tīrīšanas sesiju ar PUREi9 robota putekļsūcēju. Zonu UUID un pastāvīgās kartes UUID ir atrodami integrācijas diagnostikā (mapData/mapMatch/zones un persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Pastāvīgs kartes ID",
+                    "description": "Izmantojamās pastāvīgās kartes UUID (no diagnostikas: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Zonas",
+                    "description": "Tīrāmo zonu saraksts. Katram ierakstam ir nepieciešams zone_id (UUID no mapData/mapMatch/zones[].uuid) un izvēles power_mode (1=kluss, 2=viedais, 3=jauda, ​​noklusējuma 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -228,7 +252,7 @@
                 "name": "Atbalstīti maiņstrāvas brīdinājumi"
             },
             "hepafilterinsertedstate": {
-                "name": "Ielikts hepa filtrs"
+                "name": "Ielikts Hepa filtrs"
             },
             "dooropen": {
                 "name": "Durvis vaļā"
@@ -282,7 +306,7 @@
                 "name": "Neizslēdziet gaisa žāvēšanu"
             },
             "isdndpausingairdry": {
-                "name": "Dnd apturēt gaisa žāvēšanu"
+                "name": "Dnd apturēt gaisa sausumu"
             },
             "multifloormap": {
                 "name": "Daudzstāvu karte"
@@ -291,7 +315,7 @@
                 "name": "Vairāku stāvu kartes automātiskais slēdzis"
             },
             "robotposereliable": {
-                "name": "Robot pose reliable"
+                "name": "Uzticama robota poza"
             },
             "ovwater_tank_empty": {
                 "name": "Ūdens tvertnes statuss"
@@ -420,13 +444,13 @@
                 "name": "Apkopes vienums 5 id"
             },
             "maint5_threshold": {
-                "name": "Apkopes pozīcijas 5 slieksnis"
+                "name": "Apkopes posteņa 5 slieksnis"
             },
             "maint6_id": {
                 "name": "Apkopes vienums 6 id"
             },
             "maint6_threshold": {
-                "name": "Apkopes posteņa 6 slieksnis"
+                "name": "Apkopes pozīcijas 6 slieksnis"
             },
             "maint7_id": {
                 "name": "Apkopes vienums 7 id"
@@ -586,7 +610,7 @@
                 "name": "Cepeškrāsns augšējā uzsildīšana ir pabeigta"
             },
             "targetdurationendaction": {
-                "name": "Augšējā krāsns mērķa ilguma beigu darbība"
+                "name": "Upper oven target duration end action"
             },
             "targetfoodprobetemperatureendaction": {
                 "name": "Augšējā cepeškrāsns mērķa pārtikas zondes temperatūras beigu darbība"
@@ -787,7 +811,7 @@
                 "name": "Ūdens mīkstinātāja režīms"
             },
             "maint1_threshold": {
-                "name": "Uzturēšanas slieksnis"
+                "name": "Maintenance threshold"
             },
             "detergentextradosage": {
                 "name": "Mazgāšanas līdzekļa papildu deva"
@@ -973,7 +997,7 @@
                 "name": "Plānotāja režīms"
             },
             "totalruntime": {
-                "name": "Kopējais izpildes laiks"
+                "name": "Kopējais izpildlaiks"
             },
             "compressorcoolingruntime": {
                 "name": "Kompresora dzesēšanas darbības laiks"
@@ -1069,7 +1093,7 @@
                 "name": "Filtra veids 2"
             },
             "filteruid_1": {
-                "name": "Filtrēt 1 nfc taga uid"
+                "name": "Filtrs 1 nfc taga uid"
             },
             "filteruid_2": {
                 "name": "Filtrs 2 nfc taga uid"
@@ -1093,7 +1117,7 @@
                 "name": "Kļūda: displeja paneļa komunikācija"
             },
             "errcommsensoruibrd": {
-                "name": "Kļūda: ui dēļa komunikācija"
+                "name": "Error: ui board communication"
             },
             "signalstrength": {
                 "name": "Signāla stiprums"
@@ -1270,7 +1294,7 @@
                 "name": "Ierīces ID"
             },
             "timezonedaylightrule": {
-                "name": "Time zone daylight rule"
+                "name": "Laika joslas dienasgaismas likums"
             },
             "timezonestandardname": {
                 "name": "Laika joslas standarta nosaukums"
@@ -1392,10 +1416,10 @@
                 "name": "Tvaika režīms"
             },
             "ewx1493a_ultramix": {
-                "name": "Ultra maisījums"
+                "name": "Ultra mix"
             },
             "ewx1493a_wetmode": {
-                "name": "Mitrā režīms"
+                "name": "Wet mode"
             },
             "networkinterfacealwayson": {
                 "name": "Tīkls vienmēr ieslēgts"
@@ -1410,7 +1434,7 @@
                 "name": "Pretburzīšanās ar tvaiku"
             },
             "ultramix": {
-                "name": "Ultra maisījums"
+                "name": "Ultra mix"
             },
             "prewashphase": {
                 "name": "Iepriekšēja mazgāšana"
@@ -1479,7 +1503,7 @@
                 "name": "Automātiskais durvju atvērējs"
             },
             "sanitizeoption": {
-                "name": "Dezinficējiet"
+                "name": "Dezinficē"
             },
             "onerackoption": {
                 "name": "Viens statīvs"

--- a/custom_components/electrolux/translations/nl.json
+++ b/custom_components/electrolux/translations/nl.json
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Te veel opdrachten verzonden. Wacht even en probeer het opnieuw."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} kan niet worden aangepast in de huidige modus."
+        },
         "control_locked": {
             "message": "{attr} is vergrendeld op {value} voor programma {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "De ventilatorsnelheid kan niet worden aangepast in de modus {mode}. Schakel eerst naar de handmatige modus om de ventilatorsnelheid te regelen."
         },
         "food_probe_locked_by_program": {
             "message": "De temperatuur van de voedselsonde is vergrendeld op {value}°C voor programma {program}."
@@ -144,6 +150,24 @@
             "message": "Waarde {value} ligt onder het minimum {min_val} voor {attr}."
         }
     },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Start zonereiniging",
+            "description": "Start een zonegebaseerde reinigingssessie op een PUREi9 robotstofzuiger. Zone-UUID's en de persistente kaart-UUID zijn te vinden in de integratiediagnostiek (mapData/mapMatch/zones en persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Persistente kaart-ID",
+                    "description": "UUID van de persistente kaart die moet worden gebruikt (uit diagnostische gegevens: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Zones",
+                    "description": "Lijst met te reinigen zones. Elk item heeft zone_id nodig (UUID van mapData/mapMatch/zones[].uuid) en optionele power_mode (1=stil, 2=slim, 3=power, standaard 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
+        }
+    },
     "entity": {
         "binary_sensor": {
             "connectivitystate": {
@@ -180,7 +204,7 @@
                 "name": "Vriezer staat"
             },
             "fanstate": {
-                "name": "Staat van extra ventilatorventilator"
+                "name": "Extra ventilatorstatus"
             },
             "autosense": {
                 "name": "Autodetectie"
@@ -488,7 +512,7 @@
         },
         "select": {
             "displaylight": {
-                "name": "Displaylicht"
+                "name": "Display licht"
             },
             "targettemperaturec": {
                 "name": "Extra oventemperatuur"
@@ -535,7 +559,7 @@
                 "name": "Soort apparaat"
             },
             "capabilityhash": {
-                "name": "Mogelijkheid hasj"
+                "name": "Mogelijkheid hash"
             },
             "cpv": {
                 "name": "Cpv"
@@ -571,7 +595,7 @@
                 "name": "Weergavetemperatuur f"
             },
             "processphase": {
-                "name": "Procesfase"
+                "name": "Proces fase"
             },
             "program": {
                 "name": "Programma"
@@ -631,7 +655,7 @@
                 "name": "Toestelmodus"
             },
             "hobtohoodfanspeed": {
-                "name": "Snelheid ventilator kap"
+                "name": "Snelheid motorkapventilator"
             },
             "hobtohoodstate": {
                 "name": "Kap staat"

--- a/custom_components/electrolux/translations/no.json
+++ b/custom_components/electrolux/translations/no.json
@@ -33,7 +33,7 @@
             }
         },
         "error": {
-            "invalid_auth": "Ugyldig API-legitimasjon. Vennligst sjekk din API-nøkkel, tilgangstoken og oppdateringstoken fra Electrolux utviklerportal."
+            "invalid_auth": "Ugyldig API-legitimasjon. Vennligst sjekk API-nøkkelen, tilgangstoken og oppdateringstoken fra Electrolux utviklerportal."
         },
         "abort": {
             "single_instance_allowed": "Kun én enkelt Electrolux-konfigurasjon er tillatt.",
@@ -47,7 +47,7 @@
         "step": {
             "user": {
                 "title": "Electrolux-alternativer",
-                "description": "Oppdater Electrolux API-legitimasjonen din hvis den har utløpt.\n\n**Slik genererer du ny legitimasjon:**\n1. Besøk {url}\n2. Generer ny API-nøkkel, tilgangstoken og oppdateringstoken\n3. Oppdater feltene nedenfor\n\n**Sikkerhetsmerknad:** Feltene for tilgangstoken og oppdateringstoken er tomme med hensikt. Generer alltid ferske tokens fra portalen - aldri gjenbruk eller del eksisterende tokens.",
+                "description": "Oppdater Electrolux API-legitimasjonen din hvis den har utløpt.\n\n**Slik genererer du ny legitimasjon:**\n1. Besøk {url}\n2. Generer ny API-nøkkel, tilgangstoken og oppdateringstoken\n3. Oppdater feltene nedenfor\n\n**Sikkerhetsmerknad:** Feltene for tilgangstoken og oppdateringstoken er tomme med hensikt. Generer alltid nye tokens fra portalen - aldri gjenbruk eller del eksisterende tokens.",
                 "data": {
                     "api_key": "API-nøkkel",
                     "access_token": "Tilgangstoken",
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "For mange kommandoer sendt. Vent et øyeblikk og prøv igjen."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} kan ikke justeres i gjeldende modus."
+        },
         "control_locked": {
             "message": "{attr} er låst på {value} for program {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "Viftehastigheten kan ikke justeres i {mode}-modus. Bytt til manuell modus først for å kontrollere viftehastigheten."
         },
         "food_probe_locked_by_program": {
             "message": "Matsondetemperaturen er låst til {value}°C for program {program}."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "Verdien {value} er under minimum {min_val} for {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Start sonerengjøring",
+            "description": "Start en sonebasert rengjøringsøkt på en PUREi9 robotstøvsuger. Sone-UUID-er og den vedvarende kart-UUID-en finnes i integrasjonsdiagnostikken (mapData/mapMatch/zones and persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Vedvarende kart-ID",
+                    "description": "UUID for det vedvarende kartet som skal brukes (fra diagnostikk: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Soner",
+                    "description": "Liste over soner som skal rengjøres. Hver oppføring trenger zone_id (UUID fra mapData/mapMatch/zones[].uuid) og valgfri power_mode (1=stille, 2=smart, 3=strøm, standard 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -222,7 +246,7 @@
                 "name": "Øko-modus"
             },
             "hmepn_acairfilterclean": {
-                "name": "Rengjøring av luftfilter kreves"
+                "name": "Rengjør luftfilter nødvendig"
             },
             "hmepn_acalerts": {
                 "name": "Ac-varsler støttes"
@@ -246,7 +270,7 @@
                 "name": "Tørr automatisk mopp"
             },
             "automopwash": {
-                "name": "Automatisk moppvask"
+                "name": "Auto mop wash"
             },
             "autodetergentusage": {
                 "name": "Bruk av automatisk vaskemiddel"
@@ -288,7 +312,7 @@
                 "name": "Kart i flere etasjer"
             },
             "multifloormapautoswitch": {
-                "name": "Automatisk bryter for kart i flere etasjer"
+                "name": "Autobryter for kart i flere etasjer"
             },
             "robotposereliable": {
                 "name": "Robotposer pålitelig"
@@ -405,7 +429,7 @@
                 "name": "Vedlikeholdspunkt 2 terskel"
             },
             "maint3_id": {
-                "name": "Vedlikeholdspunkt 3 id"
+                "name": "Vedlikehold punkt 3 id"
             },
             "maint3_threshold": {
                 "name": "Vedlikeholdspunkt 3 terskel"
@@ -441,7 +465,7 @@
                 "name": "Vedlikeholdspunkt 8 terskel"
             },
             "maint9_id": {
-                "name": "Vedlikeholdspunkt 9 id"
+                "name": "Vedlikehold punkt 9 id"
             },
             "maint9_threshold": {
                 "name": "Vedlikeholdspunkt 9 terskel"
@@ -841,7 +865,7 @@
                 "name": "Automatisk finjustering av vaskemiddel"
             },
             "adfinetunesoftlevel": {
-                "name": "Finjustering av mykner for automatisk dose"
+                "name": "Autodose mykner finjustere"
             },
             "extrarinsenumber": {
                 "name": "Ekstra skylling"
@@ -889,7 +913,7 @@
                 "name": "Tørrhetsnivå (aktiv)"
             },
             "wmloadweight": {
-                "name": "Dwyw: vask lastevekt"
+                "name": "Dwyw: vask lastvekt"
             },
             "wmloadmoisture": {
                 "name": "Dwyw: vask belastning fuktighet"
@@ -1216,7 +1240,7 @@
                 "name": "Mopp bruk"
             },
             "moparmextensionfreq": {
-                "name": "Mopparmsutvidelsesfrekvens"
+                "name": "Mopp arm forlengelse frekvens"
             },
             "mopdrytime": {
                 "name": "Mopp tørketid"
@@ -1252,7 +1276,7 @@
                 "name": "Maks bruk av støvboks"
             },
             "maxusagestationbag": {
-                "name": "Maks bruk av stasjonspose"
+                "name": "Maks stasjonsposebruk"
             },
             "dndstarttime": {
                 "name": "Dnd starttid"
@@ -1270,7 +1294,7 @@
                 "name": "Enhets-ID"
             },
             "timezonedaylightrule": {
-                "name": "Tidssone dagslysregel"
+                "name": "Tidssone dagslys regel"
             },
             "timezonestandardname": {
                 "name": "Tidssone standardnavn"
@@ -1288,7 +1312,7 @@
                 "name": "Rengjøringsøkt-ID"
             },
             "completion": {
-                "name": "Rengjøring ferdig"
+                "name": "Rengjøring fullført"
             },
             "areacovered": {
                 "name": "Område dekket"
@@ -1297,7 +1321,7 @@
                 "name": "Antall kartsoner"
             },
             "zonestatus": {
-                "name": "Rensesonestatus"
+                "name": "Rengjøringssonestatus"
             },
             "ovwater_tank_empty": {
                 "name": "Vanntankstatus"
@@ -1335,7 +1359,7 @@
                 "name": "Nøkkellyd"
             },
             "windownotification": {
-                "name": "Vindusvarsling"
+                "name": "Vinduvarsling"
             },
             "hoodfiltercharcenable": {
                 "name": "Aktiver kullfilter"

--- a/custom_components/electrolux/translations/pl.json
+++ b/custom_components/electrolux/translations/pl.json
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Wysłano zbyt wiele poleceń. Poczekaj chwilę i spróbuj ponownie."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} nie można regulować w bieżącym trybie."
+        },
         "control_locked": {
             "message": "{attr} jest zablokowany w {value} dla programu {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "Nie można regulować prędkości wentylatora w trybie {mode}. Najpierw przełącz się na tryb ręczny, aby kontrolować prędkość wentylatora."
         },
         "food_probe_locked_by_program": {
             "message": "Temperatura czujnika żywności jest zablokowana na poziomie {value}°C dla programu {program}."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "Wartość {value} jest niższa od minimum {min_val} dla {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Rozpocznij czyszczenie strefy",
+            "description": "Rozpocznij sesję sprzątania strefowego na odkurzaczu robotycznym PUREi9. Identyfikatory UUID stref i trwały identyfikator UUID mapy można znaleźć w diagnostyce integracji (mapData/mapMatch/zones i trwałeMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Stały identyfikator mapy",
+                    "description": "UUID trwałej mapy do użycia (z diagnostyki: permanentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Strefy",
+                    "description": "Lista stref do oczyszczenia. Każdy wpis wymaga identyfikatora strefy (UUID z mapData/mapMatch/zones[].uuid) i opcjonalnego trybu zasilania (1=cichy, 2=inteligentny, 3=moc, domyślnie 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -225,7 +249,7 @@
                 "name": "Wymagane czyszczenie filtra powietrza"
             },
             "hmepn_acalerts": {
-                "name": "Obsługiwane alerty Ac"
+                "name": "Obsługiwane alerty AC"
             },
             "hepafilterinsertedstate": {
                 "name": "Założony filtr Hepa"
@@ -892,7 +916,7 @@
                 "name": "Dwyw: waga wsadu prania"
             },
             "wmloadmoisture": {
-                "name": "Dwyw: wilgotność wsadu do prania"
+                "name": "Dwyw: wilgotność wsadu prania"
             },
             "tdcloudtte": {
                 "name": "Dwyw: szacunkowy czas suszenia"

--- a/custom_components/electrolux/translations/pt.json
+++ b/custom_components/electrolux/translations/pt.json
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Muitos comandos enviados. Aguarde um momento e tente novamente."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} não pode ser ajustado no modo atual."
+        },
         "control_locked": {
             "message": "{attr} está bloqueado em {value} para o programa {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "A velocidade do ventilador não pode ser ajustada no modo {mode}. Mude primeiro para o modo Manual para controlar a velocidade do ventilador."
         },
         "food_probe_locked_by_program": {
             "message": "A temperatura da sonda de alimentos está bloqueada em {value}°C para o programa {program}."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "O valor {value} está abaixo do mínimo {min_val} para {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Iniciar limpeza de zona",
+            "description": "Inicie uma sessão de limpeza baseada em zona em um aspirador robô PUREi9. Os UUIDs de zona e o UUID do mapa persistente são encontrados nos diagnósticos de integração (mapData/mapMatch/zones e persistenteMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "ID do mapa persistente",
+                    "description": "UUID do mapa persistente a ser usado (do diagnóstico: persistenteMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Zonas",
+                    "description": "Lista de zonas a limpar. Cada entrada precisa de zone_id (UUID de mapData/mapMatch/zones[].uuid) e power_mode opcional (1=quiet, 2=smart, 3=power, padrão 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -955,7 +979,7 @@
                 "name": "Estado do filtro"
             },
             "hepafilterlifetime": {
-                "name": "Tempo de vida do filtro Hepa"
+                "name": "Vida útil do filtro Hepa"
             },
             "appliancecategory": {
                 "name": "Categoria de aparelho"
@@ -1249,7 +1273,7 @@
                 "name": "ID do quarto selecionado"
             },
             "maxusagedustbox": {
-                "name": "Uso máximo da caixa de poeira"
+                "name": "Uso máximo da caixa de pó"
             },
             "maxusagestationbag": {
                 "name": "Uso máximo da bolsa da estação"

--- a/custom_components/electrolux/translations/pt_br.json
+++ b/custom_components/electrolux/translations/pt_br.json
@@ -69,7 +69,7 @@
                 "step": {
                     "confirm_repair": {
                         "title": "Atualizar credenciais da API Electrolux",
-                        "description": "Seus tokens de API da Electrolux expiraram e a atualização automática falhou. Insira novas credenciais do Portal do Desenvolvedor Electrolux para restaurar a funcionalidade.\n\n**Para gerar novas credenciais:**\n1. Visite {url}\n2. Gere nova chave de API, token de acesso e token de atualização\n3. Insira-os abaixo",
+                        "description": "Seus tokens de API da Electrolux expiraram e a atualização automática falhou. Insira novas credenciais do Portal do Desenvolvedor Electrolux para restaurar a funcionalidade.\n\n**Para gerar novas credenciais:**\n1. Visite {url}\n2. Gere nova chave de API, token de acesso e token de atualização\n3. Enter them below",
                         "data": {
                             "api_key": "Chave de API",
                             "access_token": "Token de acesso",
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Muitos comandos enviados. Aguarde um momento e tente novamente."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} não pode ser ajustado no modo atual."
+        },
         "control_locked": {
             "message": "{attr} está bloqueado em {value} para o programa {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "A velocidade do ventilador não pode ser ajustada no modo {mode}. Mude primeiro para o modo Manual para controlar a velocidade do ventilador."
         },
         "food_probe_locked_by_program": {
             "message": "A temperatura da sonda de alimentos está bloqueada em {value}°C para o programa {program}."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "O valor {value} está abaixo do mínimo {min_val} para {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Iniciar limpeza de zona",
+            "description": "Inicie uma sessão de limpeza baseada em zona em um aspirador robô PUREi9. Os UUIDs de zona e o UUID do mapa persistente são encontrados nos diagnósticos de integração (mapData/mapMatch/zones e persistenteMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "ID do mapa persistente",
+                    "description": "UUID do mapa persistente a ser usado (do diagnóstico: persistenteMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Zonas",
+                    "description": "Lista de zonas a limpar. Cada entrada precisa de zone_id (UUID de mapData/mapMatch/zones[].uuid) e power_mode opcional (1=quiet, 2=smart, 3=power, padrão 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -1249,7 +1273,7 @@
                 "name": "ID do quarto selecionado"
             },
             "maxusagedustbox": {
-                "name": "Uso máximo da caixa de poeira"
+                "name": "Uso máximo da caixa de pó"
             },
             "maxusagestationbag": {
                 "name": "Uso máximo da bolsa da estação"

--- a/custom_components/electrolux/translations/ro.json
+++ b/custom_components/electrolux/translations/ro.json
@@ -33,7 +33,7 @@
             }
         },
         "error": {
-            "invalid_auth": "Acreditări API nevalide. Vă rugăm să verificați cheia API, Tokenul de acces și Tokenul de reîmprospătare de pe portalul pentru dezvoltatori Electrolux."
+            "invalid_auth": "Acreditări API nevalide. Vă rugăm să verificați cheia API, token-ul de acces și token-ul de reîmprospătare de pe portalul pentru dezvoltatori Electrolux."
         },
         "abort": {
             "single_instance_allowed": "Este permisă doar o singură configurație Electrolux.",
@@ -59,7 +59,7 @@
             }
         },
         "error": {
-            "invalid_auth": "Acreditări API nevalide. Vă rugăm să verificați cheia API, Token-ul de acces și Token-ul de reîmprospătare."
+            "invalid_auth": "Acreditări API nevalide. Vă rugăm să verificați cheia API, token-ul de acces și token-ul de reîmprospătare."
         }
     },
     "issues": {
@@ -69,7 +69,7 @@
                 "step": {
                     "confirm_repair": {
                         "title": "Actualizați acreditările API Electrolux",
-                        "description": "Tokenurile tale Electrolux API au expirat și reîmprospătarea automată a eșuat. Vă rugăm să introduceți noi acreditări de pe Portalul pentru dezvoltatori Electrolux pentru a restabili funcționalitatea.\n\n**Pentru a genera noi acreditări:**\n1. Vizitați {url}\n2. Generați o nouă cheie API, un token de acces și un token de reîmprospătare\n3. Introduceți-le mai jos",
+                        "description": "Tokenurile API Electrolux au expirat și reîmprospătarea automată a eșuat. Vă rugăm să introduceți noi acreditări de pe Portalul pentru dezvoltatori Electrolux pentru a restabili funcționalitatea.\n\n**Pentru a genera noi acreditări:**\n1. Vizitați {url}\n2. Generați o cheie API nouă, un token de acces și un token de reîmprospătare\n3. Introduceți-le mai jos",
                         "data": {
                             "api_key": "Cheia API",
                             "access_token": "Token de acces",
@@ -78,7 +78,7 @@
                     }
                 },
                 "error": {
-                    "invalid_auth": "Acreditări API nevalide. Vă rugăm să verificați cheia API, Token-ul de acces și Token-ul de reîmprospătare.",
+                    "invalid_auth": "Acreditări API nevalide. Vă rugăm să verificați cheia API, token-ul de acces și token-ul de reîmprospătare.",
                     "invalid_format": "Format de autentificare nevalid. Vă rugăm să vă asigurați că toate câmpurile sunt completate corect.",
                     "entry_not_found": "Intrarea de configurare nu a fost găsită."
                 },
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Prea multe comenzi trimise. Vă rugăm să așteptați un moment și să încercați din nou."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} nu poate fi ajustat în modul curent."
+        },
         "control_locked": {
             "message": "{attr} este blocat la {value} pentru programul {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "Viteza ventilatorului nu poate fi reglată în modul {mode}. Treceți mai întâi la modul Manual pentru a controla viteza ventilatorului."
         },
         "food_probe_locked_by_program": {
             "message": "Temperatura sondei alimentare este blocată la {value}°C pentru programul {program}."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "Valoarea {value} este sub minimul {min_val} pentru {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Începeți curățarea zonei",
+            "description": "Începeți o sesiune de curățare pe zone pe un aspirator robot PUREi9. UUID-urile zonei și UUID-ul hărții persistente se găsesc în diagnosticele de integrare (mapData/mapMatch/zones și persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "ID-ul hărții persistent",
+                    "description": "UUID-ul hărții persistente de utilizat (din diagnosticare: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Zonele",
+                    "description": "Lista zonelor de curățat. Fiecare intrare are nevoie de zone_id (UUID din mapData/mapMatch/zones[].uuid) și opțional power_mode (1=liniștit, 2=inteligent, 3=putere, implicit 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {
@@ -210,7 +234,7 @@
                 "name": "Elementul de întreținere 8 a avut loc"
             },
             "maint9_occured": {
-                "name": "Maintenance item 9 occurred"
+                "name": "Elementul de întreținere 9 a avut loc"
             },
             "maint10_occured": {
                 "name": "Elementul de întreținere 10 a avut loc"
@@ -219,7 +243,7 @@
                 "name": "A avut loc întreținerea 1"
             },
             "ecomode": {
-                "name": "Mod Eco"
+                "name": "Modul Eco"
             },
             "hmepn_acairfilterclean": {
                 "name": "Este necesară curățarea filtrului de aer"
@@ -243,7 +267,7 @@
                 "name": "Extensie automată a brațului mopului"
             },
             "automopdry": {
-                "name": "Mop uscat"
+                "name": "Mop uscat automat"
             },
             "automopwash": {
                 "name": "Spălarea automată a mopului"
@@ -390,7 +414,7 @@
                 "name": "Reglați fin nivelul detergentului"
             },
             "adfinetunesoftlevel": {
-                "name": "Reglați fin nivelul de balsam"
+                "name": "Fine tune softener level"
             },
             "extrarinsenumber": {
                 "name": "Clătiri suplimentare"
@@ -408,7 +432,7 @@
                 "name": "Element de întreținere 3 id"
             },
             "maint3_threshold": {
-                "name": "Elementul de întreținere 3 prag"
+                "name": "Punctul de întreținere 3 prag"
             },
             "maint4_id": {
                 "name": "Articol de întreținere 4 id"
@@ -694,7 +718,7 @@
                 "name": "Exponentul vitezei compresorului"
             },
             "clonetargettemperaturemode": {
-                "name": "Modul de clonare cu cavitate suplimentară"
+                "name": "Mod de clonare cu cavitate suplimentară"
             },
             "temperatureadjustingstate": {
                 "name": "Reglare suplimentară a cavității"
@@ -790,7 +814,7 @@
                 "name": "Pragul de întreținere"
             },
             "detergentextradosage": {
-                "name": "Doza suplimentara de detergent"
+                "name": "Doza suplimentară de detergent"
             },
             "optisenseresult": {
                 "name": "Greutatea încărcăturii"
@@ -805,7 +829,7 @@
                 "name": "Rezervă o rezervă"
             },
             "tankbdetloadfornominalweight": {
-                "name": "Sarcina de det rezervor b pentru greutatea nominală"
+                "name": "Rezervor b det sarcină pentru greutatea nominală"
             },
             "tankbreserve": {
                 "name": "Rezervorul b"
@@ -823,7 +847,7 @@
                 "name": "Rezervorul b dedurizator încărcat"
             },
             "ecolevel": {
-                "name": "Nivel ecologic"
+                "name": "Nivelul Eco"
             },
             "applianceuiswversion": {
                 "name": "Versiunea sw a aparatului ui"
@@ -856,7 +880,7 @@
                 "name": "Contor total de cicluri de abur"
             },
             "prewashphase": {
-                "name": "Faza de pre-spălare"
+                "name": "Faza de prespălare"
             },
             "dryingnominalloadweight": {
                 "name": "Greutatea nominală a sarcinii"
@@ -898,7 +922,7 @@
                 "name": "Dwyw: timpul estimat de uscare"
             },
             "tdecpoverload": {
-                "name": "Dwyw: indicatorul de supraîncărcare de încărcare"
+                "name": "Dwyw: indicatorul de suprasarcină de încărcare"
             },
             "wmloaderror": {
                 "name": "Dwyw: eroare de încărcare de spălare"
@@ -973,7 +997,7 @@
                 "name": "Modul programator"
             },
             "totalruntime": {
-                "name": "Durată totală de rulare"
+                "name": "Timp total de rulare"
             },
             "compressorcoolingruntime": {
                 "name": "Timp de funcționare de răcire a compresorului"
@@ -1156,7 +1180,7 @@
                 "name": "Utilizarea filtrului"
             },
             "state": {
-                "name": "Stare de curatare"
+                "name": "Stare de curățare"
             },
             "chargingstatus": {
                 "name": "Starea de încărcare"
@@ -1222,7 +1246,7 @@
                 "name": "Mop timp de uscare"
             },
             "mopwashfreqarea": {
-                "name": "Zona de frecvență de spălare a mopului"
+                "name": "Zona de frecvență de spălare cu mopul"
             },
             "mopwashfreqtime": {
                 "name": "Durata frecvenței de spălare a mopului"
@@ -1240,7 +1264,7 @@
                 "name": "Progresul upgrade-ului"
             },
             "stationupgradestatus": {
-                "name": "Starea de actualizare a stației"
+                "name": "Starea upgrade-ului stației"
             },
             "upgradestate": {
                 "name": "Stare de upgrade"
@@ -1252,7 +1276,7 @@
                 "name": "Utilizare maximă a cutiei de praf"
             },
             "maxusagestationbag": {
-                "name": "Utilizare maximă a pungii stației"
+                "name": "Utilizarea maximă a sacului de stație"
             },
             "dndstarttime": {
                 "name": "Dnd ora de începere"
@@ -1347,7 +1371,7 @@
                 "name": "Modul Sabat"
             },
             "ecomode": {
-                "name": "Mod Eco"
+                "name": "Modul Eco"
             },
             "ui2lockmode": {
                 "name": "Modul Ui 2lock"
@@ -1368,7 +1392,7 @@
                 "name": "Modul economic"
             },
             "ewx1493a_rinsehold": {
-                "name": "Clătire hold"
+                "name": "Se clătește"
             },
             "ewx1493a_intensive": {
                 "name": "Spălare intensivă"
@@ -1401,7 +1425,7 @@
                 "name": "Rețeaua mereu pornită"
             },
             "adlocalfinetuning": {
-                "name": "Reglare fină locală a dozei automate"
+                "name": "Reglare fină locală a dozării automate"
             },
             "anticreasenosteam": {
                 "name": "Anti sifonare fara abur"
@@ -1425,7 +1449,7 @@
                 "name": "Modul economic"
             },
             "rinsehold": {
-                "name": "Clătire hold"
+                "name": "Se clătește"
             },
             "tcsensor": {
                 "name": "Senzor de temperatura"
@@ -1446,7 +1470,7 @@
                 "name": "Plus invers"
             },
             "tdeconomy_eco": {
-                "name": "Mod Eco"
+                "name": "Modul Eco"
             },
             "tdeconomy_night": {
                 "name": "Modul de noapte"
@@ -1461,7 +1485,7 @@
                 "name": "Tonul tastei"
             },
             "preselectlast": {
-                "name": "Preselectați ultimul"
+                "name": "Pre-selectați ultimul"
             },
             "extrapoweroption": {
                 "name": "Putere suplimentară"

--- a/custom_components/electrolux/translations/ru.json
+++ b/custom_components/electrolux/translations/ru.json
@@ -33,7 +33,7 @@
             }
         },
         "error": {
-            "invalid_auth": "Неверные учетные данные API. Пожалуйста, проверьте свой ключ API, токен доступа и токен обновления на портале разработчиков Electrolux."
+            "invalid_auth": "Неверные учетные данные API. Проверьте свой ключ API, токен доступа и токен обновления на портале разработчиков Electrolux."
         },
         "abort": {
             "single_instance_allowed": "Допускается только одна конфигурация Electrolux.",
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Отправлено слишком много команд. Пожалуйста, подождите немного и повторите попытку."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} невозможно настроить в текущем режиме."
+        },
         "control_locked": {
             "message": "{attr} заблокирован в {value} для программы {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "Скорость вентилятора нельзя регулировать в режиме {mode}. Сначала переключитесь в ручной режим, чтобы контролировать скорость вентилятора."
         },
         "food_probe_locked_by_program": {
             "message": "Температура пищевого зонда зафиксирована на уровне {value}°C для программы {program}."
@@ -142,6 +148,24 @@
         },
         "value_below_minimum": {
             "message": "Значение {value} ниже минимального {min_val} для {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Начать очистку зоны",
+            "description": "Начните сеанс уборки по зонам на роботе-пылесосе PUREi9. UUID зоны и UUID постоянной карты можно найти в диагностике интеграции (mapData/mapMatch/zones и persistMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Постоянный идентификатор карты",
+                    "description": "UUID используемой постоянной карты (из диагностики: persistMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Зоны",
+                    "description": "Список зон для очистки. Для каждой записи требуется Zone_id (UUID из mapData/mapMatch/zones[].uuid) и необязательный power_mode (1=тихий, 2=умный, 3=питание, по умолчанию 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
         }
     },
     "entity": {

--- a/custom_components/electrolux/translations/sk.json
+++ b/custom_components/electrolux/translations/sk.json
@@ -33,7 +33,7 @@
             }
         },
         "error": {
-            "invalid_auth": "Neplatné poverenia rozhrania API. Skontrolujte svoj kľúč API, prístupový token a obnovovací token z portálu Electrolux Developer Portal."
+            "invalid_auth": "Neplatné poverenia API. Skontrolujte svoj kľúč API, prístupový token a obnovovací token z portálu Electrolux Developer Portal."
         },
         "abort": {
             "single_instance_allowed": "Je povolená iba jedna konfigurácia Electrolux.",
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Bolo odoslaných príliš veľa príkazov. Chvíľu počkajte a skúste to znova."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} nie je možné upraviť v aktuálnom režime."
+        },
         "control_locked": {
             "message": "{attr} je uzamknuté na {value} pre program {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "Rýchlosť ventilátora nie je možné upraviť v režime {mode}. Najprv prepnite do manuálneho režimu, aby ste mohli ovládať rýchlosť ventilátora."
         },
         "food_probe_locked_by_program": {
             "message": "Teplota potravinovej sondy je uzamknutá na {value}°C pre program {program}."
@@ -138,16 +144,34 @@
             "message": "Chyba integrácie: nezhoda typu údajov pre {attr}. Očakávaná logická hodnota."
         },
         "value_above_maximum": {
-            "message": "Value {value} is above the maximum {max_val} for {attr}."
+            "message": "Hodnota {value} je vyššia ako maximum {max_val} pre {attr}."
         },
         "value_below_minimum": {
             "message": "Hodnota {value} je nižšia ako minimum {min_val} pre {attr}."
         }
     },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Spustite čistenie zóny",
+            "description": "Začnite zónové čistenie na robotickom vysávači PUREi9. Zónové UUID a trvalé mapové UUID sa nachádzajú v integračnej diagnostike (mapData/mapMatch/zones a persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Trvalé ID mapy",
+                    "description": "UUID trvalej mapy, ktorá sa má použiť (z diagnostiky: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Zóny",
+                    "description": "Zoznam zón na čistenie. Každý záznam potrebuje zone_id (UUID z mapData/mapMatch/zones[].uuid) a voliteľný power_mode (1=tichý, 2=inteligentný, 3=napájanie, predvolené 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
+        }
+    },
     "entity": {
         "binary_sensor": {
             "connectivitystate": {
-                "name": "Connectivity state"
+                "name": "Stav pripojenia"
             },
             "doorstate": {
                 "name": "Stav dverí"
@@ -261,16 +285,16 @@
                 "name": "Vráťte sa umyť"
             },
             "roomselected": {
-                "name": "Room selected"
+                "name": "Vybraná miestnosť"
             },
             "carpetboost": {
-                "name": "Carpet boost"
+                "name": "Zosilnenie koberca"
             },
             "carpetavoid": {
                 "name": "Vyhnite sa kobercom"
             },
             "carpetdisplay": {
-                "name": "Displej na koberce"
+                "name": "Displej kobercov"
             },
             "obstacleavoidance": {
                 "name": "Vyhýbanie sa prekážkam"
@@ -814,7 +838,7 @@
                 "name": "Spotreba vody"
             },
             "adtankadetloaded": {
-                "name": "Nádrž naplnený čistiacim prostriedkom"
+                "name": "Nádrž s čistiacim prostriedkom"
             },
             "adtankbdetloaded": {
                 "name": "Nádrž b na čistiaci prostriedok je naplnená"
@@ -1048,7 +1072,7 @@
                 "name": "Aqi svetlo"
             },
             "louverswing": {
-                "name": "Hojdačka žalúzií"
+                "name": "Hojdačka žalúzie"
             },
             "quietfan": {
                 "name": "Tichý ventilátor"
@@ -1123,7 +1147,7 @@
                 "name": "Chyba: filter 1 nfc transceiver"
             },
             "errnfctransceiver_2": {
-                "name": "Error: filter 2 nfc transceiver"
+                "name": "Chyba: filter 2 nfc transceiver"
             },
             "errtemprhnotresp": {
                 "name": "Chyba: snímač teploty/vlhkosti nereaguje"
@@ -1237,7 +1261,7 @@
                 "name": "Hlasitosť hlasu"
             },
             "upgradeprogress": {
-                "name": "Priebeh inovácie"
+                "name": "Pokrok v inovácii"
             },
             "stationupgradestatus": {
                 "name": "Stav aktualizácie stanice"
@@ -1323,7 +1347,7 @@
                 "name": "Vnútorná detská poistka"
             },
             "cavitylight": {
-                "name": "Dutinové svetlo"
+                "name": "Cavity light"
             },
             "childlock": {
                 "name": "Detská poistka"

--- a/custom_components/electrolux/translations/sl.json
+++ b/custom_components/electrolux/translations/sl.json
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "Preveč poslanih ukazov. Počakajte trenutek in poskusite znova."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} ni mogoče prilagoditi v trenutnem načinu."
+        },
         "control_locked": {
             "message": "{attr} je zaklenjen na {value} za program {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "Hitrosti ventilatorja ni mogoče prilagoditi v načinu {mode}. Najprej preklopite v ročni način, da nadzirate hitrost ventilatorja."
         },
         "food_probe_locked_by_program": {
             "message": "Temperatura sonde za hrano je zaklenjena na {value}°C za program {program}."
@@ -144,6 +150,24 @@
             "message": "Vrednost {value} je pod najmanjšo vrednostjo {min_val} za {attr}."
         }
     },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Začnite čiščenje območja",
+            "description": "Začnite območno sejo čiščenja na robotskem sesalniku PUREi9. UUID cone in UUID trajnega zemljevida najdete v diagnostiki integracije (mapData/mapMatch/zones in persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Trajni ID zemljevida",
+                    "description": "UUID obstojnega zemljevida za uporabo (iz diagnostike: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Cone",
+                    "description": "Seznam območij za čiščenje. Vsak vnos potrebuje zone_id (UUID iz mapData/mapMatch/zones[].uuid) in izbirni power_mode (1=tiho, 2=pametno, 3=moč, privzeto 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
+        }
+    },
     "entity": {
         "binary_sensor": {
             "connectivitystate": {
@@ -174,7 +198,7 @@
                 "name": "Svetloba, osredotočena na človeka"
             },
             "hoodautoswitchoffevent": {
-                "name": "Auto switch-off"
+                "name": "Samodejni izklop"
             },
             "appliancestate": {
                 "name": "Stanje zamrzovalnika"
@@ -592,7 +616,7 @@
                 "name": "Končno delovanje zgornje ciljne sonde za hrano"
             },
             "watertanklevel": {
-                "name": "Zgornja raven rezervoarja za vodo v pečici"
+                "name": "Nivo zgornjega rezervoarja za vodo v pečici"
             },
             "waterhardness": {
                 "name": "Trdota vode"
@@ -1123,7 +1147,7 @@
                 "name": "Napaka: filter 1 sprejemnik-sprejemnik nfc"
             },
             "errnfctransceiver_2": {
-                "name": "Napaka: filter 2 nfc oddajnik-sprejemnik"
+                "name": "Napaka: filter 2 nfc sprejemnik-sprejemnik"
             },
             "errtemprhnotresp": {
                 "name": "Napaka: senzor temperature/vlažnosti se ne odziva"

--- a/custom_components/electrolux/translations/sv.json
+++ b/custom_components/electrolux/translations/sv.json
@@ -59,7 +59,7 @@
             }
         },
         "error": {
-            "invalid_auth": "Ogiltiga API-uppgifter. Kontrollera din API-nyckel, åtkomsttoken och uppdateringstoken."
+            "invalid_auth": "Ogiltiga API-uppgifter. Kontrollera din API-nyckel, Access Token och Refresh Token."
         }
     },
     "issues": {
@@ -78,7 +78,7 @@
                     }
                 },
                 "error": {
-                    "invalid_auth": "Ogiltiga API-uppgifter. Kontrollera din API-nyckel, åtkomsttoken och uppdateringstoken.",
+                    "invalid_auth": "Ogiltiga API-uppgifter. Kontrollera din API-nyckel, Access Token och Refresh Token.",
                     "invalid_format": "Ogiltigt autentiseringsformat. Se till att alla fält är korrekt ifyllda.",
                     "entry_not_found": "Konfigurationsposten hittades inte."
                 },
@@ -104,8 +104,14 @@
         "command_rate_limited": {
             "message": "För många kommandon skickade. Vänta ett ögonblick och försök igen."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} kan inte justeras i det aktuella läget."
+        },
         "control_locked": {
             "message": "{attr} är låst vid {value} för program {program}."
+        },
+        "fanspeed_disabled": {
+            "message": "Fläkthastigheten kan inte justeras i läget {mode}. Byt först till manuellt läge för att styra fläkthastigheten."
         },
         "food_probe_locked_by_program": {
             "message": "Matsondens temperatur är låst till {value}°C för program {program}."
@@ -144,6 +150,24 @@
             "message": "Värdet {value} är under det lägsta {min_val} för {attr}."
         }
     },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Starta zonrengöring",
+            "description": "Starta en zonbaserad rengöringssession på en PUREi9 robotdammsugare. Zon-UUID och den beständiga kartan-UUID finns i integrationsdiagnostiken (mapData/mapMatch/zones och persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Ihållande kart-ID",
+                    "description": "UUID för den beständiga kartan som ska användas (från diagnostik: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Zoner",
+                    "description": "Lista över zoner att rengöra. Varje post behöver zone_id (UUID från mapData/mapMatch/zones[].uuid) och valfritt power_mode (1=tyst, 2=smart, 3=power, standard 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
+        }
+    },
     "entity": {
         "binary_sensor": {
             "connectivitystate": {
@@ -156,7 +180,7 @@
                 "name": "Matsond"
             },
             "foodprobesupported": {
-                "name": "Support för matsonden"
+                "name": "Matprobstöd"
             },
             "watertrayinsertionstate": {
                 "name": "Vattenbricka"
@@ -228,7 +252,7 @@
                 "name": "Ac-varningar stöds"
             },
             "hepafilterinsertedstate": {
-                "name": "Hepa-filter insatt"
+                "name": "Hepa-filter isatt"
             },
             "dooropen": {
                 "name": "Dörren öppen"
@@ -288,7 +312,7 @@
                 "name": "Flervåningskarta"
             },
             "multifloormapautoswitch": {
-                "name": "Flervånings karta automatisk switch"
+                "name": "Flervåningskarta automatisk switch"
             },
             "robotposereliable": {
                 "name": "Robotpose pålitlig"
@@ -772,7 +796,7 @@
                 "name": "Tidsansvarig"
             },
             "adtankasel": {
-                "name": "Autodoseringstank a"
+                "name": "Automatisk dostank a"
             },
             "adtankbsel": {
                 "name": "Automatisk dostank b"
@@ -898,7 +922,7 @@
                 "name": "Dwyw: beräknad torktid"
             },
             "tdecpoverload": {
-                "name": "Dwyw: load overload flag"
+                "name": "Dwyw: ladda överbelastningsflagga"
             },
             "wmloaderror": {
                 "name": "Dwyw: tvättladdningsfel"
@@ -1434,7 +1458,7 @@
                 "name": "Blöta"
             },
             "softener": {
-                "name": "Sköljmedel"
+                "name": "Mjukgörare"
             },
             "defaultsoftplus": {
                 "name": "Standard mjukt plus"

--- a/custom_components/electrolux/translations/tr.json
+++ b/custom_components/electrolux/translations/tr.json
@@ -104,11 +104,17 @@
         "command_rate_limited": {
             "message": "Çok fazla komut gönderildi. Lütfen biraz bekleyip tekrar deneyin."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} mevcut modda ayarlanamaz."
+        },
         "control_locked": {
             "message": "{attr}, {program} programı için {value} konumunda kilitlendi."
         },
+        "fanspeed_disabled": {
+            "message": "Fan hızı {mode} modunda ayarlanamaz. Fan hızını kontrol etmek için önce Manuel moda geçin."
+        },
         "food_probe_locked_by_program": {
-            "message": "Yiyecek termometresi sıcaklığı {program} programı için {value}_°C'de kilitlendi."
+            "message": "Yemek termometresi sıcaklığı {program} programı için {value}°C'de kilitlendi."
         },
         "food_probe_not_inserted": {
             "message": "Hedef sıcaklığı ayarlamak için yemek termometresinin takılması gerekir."
@@ -123,7 +129,7 @@
             "message": "Geçersiz ön ayar modu {mode}. Kullanılabilir modlar: {modes}."
         },
         "not_supported_by_program": {
-            "message": "{attr} değiştirilemiyor: mevcut program {program} tarafından desteklenmiyor."
+            "message": "{attr} değiştirilemiyor: mevcut {program} programı tarafından desteklenmiyor."
         },
         "remote_control_disabled": {
             "message": "Bu cihaz için uzaktan kumanda devre dışı bırakıldı. Lütfen cihazın kontrol panelinde etkinleştirin."
@@ -142,6 +148,1417 @@
         },
         "value_below_minimum": {
             "message": "{value} değeri, {attr} için minimum {min_val} değerinin altında."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Bölge temizliğini başlat",
+            "description": "PUREi9 robot süpürgesinde bölge bazlı bir temizleme oturumu başlatın. Bölge UUID'leri ve kalıcı harita UUID'si entegrasyon tanılamasında bulunur (mapData/mapMatch/zones ve persistsMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Kalıcı harita kimliği",
+                    "description": "Kullanılacak kalıcı haritanın UUID'si (tanılamadan: persistMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Bölgeler",
+                    "description": "Temizlenecek bölgelerin listesi. Her giriş, Zone_id'ye (mapData/mapMatch/zones[.uuid'den UUID) ve isteğe bağlı power_mode'a (1=sessiz, 2=akıllı, 3=güç, varsayılan 1) ihtiyaç duyar.",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
+        }
+    },
+    "entity": {
+        "binary_sensor": {
+            "connectivitystate": {
+                "name": "Bağlantı durumu"
+            },
+            "doorstate": {
+                "name": "Kapı durumu"
+            },
+            "foodprobeinsertionstate": {
+                "name": "Gıda Sondası"
+            },
+            "foodprobesupported": {
+                "name": "Gıda Probu Desteği"
+            },
+            "watertrayinsertionstate": {
+                "name": "Su tepsisi"
+            },
+            "watertankempty": {
+                "name": "Su deposu boş"
+            },
+            "cleaningreminder": {
+                "name": "Temizlik hatırlatıcısı"
+            },
+            "drawerstatus": {
+                "name": "Çekmece"
+            },
+            "humancentriclighteventstate": {
+                "name": "İnsan merkezli ışık"
+            },
+            "hoodautoswitchoffevent": {
+                "name": "Otomatik kapanma"
+            },
+            "appliancestate": {
+                "name": "Dondurucu durumu"
+            },
+            "fanstate": {
+                "name": "Ekstra boşluklu fan durumu"
+            },
+            "autosense": {
+                "name": "Otomatik algılama"
+            },
+            "maint1_occured": {
+                "name": "Bakım gerekli"
+            },
+            "maint2_occured": {
+                "name": "Bakım öğesi 2 oluştu"
+            },
+            "maint3_occured": {
+                "name": "Bakım öğesi 3 oluştu"
+            },
+            "maint4_occured": {
+                "name": "Bakım öğesi 4 oluştu"
+            },
+            "maint5_occured": {
+                "name": "Bakım öğesi 5 oluştu"
+            },
+            "maint6_occured": {
+                "name": "Bakım öğesi 6 oluştu"
+            },
+            "maint7_occured": {
+                "name": "Bakım öğesi 7 oluştu"
+            },
+            "maint8_occured": {
+                "name": "Bakım öğesi 8 oluştu"
+            },
+            "maint9_occured": {
+                "name": "Bakım öğesi 9 oluştu"
+            },
+            "maint10_occured": {
+                "name": "Bakım öğesi 10 oluştu"
+            },
+            "occured": {
+                "name": "Bakım 1 gerçekleşti"
+            },
+            "ecomode": {
+                "name": "Eko modu"
+            },
+            "hmepn_acairfilterclean": {
+                "name": "Hava filtresi temizliği gerekli"
+            },
+            "hmepn_acalerts": {
+                "name": "Ac uyarıları desteklenir"
+            },
+            "hepafilterinsertedstate": {
+                "name": "Hepa filtresi takıldı"
+            },
+            "dooropen": {
+                "name": "Kapı açık"
+            },
+            "watertraylevellow": {
+                "name": "Su tepsisi seviyesi düşük"
+            },
+            "autodustcollection": {
+                "name": "Otomatik toz toplama"
+            },
+            "automoparmextension": {
+                "name": "Otomatik paspas kolu uzatması"
+            },
+            "automopdry": {
+                "name": "Otomatik paspasla kurutma"
+            },
+            "automopwash": {
+                "name": "Otomatik paspas yıkama"
+            },
+            "autodetergentusage": {
+                "name": "Oto deterjan kullanımı"
+            },
+            "mopinstalled": {
+                "name": "Paspas kuruldu"
+            },
+            "incharger": {
+                "name": "Şarj cihazında"
+            },
+            "returntowash": {
+                "name": "Yıkamaya geri dön"
+            },
+            "roomselected": {
+                "name": "Oda seçildi"
+            },
+            "carpetboost": {
+                "name": "Halı güçlendirme"
+            },
+            "carpetavoid": {
+                "name": "Halı önlemek"
+            },
+            "carpetdisplay": {
+                "name": "Halı ekranı"
+            },
+            "obstacleavoidance": {
+                "name": "Engellerden kaçınma"
+            },
+            "dndenabled": {
+                "name": "Rahatsız etmeyin etkin"
+            },
+            "dnddisableairdry": {
+                "name": "Havayla kurutmayı devre dışı bırakın"
+            },
+            "isdndpausingairdry": {
+                "name": "Havayla kurutmayı duraklatın"
+            },
+            "multifloormap": {
+                "name": "Çok katlı harita"
+            },
+            "multifloormapautoswitch": {
+                "name": "Çok katlı harita otomatik anahtarı"
+            },
+            "robotposereliable": {
+                "name": "Robot pozu güvenilir"
+            },
+            "ovwater_tank_empty": {
+                "name": "Su Deposu Durumu"
+            },
+            "ovcleaning_ended": {
+                "name": "Temizleme Durumu"
+            },
+            "ovfood_probe_end_of_cooking": {
+                "name": "Pişirme Sonu Probu"
+            }
+        },
+        "button": {
+            "command": {
+                "name": "Ağ komutu"
+            },
+            "startupcommand": {
+                "name": "Başlatma komutu"
+            },
+            "manualsync": {
+                "name": "Manuel senkronizasyon"
+            },
+            "executecommand": {
+                "name": "Güç"
+            },
+            "waterfilterstatereset": {
+                "name": "Su filtresini sıfırla"
+            },
+            "airfilterstatereset": {
+                "name": "Hava filtresini sıfırla"
+            },
+            "saveappfavorite": {
+                "name": "Favoriyi kaydet"
+            },
+            "shortcutproglistcmd": {
+                "name": "Kısayol program listesi komutu"
+            },
+            "filterreset": {
+                "name": "Filtre sıfırlama"
+            },
+            "hepafilterreset": {
+                "name": "Hepa filtre sıfırlama"
+            },
+            "findme": {
+                "name": "Beni bul"
+            }
+        },
+        "fan": {
+            "fan": {
+                "name": "Hava temizleyici"
+            }
+        },
+        "number": {
+            "starttime": {
+                "name": "Başlangıç ​​zamanı"
+            },
+            "targetduration": {
+                "name": "Hedef süre"
+            },
+            "targetfoodprobetemperaturec": {
+                "name": "Hedef gıda termometresi sıcaklığı c"
+            },
+            "targetfoodprobetemperaturef": {
+                "name": "Hedef gıda termometresi sıcaklığı f"
+            },
+            "targettemperaturec": {
+                "name": "Hedef sıcaklık c"
+            },
+            "targettemperaturef": {
+                "name": "Hedef sıcaklık f"
+            },
+            "remindertime": {
+                "name": "Üst fırın hatırlatma zamanı"
+            },
+            "appliancelocaltimeoffset": {
+                "name": "Cihazın yerel saat farkı"
+            },
+            "lightintensity": {
+                "name": "Işık yoğunluğu"
+            },
+            "lightcolortemperature": {
+                "name": "Açık renk sıcaklığı"
+            },
+            "stoptime": {
+                "name": "Durdurma zamanı"
+            },
+            "adtankadetstandarddose": {
+                "name": "Bir deterjan standart dozunu depolayın"
+            },
+            "adtankbdetstandarddose": {
+                "name": "Tank b deterjan standart dozu"
+            },
+            "adtankbsoftstandarddose": {
+                "name": "Tank b yumuşatıcı standart dozu"
+            },
+            "adfinetunedetlevel": {
+                "name": "Deterjan seviyesine ince ayar yapın"
+            },
+            "adfinetunesoftlevel": {
+                "name": "Yumuşatıcı seviyesinin ince ayarı"
+            },
+            "extrarinsenumber": {
+                "name": "Ekstra durulamalar"
+            },
+            "maint1_id": {
+                "name": "Bakım öğesi 1 kimliği"
+            },
+            "maint2_id": {
+                "name": "Bakım öğesi 2 kimliği"
+            },
+            "maint2_threshold": {
+                "name": "Bakım öğesi 2 eşiği"
+            },
+            "maint3_id": {
+                "name": "Bakım öğesi 3 kimliği"
+            },
+            "maint3_threshold": {
+                "name": "Bakım öğesi 3 eşiği"
+            },
+            "maint4_id": {
+                "name": "Bakım öğesi 4 kimliği"
+            },
+            "maint4_threshold": {
+                "name": "Bakım öğesi 4 eşiği"
+            },
+            "maint5_id": {
+                "name": "Bakım öğesi 5 kimliği"
+            },
+            "maint5_threshold": {
+                "name": "Bakım öğesi 5 eşiği"
+            },
+            "maint6_id": {
+                "name": "Bakım öğesi 6 kimliği"
+            },
+            "maint6_threshold": {
+                "name": "Bakım öğesi 6 eşiği"
+            },
+            "maint7_id": {
+                "name": "Bakım öğesi 7 kimliği"
+            },
+            "maint7_threshold": {
+                "name": "Bakım öğesi 7 eşiği"
+            },
+            "maint8_id": {
+                "name": "Bakım öğesi 8 kimliği"
+            },
+            "maint8_threshold": {
+                "name": "Bakım öğesi 8 eşiği"
+            },
+            "maint9_id": {
+                "name": "Bakım öğesi 9 kimliği"
+            },
+            "maint9_threshold": {
+                "name": "Bakım öğesi 9 eşiği"
+            },
+            "maint10_id": {
+                "name": "Bakım öğesi 10 kimliği"
+            },
+            "maint10_threshold": {
+                "name": "Bakım öğesi 10 eşiği"
+            },
+            "clearcyclepersonalizationcmd": {
+                "name": "Döngü kişiselleştirmeyi temizle"
+            },
+            "memoryid": {
+                "name": "Bellek yuvası"
+            },
+            "dryingtime": {
+                "name": "Zamanlanmış kurutma (aktif)"
+            },
+            "timetonotify": {
+                "name": "Bildirim zamanı"
+            },
+            "anticreasevalue": {
+                "name": "Kırışık önleme (aktif)"
+            },
+            "rinseaidlevel": {
+                "name": "Parlatıcı seviyesi"
+            },
+            "targethumidity": {
+                "name": "Hedef nem"
+            },
+            "targettemperature": {
+                "name": "Hedef sıcaklık"
+            },
+            "fanspeed": {
+                "name": "Fan hızı"
+            },
+            "humiditytarget": {
+                "name": "Hedef nem"
+            },
+            "powermode": {
+                "name": "Güç modu"
+            }
+        },
+        "select": {
+            "displaylight": {
+                "name": "Ekran ışığı"
+            },
+            "targettemperaturec": {
+                "name": "Ekstra boşluk sıcaklığı"
+            },
+            "mode": {
+                "name": "Mod"
+            },
+            "fanspeedsetting": {
+                "name": "Fan hızı"
+            }
+        },
+        "sensor": {
+            "alerts": {
+                "name": "Uyarılar"
+            },
+            "appliancestate": {
+                "name": "Cihaz Durumu"
+            },
+            "temperaturerepresentation": {
+                "name": "Sıcaklık gösterimi"
+            },
+            "linkqualityindicator": {
+                "name": "Ağ arayüzü bağlantı kalitesi göstergesi"
+            },
+            "niuswupdatecurrentdescription": {
+                "name": "Niu sw güncelleme açıklaması"
+            },
+            "otastate": {
+                "name": "Ağ arayüzü ota durumu"
+            },
+            "swancandrevision": {
+                "name": "Anahtar ve revizyon"
+            },
+            "swversion": {
+                "name": "Ağ arayüzü yazılım sürümü"
+            },
+            "endofcyclesound": {
+                "name": "Döngü sonu sesi"
+            },
+            "programuid": {
+                "name": "Program kimliği"
+            },
+            "appliancetype": {
+                "name": "Cihaz tipi"
+            },
+            "capabilityhash": {
+                "name": "Yetenek karması"
+            },
+            "cpv": {
+                "name": "GBM"
+            },
+            "remotecontrol": {
+                "name": "Uzaktan kumanda"
+            },
+            "totalcyclecounter": {
+                "name": "Toplam döngü sayacı"
+            },
+            "appliancetotalworkingtime": {
+                "name": "Cihazın toplam çalışma süresi"
+            },
+            "timetoend": {
+                "name": "Bitme zamanı"
+            },
+            "displayfoodprobetemperature": {
+                "name": "Gıda termometresi sıcaklığını göster"
+            },
+            "displayfoodprobetemperaturec": {
+                "name": "Gıda termometresi sıcaklığının görüntülenmesi c"
+            },
+            "displayfoodprobetemperaturef": {
+                "name": "Gıda termometresi sıcaklığını görüntüleme f"
+            },
+            "displaytemperature": {
+                "name": "Ekran sıcaklığı"
+            },
+            "displaytemperaturec": {
+                "name": "Ekran sıcaklığı c"
+            },
+            "displaytemperaturef": {
+                "name": "Ekran sıcaklığı f"
+            },
+            "processphase": {
+                "name": "Süreç aşaması"
+            },
+            "program": {
+                "name": "programı"
+            },
+            "runningtime": {
+                "name": "Koşu süresi"
+            },
+            "fastheatupfeature": {
+                "name": "Üst fırın hızlı ısınma özelliği"
+            },
+            "preheatcomplete": {
+                "name": "Üst fırın ön ısıtması tamamlandı"
+            },
+            "targetdurationendaction": {
+                "name": "Üst fırın hedefi süre sonu eylemi"
+            },
+            "targetfoodprobetemperatureendaction": {
+                "name": "Üst fırın hedefi gıda sensörü sıcaklığı son eylemi"
+            },
+            "watertanklevel": {
+                "name": "Üst fırın su deposu seviyesi"
+            },
+            "waterhardness": {
+                "name": "Su sertliği"
+            },
+            "descalingreminderstate": {
+                "name": "Kireç çözme hatırlatıcısı"
+            },
+            "clockstyle": {
+                "name": "Saat stili"
+            },
+            "language": {
+                "name": "Dil"
+            },
+            "localtimeautomaticmode": {
+                "name": "Yerel saat otomatik modu"
+            },
+            "autolocaltimeoffset": {
+                "name": "Otomatik yerel saat farkı"
+            },
+            "favoriteorder": {
+                "name": "Favori sipariş"
+            },
+            "number": {
+                "name": "Favori sipariş sayısı"
+            },
+            "favoriteselect": {
+                "name": "Favori seçimi"
+            },
+            "favoritestatus": {
+                "name": "Favori durumu"
+            },
+            "activemessageindex": {
+                "name": "Aktif mesaj dizini"
+            },
+            "appliancemode": {
+                "name": "Cihaz modu"
+            },
+            "hobtohoodfanspeed": {
+                "name": "Davlumbaz fan hızı"
+            },
+            "hobtohoodstate": {
+                "name": "Başlık durumu"
+            },
+            "hoodfanlevel": {
+                "name": "Fan seviyesi"
+            },
+            "hoodcharcfiltertimer": {
+                "name": "Kömür filtre zamanlayıcısı"
+            },
+            "hoodgreasefiltertimer": {
+                "name": "Yağ filtresi zamanlayıcısı"
+            },
+            "tvocfiltertime": {
+                "name": "Tvoc filtre süresi"
+            },
+            "fastmodetimetoend": {
+                "name": "Dondurucu hızlı modunun bitme zamanı"
+            },
+            "sensortemperaturec": {
+                "name": "Dondurucu sıcaklığı"
+            },
+            "vacationholidaymode": {
+                "name": "Tatil tatili modu"
+            },
+            "sensorhumidity": {
+                "name": "Nem"
+            },
+            "waterfilterstate": {
+                "name": "Su filtresi durumu"
+            },
+            "waterfilterlifetime": {
+                "name": "Su filtresi ömrü"
+            },
+            "waterfilterflow": {
+                "name": "Su filtresi akışı"
+            },
+            "airfilterstate": {
+                "name": "Hava filtresi durumu"
+            },
+            "airfilterlifetime": {
+                "name": "Hava filtresi ömrü"
+            },
+            "coolingvalvestate": {
+                "name": "Soğutma valfi durumu"
+            },
+            "defrostroutinestate": {
+                "name": "Buz çözme rutin durumu"
+            },
+            "compressorstate": {
+                "name": "Kompresör durumu"
+            },
+            "compressorspeed": {
+                "name": "Kompresör hızı"
+            },
+            "coefficient": {
+                "name": "Kompresör hız katsayısı"
+            },
+            "exponent": {
+                "name": "Kompresör hız üssü"
+            },
+            "clonetargettemperaturemode": {
+                "name": "Ekstra boşluk klonlama modu"
+            },
+            "temperatureadjustingstate": {
+                "name": "Ekstra boşluk ayarı"
+            },
+            "defrosttemperaturec": {
+                "name": "Buz yapıcı buz çözme sıcaklığı"
+            },
+            "evaporatorfanstate": {
+                "name": "Buz yapıcı fan durumu"
+            },
+            "icedispenserstate": {
+                "name": "Buz pınarı durumu"
+            },
+            "icetraywaterfillsetting": {
+                "name": "Buz tepsisi doldurma ayarı"
+            },
+            "airfilterlifetimebuythreshold": {
+                "name": "Hava filtresi satın alma eşiği"
+            },
+            "airfilterlifetimechangethreshold": {
+                "name": "Hava filtresi değiştirme eşiği"
+            },
+            "waterfilterflowbuythreshold": {
+                "name": "Su filtresi satın alma eşiği (akış)"
+            },
+            "waterfilterflowchangethreshold": {
+                "name": "Su filtresi değişim eşiği (akış)"
+            },
+            "waterfilterlifetimebuythreshold": {
+                "name": "Su filtresi satın alma eşiği (zaman)"
+            },
+            "waterfilterlifetimechangethreshold": {
+                "name": "Su filtresi değişim eşiği (zaman)"
+            },
+            "appliancemainboardswversion": {
+                "name": "Ana kart yazılım sürümü"
+            },
+            "defaultextrarinse": {
+                "name": "Varsayılan ekstra durulama"
+            },
+            "cyclephase": {
+                "name": "Döngü aşaması"
+            },
+            "cyclesubphase": {
+                "name": "Döngü alt fazı"
+            },
+            "measuredloadweight": {
+                "name": "Ölçülen yük ağırlığı"
+            },
+            "doorlock": {
+                "name": "Kapı kilidi"
+            },
+            "totalwashcyclescount": {
+                "name": "Toplam yıkama çevrimleri"
+            },
+            "totalwashingtime": {
+                "name": "Toplam yıkama süresi"
+            },
+            "fcoptisenseloadweight": {
+                "name": "Yük ağırlığı"
+            },
+            "washingnominalloadweight": {
+                "name": "Yıkama yükü ağırlığı"
+            },
+            "adtankaconfiguration": {
+                "name": "Bir yapılandırmayı depolayın"
+            },
+            "adtankbconfiguration": {
+                "name": "Tank b konfigürasyonu"
+            },
+            "steamvalue": {
+                "name": "Buhar seviyesi"
+            },
+            "timemanagerlevel": {
+                "name": "Zaman yöneticisi"
+            },
+            "adtankasel": {
+                "name": "Otomatik dozaj tankı a"
+            },
+            "adtankbsel": {
+                "name": "Otomatik doz tankı b"
+            },
+            "analogspinspeed": {
+                "name": "Sıkma hızı"
+            },
+            "analogtemperature": {
+                "name": "Sıcaklık"
+            },
+            "watersoftenermode": {
+                "name": "Su yumuşatıcı modu"
+            },
+            "maint1_threshold": {
+                "name": "Bakım eşiği"
+            },
+            "detergentextradosage": {
+                "name": "Deterjan ekstra dozajı"
+            },
+            "optisenseresult": {
+                "name": "Yük ağırlığı"
+            },
+            "softenerextradosage": {
+                "name": "Yumuşatıcı ekstra dozajı"
+            },
+            "tankadetloadfornominalweight": {
+                "name": "Nominal ağırlık için belirli bir yük depolayın"
+            },
+            "tankareserve": {
+                "name": "Rezerv depolayın"
+            },
+            "tankbdetloadfornominalweight": {
+                "name": "Nominal ağırlık için tank b det yükü"
+            },
+            "tankbreserve": {
+                "name": "Tank b rezervi"
+            },
+            "waterusage": {
+                "name": "Su kullanımı"
+            },
+            "adtankadetloaded": {
+                "name": "Deterjan dolu bir depoya koyun"
+            },
+            "adtankbdetloaded": {
+                "name": "Tank b deterjan yüklü"
+            },
+            "adtankbsoftloaded": {
+                "name": "Tank b yumuşatıcı yüklü"
+            },
+            "ecolevel": {
+                "name": "Eko düzeyi"
+            },
+            "applianceuiswversion": {
+                "name": "Cihaz kullanıcı arayüzü yazılım sürümü"
+            },
+            "remotenotificationpending": {
+                "name": "Uzaktan bildirim bekleniyor"
+            },
+            "minfinishintime": {
+                "name": "Minimum sürede bitirme"
+            },
+            "ewx1493a_wmeconomy": {
+                "name": "Ekonomi modu"
+            },
+            "adfinetunedetlevel": {
+                "name": "Otomatik doz deterjan ince ayarı"
+            },
+            "adfinetunesoftlevel": {
+                "name": "Otomatik doz yumuşatıcının ince ayarı"
+            },
+            "extrarinsenumber": {
+                "name": "Ekstra durulama"
+            },
+            "threshold": {
+                "name": "Bakım 1 eşiği"
+            },
+            "timezonedatabasename": {
+                "name": "Saat dilimi veritabanı"
+            },
+            "totalsteamcyclecounter": {
+                "name": "Toplam buhar döngüsü sayacı"
+            },
+            "prewashphase": {
+                "name": "Ön yıkama aşaması"
+            },
+            "dryingnominalloadweight": {
+                "name": "Nominal yük ağırlığı"
+            },
+            "humiditytarget": {
+                "name": "Nem hedefi (aktif)"
+            },
+            "tankalevel": {
+                "name": "Bir seviye tanklayın"
+            },
+            "tankblevel": {
+                "name": "Tank b seviyesi"
+            },
+            "totaldrycyclescount": {
+                "name": "Toplam kuru döngüler"
+            },
+            "totaldryingtime": {
+                "name": "Toplam kuruma süresi"
+            },
+            "totalwashdrycyclescount": {
+                "name": "Toplam yıkama+kurutma döngüleri"
+            },
+            "programsorder": {
+                "name": "Program sırası"
+            },
+            "carelevel": {
+                "name": "Bakım düzeyi"
+            },
+            "drynessvalue": {
+                "name": "Kuruluk seviyesi (aktif)"
+            },
+            "wmloadweight": {
+                "name": "Dwyw: yıkama yükünün ağırlığı"
+            },
+            "wmloadmoisture": {
+                "name": "Dwyw: yıkama yükü nemi"
+            },
+            "tdcloudtte": {
+                "name": "Dwyw: tahmini kuruma süresi"
+            },
+            "tdecpoverload": {
+                "name": "Dwyw: aşırı yükleme bayrağını yükle"
+            },
+            "wmloaderror": {
+                "name": "Dwyw: yıkama yükleme hatası"
+            },
+            "wmsn": {
+                "name": "Dwyw: eşleştirilmiş yıkayıcı serisi"
+            },
+            "command": {
+                "name": "Dwyw: komut"
+            },
+            "displayonfloor": {
+                "name": "Yerde sergileme"
+            },
+            "energyscore": {
+                "name": "Enerji puanı"
+            },
+            "waterscore": {
+                "name": "Su puanı"
+            },
+            "ecoscore": {
+                "name": "Eko puanı"
+            },
+            "miscellaneousstate": {
+                "name": "Çeşitli durum"
+            },
+            "ambienttemperaturec": {
+                "name": "Ortam sıcaklığı c"
+            },
+            "ambienttemperaturef": {
+                "name": "Ortam sıcaklığı f"
+            },
+            "fanmode": {
+                "name": "Fan modu"
+            },
+            "swingmode": {
+                "name": "Salınım modu"
+            },
+            "ambienthumidity": {
+                "name": "Ortam nemi"
+            },
+            "filterstatus": {
+                "name": "Filtre durumu"
+            },
+            "powerconsumption": {
+                "name": "Güç tüketimi"
+            },
+            "energyconsumption": {
+                "name": "Enerji tüketimi"
+            },
+            "fanspeedstate": {
+                "name": "Fan hızı durumu"
+            },
+            "filterstate": {
+                "name": "Filtre durumu"
+            },
+            "hepafilterlifetime": {
+                "name": "Hepa filtre ömrü"
+            },
+            "appliancecategory": {
+                "name": "Cihaz kategorisi"
+            },
+            "vmno_niu": {
+                "name": "Niu versiyonu"
+            },
+            "vmno_mcu": {
+                "name": "Mcu sürümü"
+            },
+            "schedulersession": {
+                "name": "Zamanlayıcı oturumu"
+            },
+            "schedulermode": {
+                "name": "Zamanlayıcı modu"
+            },
+            "totalruntime": {
+                "name": "Toplam çalışma süresi"
+            },
+            "compressorcoolingruntime": {
+                "name": "Kompresör soğutma çalışma süresi"
+            },
+            "compressorheatingruntime": {
+                "name": "Kompresör ısıtma çalışma süresi"
+            },
+            "mainunittemp": {
+                "name": "Ana ünite sıcaklığı"
+            },
+            "loge": {
+                "name": "Günlük e"
+            },
+            "logw": {
+                "name": "Günlük w"
+            },
+            "demandresponseau": {
+                "name": "Talep yanıtı au"
+            },
+            "pm25": {
+                "name": "PM2,5"
+            },
+            "pm10": {
+                "name": "PM10"
+            },
+            "modestate": {
+                "name": "Mod durumu"
+            },
+            "filterruntime": {
+                "name": "Çalışma zamanını filtrele"
+            },
+            "hepafilterstate": {
+                "name": "Hepa filtre durumu"
+            },
+            "airqualitylevel": {
+                "name": "Hava kalitesi seviyesi"
+            },
+            "temperature": {
+                "name": "Ortam sıcaklığı"
+            },
+            "mode": {
+                "name": "Mod"
+            },
+            "temp": {
+                "name": "Sıcaklık"
+            },
+            "humidity": {
+                "name": "Nem"
+            },
+            "pm1": {
+                "name": "PM1"
+            },
+            "pm2_5": {
+                "name": "PM2,5"
+            },
+            "tvoc": {
+                "name": "TVoc"
+            },
+            "eco2": {
+                "name": "Eko2"
+            },
+            "filtertype": {
+                "name": "Filtre türü"
+            },
+            "filterlife": {
+                "name": "Filtre ömrü"
+            },
+            "workmode": {
+                "name": "Çalışma modu"
+            },
+            "aqilight": {
+                "name": "Aqi ışığı"
+            },
+            "louverswing": {
+                "name": "Panjur salınımı"
+            },
+            "quietfan": {
+                "name": "Sessiz fan"
+            },
+            "humidificationfilter_resetdate": {
+                "name": "Nemlendirme filtresi sıfırlama tarihi"
+            },
+            "filterlife_1": {
+                "name": "Filtre ömrü"
+            },
+            "filterlife_2": {
+                "name": "Filtre ömrü 2"
+            },
+            "filtertype_1": {
+                "name": "Filtre türü"
+            },
+            "filtertype_2": {
+                "name": "Filtre türü 2"
+            },
+            "filteruid_1": {
+                "name": "1 nfc etiketi kullanıcı kimliğini filtrele"
+            },
+            "filteruid_2": {
+                "name": "Filtre 2 nfc etiketi kullanıcı kimliği"
+            },
+            "pm2_5_approximate": {
+                "name": "Pm2,5 (yaklaşık)"
+            },
+            "uvruntime": {
+                "name": "UV çalışma zamanı"
+            },
+            "schedulingstate": {
+                "name": "Planlama durumu"
+            },
+            "errimpellerstuck": {
+                "name": "Hata: pervane sıkışmış"
+            },
+            "errpmnotresp": {
+                "name": "Hata: pm sensörü yanıt vermiyor"
+            },
+            "errcommsensordisplaybrd": {
+                "name": "Hata: ekran kartı iletişimi"
+            },
+            "errcommsensoruibrd": {
+                "name": "Hata: kullanıcı arayüzü kartı iletişimi"
+            },
+            "signalstrength": {
+                "name": "Sinyal gücü"
+            },
+            "rssi": {
+                "name": "RSSI"
+            },
+            "filterrfid": {
+                "name": "RFID'yi filtrele"
+            },
+            "errgasnotresp": {
+                "name": "Hata: gaz sensörü yanıt vermiyor"
+            },
+            "errnfctagnotpres_1": {
+                "name": "Hata: filtre 1 nfc etiketi mevcut değil"
+            },
+            "errnfctagnotpres_2": {
+                "name": "Hata: filtre 2 nfc etiketi mevcut değil"
+            },
+            "errnfctagpresnotvalid_1": {
+                "name": "Hata: filtre 1 nfc etiketi geçersiz"
+            },
+            "errnfctagpresnotvalid_2": {
+                "name": "Hata: filtre 2 nfc etiketi geçersiz"
+            },
+            "errnfctransceiver_1": {
+                "name": "Hata: 1 nfc alıcı-vericiyi filtrele"
+            },
+            "errnfctransceiver_2": {
+                "name": "Hata: filtre 2 nfc alıcı-verici"
+            },
+            "errtemprhnotresp": {
+                "name": "Hata: sıcaklık/nem sensörü yanıt vermiyor"
+            },
+            "errwatertrayremoved": {
+                "name": "Hata: su tepsisi çıkarıldı"
+            },
+            "waterbucketlevel": {
+                "name": "Su kovası seviyesi"
+            },
+            "batterystatus": {
+                "name": "Pil"
+            },
+            "robotstatus": {
+                "name": "Robot durumu"
+            },
+            "cleaningcommand": {
+                "name": "Temizleme komutu"
+            },
+            "dustbinstatus": {
+                "name": "Çöp kutusu durumu"
+            },
+            "mainbrushsqm": {
+                "name": "Ana fırça kullanımı"
+            },
+            "sidebrushsqm": {
+                "name": "Yan fırça kullanımı"
+            },
+            "filtersqm": {
+                "name": "Filtre kullanımı"
+            },
+            "state": {
+                "name": "Temizleme durumu"
+            },
+            "chargingstatus": {
+                "name": "Şarj durumu"
+            },
+            "vacuummode": {
+                "name": "Vakum modu"
+            },
+            "cleaningtype": {
+                "name": "Temizleme türü"
+            },
+            "cleaningmode": {
+                "name": "Temizleme modu"
+            },
+            "waterpumprate": {
+                "name": "Su pompası hızı"
+            },
+            "waterstationaction": {
+                "name": "Su istasyonu eylemi"
+            },
+            "moproute": {
+                "name": "Paspas rotası"
+            },
+            "notificationevent": {
+                "name": "Bildirim etkinliği"
+            },
+            "dirtcleanmode": {
+                "name": "Kir temizleme modu"
+            },
+            "faultcode": {
+                "name": "Arıza kodu"
+            },
+            "filterusage": {
+                "name": "Filtre kullanımı"
+            },
+            "cleansize": {
+                "name": "Temiz boyut"
+            },
+            "cleantime": {
+                "name": "Temiz zaman"
+            },
+            "dustbagusage": {
+                "name": "Toz torbası kullanımı"
+            },
+            "dustboxusage": {
+                "name": "Toz kutusu kullanımı"
+            },
+            "emptyingtime": {
+                "name": "Boşaltma süresi"
+            },
+            "mainbrushusage": {
+                "name": "Ana fırça kullanımı"
+            },
+            "sidebrushusage": {
+                "name": "Yan fırça kullanımı"
+            },
+            "mopusage": {
+                "name": "Paspas kullanımı"
+            },
+            "moparmextensionfreq": {
+                "name": "Paspas kolu uzatma frekansı"
+            },
+            "mopdrytime": {
+                "name": "Paspasın kuruma süresi"
+            },
+            "mopwashfreqarea": {
+                "name": "Paspas yıkama sıklığı alanı"
+            },
+            "mopwashfreqtime": {
+                "name": "Paspas yıkama sıklığı süresi"
+            },
+            "mopwashfreqtype": {
+                "name": "Paspas yıkama sıklığı tipi"
+            },
+            "numberofcleaningrepetitions": {
+                "name": "Temizleme tekrarları"
+            },
+            "voicevolume": {
+                "name": "Ses seviyesi"
+            },
+            "upgradeprogress": {
+                "name": "Yükseltme ilerlemesi"
+            },
+            "stationupgradestatus": {
+                "name": "İstasyon yükseltme durumu"
+            },
+            "upgradestate": {
+                "name": "Yükseltme durumu"
+            },
+            "selectedroomid": {
+                "name": "Seçilen oda kimliği"
+            },
+            "maxusagedustbox": {
+                "name": "Maksimum toz kutusu kullanımı"
+            },
+            "maxusagestationbag": {
+                "name": "Maksimum istasyon çantası kullanımı"
+            },
+            "dndstarttime": {
+                "name": "Dnd başlangıç ​​zamanı"
+            },
+            "dndendtime": {
+                "name": "Bitiş zamanı"
+            },
+            "datamodelversion": {
+                "name": "Veri modeli sürümü"
+            },
+            "basestationversion": {
+                "name": "Baz istasyonu versiyonu"
+            },
+            "deviceid": {
+                "name": "Cihaz kimliği"
+            },
+            "timezonedaylightrule": {
+                "name": "Saat dilimi gün ışığı kuralı"
+            },
+            "timezonestandardname": {
+                "name": "Saat dilimi standart adı"
+            },
+            "bintank": {
+                "name": "Çöp kutusu tankı"
+            },
+            "setvoicevolume": {
+                "name": "Ses ses seviyesi"
+            },
+            "mapid": {
+                "name": "Kalıcı harita kimliği"
+            },
+            "sessionid": {
+                "name": "Temizleme oturumu kimliği"
+            },
+            "completion": {
+                "name": "Temizlemenin tamamlanması"
+            },
+            "areacovered": {
+                "name": "Kapsanan alan"
+            },
+            "zones": {
+                "name": "Harita bölgesi sayısı"
+            },
+            "zonestatus": {
+                "name": "Temizleme bölgesi durumu"
+            },
+            "ovwater_tank_empty": {
+                "name": "Su Deposu Durumu"
+            },
+            "foodprobeinsertionstate": {
+                "name": "Gıda Sondası"
+            },
+            "ovcleaning_ended": {
+                "name": "Temizleme Durumu"
+            },
+            "ovfood_probe_end_of_cooking": {
+                "name": "Pişirme Sonu Probu"
+            },
+            "connectivitystate": {
+                "name": "Bağlantı Durumu"
+            },
+            "executionstate": {
+                "name": "Yürütme Durumu"
+            }
+        },
+        "switch": {
+            "uilockmode": {
+                "name": "Çocuk kilidi dahili"
+            },
+            "cavitylight": {
+                "name": "Boşluk ışığı"
+            },
+            "childlock": {
+                "name": "Çocuk kilidi"
+            },
+            "soundvolume": {
+                "name": "Ses seviyesi"
+            },
+            "keysoundtone": {
+                "name": "Tuş sesi"
+            },
+            "windownotification": {
+                "name": "Pencere bildirimi"
+            },
+            "hoodfiltercharcenable": {
+                "name": "Kömür filtresini etkinleştir"
+            },
+            "fastmode": {
+                "name": "Dondurucu hızlı modu"
+            },
+            "sabbathmode": {
+                "name": "Şabat modu"
+            },
+            "ecomode": {
+                "name": "Eko modu"
+            },
+            "ui2lockmode": {
+                "name": "Kullanıcı arayüzü 2 kilit modu"
+            },
+            "ewx1493a_prewashphase": {
+                "name": "Ön yıkama"
+            },
+            "ewx1493a_anticreasenosteam": {
+                "name": "Kırışık önleme (buhar yok)"
+            },
+            "ewx1493a_anticreasewsteam": {
+                "name": "Buharla kırışıklık önleme"
+            },
+            "ewx1493a_nightcycle": {
+                "name": "Gece döngüsü"
+            },
+            "ewx1493a_wmeconomy": {
+                "name": "Ekonomi modu"
+            },
+            "ewx1493a_rinsehold": {
+                "name": "Durulamada bekletme"
+            },
+            "ewx1493a_intensive": {
+                "name": "Yoğun yıkama"
+            },
+            "ewx1493a_tcsensor": {
+                "name": "Sıcaklık sensörü"
+            },
+            "ewx1493a_stain": {
+                "name": "Leke tedavisi"
+            },
+            "ewx1493a_drymode": {
+                "name": "Kurutma modu"
+            },
+            "ewx1493a_easyiron": {
+                "name": "Kolay ütü"
+            },
+            "ewx1493a_pod": {
+                "name": "Kapsül"
+            },
+            "ewx1493a_steammode": {
+                "name": "Buhar modu"
+            },
+            "ewx1493a_ultramix": {
+                "name": "Ultra karışım"
+            },
+            "ewx1493a_wetmode": {
+                "name": "Islak mod"
+            },
+            "networkinterfacealwayson": {
+                "name": "Ağ her zaman açık"
+            },
+            "adlocalfinetuning": {
+                "name": "Otomatik doz yerel ince ayar"
+            },
+            "anticreasenosteam": {
+                "name": "Kırışık önleyici buhar yok"
+            },
+            "anticreasewsteam": {
+                "name": "Buharla kırışıklık önleme"
+            },
+            "ultramix": {
+                "name": "Ultra karışım"
+            },
+            "prewashphase": {
+                "name": "Ön yıkama"
+            },
+            "stain": {
+                "name": "Leke eylemi"
+            },
+            "nightcycle": {
+                "name": "Gece döngüsü"
+            },
+            "wmeconomy": {
+                "name": "Ekonomi modu"
+            },
+            "rinsehold": {
+                "name": "Durulamada bekletme"
+            },
+            "tcsensor": {
+                "name": "Sıcaklık sensörü"
+            },
+            "soak": {
+                "name": "Emmek"
+            },
+            "softener": {
+                "name": "Yumuşatıcı"
+            },
+            "defaultsoftplus": {
+                "name": "Varsayılan yumuşak artı"
+            },
+            "intensive": {
+                "name": "Yoğun"
+            },
+            "reverseplus": {
+                "name": "Ters artı"
+            },
+            "tdeconomy_eco": {
+                "name": "Eko modu"
+            },
+            "tdeconomy_night": {
+                "name": "Gece modu"
+            },
+            "tdeconomy_quick": {
+                "name": "Hızlı mod"
+            },
+            "refresh": {
+                "name": "Programı yenile"
+            },
+            "keytone": {
+                "name": "Tuş sesi"
+            },
+            "preselectlast": {
+                "name": "Pre select last"
+            },
+            "extrapoweroption": {
+                "name": "Ekstra güç"
+            },
+            "extrasilentoption": {
+                "name": "Extra silent"
+            },
+            "glasscareoption": {
+                "name": "Cam bakımı"
+            },
+            "sprayzoneoption": {
+                "name": "Püskürtme bölgesi"
+            },
+            "autodooropener": {
+                "name": "Otomatik kapı açıcı"
+            },
+            "sanitizeoption": {
+                "name": "Sterilize et"
+            },
+            "onerackoption": {
+                "name": "Bir raf"
+            },
+            "zonecleanoption": {
+                "name": "Bölge temizliği"
+            },
+            "xtradryoption": {
+                "name": "Ekstra kuru"
+            },
+            "cleanairmode": {
+                "name": "Temiz hava modu"
+            },
+            "sleepmode": {
+                "name": "Uyku modu"
+            },
+            "batchschedulermode": {
+                "name": "Toplu planlayıcı modu"
+            },
+            "verticalswing": {
+                "name": "Dikey salınım"
+            },
+            "turbofunction": {
+                "name": "Turbo işlevi"
+            },
+            "energysavingmode": {
+                "name": "Enerji tasarrufu modu"
+            },
+            "autocleantrigger": {
+                "name": "Otomatik temizleme tetikleyicisi"
+            },
+            "flappositionavoiduser": {
+                "name": "Flap konumu kullanıcıyı önler"
+            },
+            "horizontalswing": {
+                "name": "Yatay salıncak"
+            },
+            "humidification": {
+                "name": "Nemlendirme"
+            },
+            "uilight": {
+                "name": "Kullanıcı arayüzü ışığı"
+            },
+            "safetylock": {
+                "name": "Emniyet kilidi"
+            },
+            "ionizer": {
+                "name": "İyonlaştırıcı"
+            },
+            "uvstate": {
+                "name": "UV ışığı"
+            },
+            "mute": {
+                "name": "Sesini kapatmak"
+            }
         }
     }
 }

--- a/custom_components/electrolux/translations/translate.py
+++ b/custom_components/electrolux/translations/translate.py
@@ -96,27 +96,27 @@ def main():
 
     # Define the target languages (excluding English)
     languages = {
-        # "bg": ("български", "bg"),
-        # "cs": ("český", "cs"),
-        # "da": ("Dansk", "da"),
-        # "de": ("Deutsch", "de"),
-        # "el": ("ελληνικός", "el"),
-        # "es": ("Español", "es"),
-        # "et": ("eesti", "et"),
-        # "fi": ("Suomi", "fi"),
-        # "fr": ("Français", "fr"),
-        # "hr": ("Hrvatski", "hr"),
-        # "hu": ("magyar", "hu"),
-        # "it": ("Italiano", "it"),
-        # "lb": ("Lëtzebuergesch", "lb"),
-        # "lt": ("lietuvių", "lt"),
-        # "lv": ("latviešu", "lv"),
-        # "nl": ("nederlands", "nl"),
-        # "no": ("norsk", "no"),
-        # "pl": ("polski", "pl"),
-        # "pt_br": ("Português Brasil", "pt"),
-        # "pt": ("Português", "pt"),
-        # "ro": ("Română", "ro"),
+        "bg": ("български", "bg"),
+        "cs": ("český", "cs"),
+        "da": ("Dansk", "da"),
+        "de": ("Deutsch", "de"),
+        "el": ("ελληνικός", "el"),
+        "es": ("Español", "es"),
+        "et": ("eesti", "et"),
+        "fi": ("Suomi", "fi"),
+        "fr": ("Français", "fr"),
+        "hr": ("Hrvatski", "hr"),
+        "hu": ("magyar", "hu"),
+        "it": ("Italiano", "it"),
+        "lb": ("Lëtzebuergesch", "lb"),
+        "lt": ("lietuvių", "lt"),
+        "lv": ("latviešu", "lv"),
+        "nl": ("nederlands", "nl"),
+        "no": ("norsk", "no"),
+        "pl": ("polski", "pl"),
+        "pt_br": ("Português Brasil", "pt"),
+        "pt": ("Português", "pt"),
+        "ro": ("Română", "ro"),
         "ru": ("русский", "ru"),
         "sk": ("slovenský", "sk"),
         "sl": ("slovenščina", "sl"),
@@ -144,9 +144,7 @@ def main():
             continue
         # Skip manually translated languages
         if language_code in manually_translated:
-            print(
-                f"Skipping {language_name} ({language_code}.json) - already manually translated"
-            )
+            print(f"Skipping {language_name} ({language_code}.json) - already manually translated")
             continue
         print(f"Translating {language_name} ({language_code}.json)")
 
@@ -155,9 +153,7 @@ def main():
             cache = {}
             translated_data = translate_value(en_data, translator, cache)
 
-            output_path = os.path.join(
-                os.path.dirname(__file__), f"{language_code}.json"
-            )
+            output_path = os.path.join(os.path.dirname(__file__), f"{language_code}.json")
             with open(output_path, "w", encoding="utf-8") as file:
                 json.dump(translated_data, file, ensure_ascii=False, indent=4)
 
@@ -166,9 +162,7 @@ def main():
         except Exception as e:
             print(f"✗ Failed to translate {language_name}: {e}")
             # Fallback to English
-            output_path = os.path.join(
-                os.path.dirname(__file__), f"{language_code}.json"
-            )
+            output_path = os.path.join(os.path.dirname(__file__), f"{language_code}.json")
             with open(output_path, "w", encoding="utf-8") as file:
                 json.dump(en_data, file, ensure_ascii=False, indent=4)
 

--- a/custom_components/electrolux/translations/uk.json
+++ b/custom_components/electrolux/translations/uk.json
@@ -2,11 +2,11 @@
     "config": {
         "step": {
             "user": {
-                "title": "Electrolux Setup",
-                "description": "Connect your Electrolux appliances using API credentials from the Electrolux Developer Portal.\n\n**Щоб отримати облікові дані API:**\n1. Відвідайте {url}\n2. Зареєструватися та створити заявку\n3. Obtain your API Key, Access Token, and Refresh Token\n\nIf you need help, visit the integration documentation.",
+                "title": "Налаштування Electrolux",
+                "description": "Підключіть свої прилади Electrolux за допомогою облікових даних API з порталу розробників Electrolux.\n\n**Щоб отримати облікові дані API:**\n1. Відвідайте {url}\n2. Зареєструватися та створити заявку\n3. Отримайте ключ API, маркер доступу та маркер оновлення\n\nЯкщо вам потрібна допомога, відвідайте документацію інтеграції.",
                 "data": {
                     "api_key": "Ключ API",
-                    "access_token": "Access Token",
+                    "access_token": "Маркер доступу",
                     "refresh_token": "Оновити маркер",
                     "notifications": "Увімкнути сповіщення для критичних сповіщень",
                     "notifications_warning": "Увімкнути сповіщення для попереджень",
@@ -15,7 +15,7 @@
             },
             "reauth_validate": {
                 "title": "Повторно автентифікуйте Electrolux",
-                "description": "Термін дії ваших токенів Electrolux API закінчився або вони недійсні. Оновіть їх новими маркерами з порталу розробників Electrolux.\n\nВідвідайте {url}, щоб створити нові токени.",
+                "description": "Термін дії ваших токенів Electrolux API закінчився або вони недійсні. Оновіть їх новими маркерами з порталу розробників Electrolux.\n\nВідвідайте {url}, щоб створити нові маркери.",
                 "data": {
                     "api_key": "Ключ API",
                     "access_token": "Маркер доступу",
@@ -24,7 +24,7 @@
             },
             "reconfigure": {
                 "title": "Переконфігуруйте Electrolux",
-                "description": "Оновіть свої облікові дані Electrolux API.\n\nВідвідайте {url}, щоб створити нові токени.",
+                "description": "Оновіть свої облікові дані Electrolux API.\n\nВідвідайте {url}, щоб створити нові маркери.",
                 "data": {
                     "api_key": "Ключ API",
                     "access_token": "Маркер доступу",
@@ -33,7 +33,7 @@
             }
         },
         "error": {
-            "invalid_auth": "Недійсні облікові дані API. Please check your API Key, Access Token, and Refresh Token from the Electrolux Developer Portal."
+            "invalid_auth": "Недійсні облікові дані API. Перевірте свій ключ API, маркер доступу та маркер оновлення на порталі розробників Electrolux."
         },
         "abort": {
             "single_instance_allowed": "Допускається лише одна конфігурація Electrolux.",
@@ -47,7 +47,7 @@
         "step": {
             "user": {
                 "title": "Опції Electrolux",
-                "description": "Оновіть свої облікові дані Electrolux API, якщо термін їх дії минув.\n\n**Щоб створити нові облікові дані:**\n1. Відвідайте {url}\n2. Створіть новий ключ API, маркер доступу та маркер оновлення\n3. Оновіть поля нижче\n\n**Примітка щодо безпеки:** поля маркера доступу та маркера оновлення навмисно залишено порожніми. Завжди створюйте нові токени з порталу – ніколи не використовуйте повторно та не діліться існуючими токенами.",
+                "description": "Оновіть свої облікові дані Electrolux API, якщо термін їх дії минув.\n\n**Щоб створити нові облікові дані:**\n1. Відвідайте {url}\n2. Створіть новий ключ API, маркер доступу та маркер оновлення\n3. Оновіть поля нижче\n\n**Примітка щодо безпеки.** Поля маркера доступу та маркера оновлення навмисно залишено порожніми. Завжди створюйте нові токени з порталу – ніколи не використовуйте повторно та не діліться наявними токенами.",
                 "data": {
                     "api_key": "Ключ API",
                     "access_token": "Маркер доступу",
@@ -104,11 +104,17 @@
         "command_rate_limited": {
             "message": "Надіслано забагато команд. Будь ласка, зачекайте трохи і спробуйте ще раз."
         },
+        "control_disabled_by_mode": {
+            "message": "{attr} не можна налаштувати в поточному режимі."
+        },
         "control_locked": {
             "message": "{attr} заблоковано на {value} для програми {program}."
         },
+        "fanspeed_disabled": {
+            "message": "Швидкість вентилятора не можна регулювати в режимі {mode}. Спочатку перейдіть у ручний режим, щоб контролювати швидкість вентилятора."
+        },
         "food_probe_locked_by_program": {
-            "message": "Температура харчового зонда зафіксована на рівні {value}°C для програми {program}."
+            "message": "Температура харчового датчика зафіксована на {value}°C для програми {program}."
         },
         "food_probe_not_inserted": {
             "message": "Щоб встановити цільову температуру, потрібно вставити харчовий зонд."
@@ -142,6 +148,1417 @@
         },
         "value_below_minimum": {
             "message": "Значення {value} нижче мінімального {min_val} для {attr}."
+        }
+    },
+    "services": {
+        "start_zone_cleaning": {
+            "name": "Почніть очищення зони",
+            "description": "Почніть сеанс зонального прибирання на роботі-пилососі PUREi9. UUID зони та UUID постійної карти можна знайти в діагностиці інтеграції (mapData/mapMatch/zones і persistentMapsCreated/mapId).",
+            "fields": {
+                "persistent_map_id": {
+                    "name": "Постійний ідентифікатор карти",
+                    "description": "UUID постійної карти для використання (з діагностики: persistentMapsCreated/mapId).",
+                    "example": "afb13c1b-b557-4a11-84a6-5bfaef90304e"
+                },
+                "zones": {
+                    "name": "Зони",
+                    "description": "Список зон для очищення. Для кожного запису потрібен zone_id (UUID з mapData/mapMatch/zones[].uuid) і необов’язковий power_mode (1=тихий, 2=розумний, 3=потужний, за умовчанням 1).",
+                    "example": "9082f714-bdba-4f3a-892f-46b2ff2e07de"
+                }
+            }
+        }
+    },
+    "entity": {
+        "binary_sensor": {
+            "connectivitystate": {
+                "name": "Стан підключення"
+            },
+            "doorstate": {
+                "name": "Стан дверей"
+            },
+            "foodprobeinsertionstate": {
+                "name": "Харчовий зонд"
+            },
+            "foodprobesupported": {
+                "name": "Підтримка харчового зонда"
+            },
+            "watertrayinsertionstate": {
+                "name": "Піддон для води"
+            },
+            "watertankempty": {
+                "name": "Бак для води порожній"
+            },
+            "cleaningreminder": {
+                "name": "Нагадування про очищення"
+            },
+            "drawerstatus": {
+                "name": "Шухляда"
+            },
+            "humancentriclighteventstate": {
+                "name": "Людиноцентричне світло"
+            },
+            "hoodautoswitchoffevent": {
+                "name": "Автоматичне відключення"
+            },
+            "appliancestate": {
+                "name": "Морозильний стан"
+            },
+            "fanstate": {
+                "name": "Додатковий стан вентилятора порожнини"
+            },
+            "autosense": {
+                "name": "Автосенс"
+            },
+            "maint1_occured": {
+                "name": "Потрібне технічне обслуговування"
+            },
+            "maint2_occured": {
+                "name": "Відбулося технічне обслуговування 2"
+            },
+            "maint3_occured": {
+                "name": "Відбувся елемент технічного обслуговування 3"
+            },
+            "maint4_occured": {
+                "name": "Відбувся елемент технічного обслуговування 4"
+            },
+            "maint5_occured": {
+                "name": "Відбувся елемент технічного обслуговування 5"
+            },
+            "maint6_occured": {
+                "name": "Відбувся елемент технічного обслуговування 6"
+            },
+            "maint7_occured": {
+                "name": "Відбувся елемент обслуговування 7"
+            },
+            "maint8_occured": {
+                "name": "Виникла тема технічного обслуговування 8"
+            },
+            "maint9_occured": {
+                "name": "Відбувся елемент технічного обслуговування 9"
+            },
+            "maint10_occured": {
+                "name": "Відбувся елемент технічного обслуговування 10"
+            },
+            "occured": {
+                "name": "Відбулося технічне обслуговування 1"
+            },
+            "ecomode": {
+                "name": "Еко режим"
+            },
+            "hmepn_acairfilterclean": {
+                "name": "Потрібне очищення повітряного фільтра"
+            },
+            "hmepn_acalerts": {
+                "name": "Підтримуються сповіщення AC"
+            },
+            "hepafilterinsertedstate": {
+                "name": "Вставлений фільтр Hepa"
+            },
+            "dooropen": {
+                "name": "Двері відкриті"
+            },
+            "watertraylevellow": {
+                "name": "Низький рівень піддона для води"
+            },
+            "autodustcollection": {
+                "name": "Автоматичне збирання пилу"
+            },
+            "automoparmextension": {
+                "name": "Автоматичний подовжувач рукава швабри"
+            },
+            "automopdry": {
+                "name": "Auto mop dry"
+            },
+            "automopwash": {
+                "name": "Автомобільна мийка"
+            },
+            "autodetergentusage": {
+                "name": "Використання автоматичного миючого засобу"
+            },
+            "mopinstalled": {
+                "name": "Швабра встановлена"
+            },
+            "incharger": {
+                "name": "В зарядному пристрої"
+            },
+            "returntowash": {
+                "name": "Поверніться до прання"
+            },
+            "roomselected": {
+                "name": "Кімната обрана"
+            },
+            "carpetboost": {
+                "name": "Посилення килима"
+            },
+            "carpetavoid": {
+                "name": "Уникайте килимів"
+            },
+            "carpetdisplay": {
+                "name": "Килимовий дисплей"
+            },
+            "obstacleavoidance": {
+                "name": "Уникнення перешкод"
+            },
+            "dndenabled": {
+                "name": "Не турбувати ввімкнено"
+            },
+            "dnddisableairdry": {
+                "name": "Не вимикайте сушіння повітрям"
+            },
+            "isdndpausingairdry": {
+                "name": "Не зупиняйте сушіння на повітрі"
+            },
+            "multifloormap": {
+                "name": "Багатоповерхова карта"
+            },
+            "multifloormapautoswitch": {
+                "name": "Автоматичний перемикач багатоповерхової карти"
+            },
+            "robotposereliable": {
+                "name": "Поза робота надійна"
+            },
+            "ovwater_tank_empty": {
+                "name": "Стан резервуара для води"
+            },
+            "ovcleaning_ended": {
+                "name": "Статус очищення"
+            },
+            "ovfood_probe_end_of_cooking": {
+                "name": "Зонд закінчення приготування"
+            }
+        },
+        "button": {
+            "command": {
+                "name": "Команда мережі"
+            },
+            "startupcommand": {
+                "name": "Команда запуску"
+            },
+            "manualsync": {
+                "name": "Ручна синхронізація"
+            },
+            "executecommand": {
+                "name": "потужність"
+            },
+            "waterfilterstatereset": {
+                "name": "Скинути водяний фільтр"
+            },
+            "airfilterstatereset": {
+                "name": "Скинути повітряний фільтр"
+            },
+            "saveappfavorite": {
+                "name": "Save favorite"
+            },
+            "shortcutproglistcmd": {
+                "name": "Команда списку ярликів програм"
+            },
+            "filterreset": {
+                "name": "Скидання фільтра"
+            },
+            "hepafilterreset": {
+                "name": "Скидання фільтра Hepa"
+            },
+            "findme": {
+                "name": "Знайди мене"
+            }
+        },
+        "fan": {
+            "fan": {
+                "name": "Очищувач повітря"
+            }
+        },
+        "number": {
+            "starttime": {
+                "name": "Час початку"
+            },
+            "targetduration": {
+                "name": "Цільова тривалість"
+            },
+            "targetfoodprobetemperaturec": {
+                "name": "Цільова температура харчового зонда c"
+            },
+            "targetfoodprobetemperaturef": {
+                "name": "Цільова температура харчового зонда f"
+            },
+            "targettemperaturec": {
+                "name": "Цільова температура c"
+            },
+            "targettemperaturef": {
+                "name": "Цільова температура f"
+            },
+            "remindertime": {
+                "name": "Час нагадування верхньої духовки"
+            },
+            "appliancelocaltimeoffset": {
+                "name": "Зсув місцевого часу пристрою"
+            },
+            "lightintensity": {
+                "name": "Інтенсивність світла"
+            },
+            "lightcolortemperature": {
+                "name": "Світла колірна температура"
+            },
+            "stoptime": {
+                "name": "Зупинити час"
+            },
+            "adtankadetstandarddose": {
+                "name": "Наберіть стандартну дозу миючого засобу"
+            },
+            "adtankbdetstandarddose": {
+                "name": "Резервуар b стандартна доза миючого засобу"
+            },
+            "adtankbsoftstandarddose": {
+                "name": "Резервуар b пом'якшувач стандартна доза"
+            },
+            "adfinetunedetlevel": {
+                "name": "Точне налаштування рівня миючого засобу"
+            },
+            "adfinetunesoftlevel": {
+                "name": "Точне налаштування рівня пом’якшувача"
+            },
+            "extrarinsenumber": {
+                "name": "Додаткові полоскання"
+            },
+            "maint1_id": {
+                "name": "Технічне обслуговування 1 id"
+            },
+            "maint2_id": {
+                "name": "Технічне обслуговування 2 ід"
+            },
+            "maint2_threshold": {
+                "name": "Порогове значення елемента обслуговування 2"
+            },
+            "maint3_id": {
+                "name": "Пункт обслуговування 3 id"
+            },
+            "maint3_threshold": {
+                "name": "Порогове значення елемента обслуговування 3"
+            },
+            "maint4_id": {
+                "name": "Пункт технічного обслуговування 4 ід"
+            },
+            "maint4_threshold": {
+                "name": "Порогове значення елемента обслуговування 4"
+            },
+            "maint5_id": {
+                "name": "Пункт технічного обслуговування 5 ід"
+            },
+            "maint5_threshold": {
+                "name": "Порогове значення елемента обслуговування 5"
+            },
+            "maint6_id": {
+                "name": "Пункт технічного обслуговування 6 ід"
+            },
+            "maint6_threshold": {
+                "name": "Порогове значення пункту технічного обслуговування 6"
+            },
+            "maint7_id": {
+                "name": "Пункт обслуговування 7 ід"
+            },
+            "maint7_threshold": {
+                "name": "Порогове значення пункту технічного обслуговування 7"
+            },
+            "maint8_id": {
+                "name": "Пункт технічного обслуговування 8 ід"
+            },
+            "maint8_threshold": {
+                "name": "Порогове значення пункту технічного обслуговування 8"
+            },
+            "maint9_id": {
+                "name": "Пункт технічного обслуговування 9 ід"
+            },
+            "maint9_threshold": {
+                "name": "Порогове значення пункту технічного обслуговування 9"
+            },
+            "maint10_id": {
+                "name": "Пункт технічного обслуговування 10 ід"
+            },
+            "maint10_threshold": {
+                "name": "Порогове значення елемента обслуговування 10"
+            },
+            "clearcyclepersonalizationcmd": {
+                "name": "Чітка персоналізація циклу"
+            },
+            "memoryid": {
+                "name": "Слот пам'яті"
+            },
+            "dryingtime": {
+                "name": "Сушка за часом (активна)"
+            },
+            "timetonotify": {
+                "name": "Час повідомити"
+            },
+            "anticreasevalue": {
+                "name": "Антизминання (активне)"
+            },
+            "rinseaidlevel": {
+                "name": "Рівень ополіскувача"
+            },
+            "targethumidity": {
+                "name": "Цільова вологість"
+            },
+            "targettemperature": {
+                "name": "Цільова температура"
+            },
+            "fanspeed": {
+                "name": "Швидкість вентилятора"
+            },
+            "humiditytarget": {
+                "name": "Цільова вологість"
+            },
+            "powermode": {
+                "name": "Режим потужності"
+            }
+        },
+        "select": {
+            "displaylight": {
+                "name": "Світло дисплея"
+            },
+            "targettemperaturec": {
+                "name": "Додаткова температура порожнини"
+            },
+            "mode": {
+                "name": "Режим"
+            },
+            "fanspeedsetting": {
+                "name": "Швидкість вентилятора"
+            }
+        },
+        "sensor": {
+            "alerts": {
+                "name": "Оповіщення"
+            },
+            "appliancestate": {
+                "name": "Стан пристрою"
+            },
+            "temperaturerepresentation": {
+                "name": "Представлення температури"
+            },
+            "linkqualityindicator": {
+                "name": "Індикатор якості зв'язку мережевого інтерфейсу"
+            },
+            "niuswupdatecurrentdescription": {
+                "name": "Опис оновлення Niu sw"
+            },
+            "otastate": {
+                "name": "Стан мережевого інтерфейсу"
+            },
+            "swancandrevision": {
+                "name": "Sw anc і перегляд"
+            },
+            "swversion": {
+                "name": "Версія ПЗ мережевого інтерфейсу"
+            },
+            "endofcyclesound": {
+                "name": "Звук закінчення циклу"
+            },
+            "programuid": {
+                "name": "uid програми"
+            },
+            "appliancetype": {
+                "name": "Тип приладу"
+            },
+            "capabilityhash": {
+                "name": "Хеш можливостей"
+            },
+            "cpv": {
+                "name": "Cpv"
+            },
+            "remotecontrol": {
+                "name": "Дистанційне керування"
+            },
+            "totalcyclecounter": {
+                "name": "Лічильник загального циклу"
+            },
+            "appliancetotalworkingtime": {
+                "name": "Загальний час роботи приладу"
+            },
+            "timetoend": {
+                "name": "Час закінчувати"
+            },
+            "displayfoodprobetemperature": {
+                "name": "Відображення температури харчового датчика"
+            },
+            "displayfoodprobetemperaturec": {
+                "name": "Відображення температури харчового датчика c"
+            },
+            "displayfoodprobetemperaturef": {
+                "name": "Відображення температури харчового зонда f"
+            },
+            "displaytemperature": {
+                "name": "Відображення температури"
+            },
+            "displaytemperaturec": {
+                "name": "Відображення температури c"
+            },
+            "displaytemperaturef": {
+                "name": "Відображення температури f"
+            },
+            "processphase": {
+                "name": "Фаза процесу"
+            },
+            "program": {
+                "name": "програма"
+            },
+            "runningtime": {
+                "name": "Час роботи"
+            },
+            "fastheatupfeature": {
+                "name": "Верхня функція швидкого нагрівання духовки"
+            },
+            "preheatcomplete": {
+                "name": "Попередній нагрів верхньої духовки завершено"
+            },
+            "targetdurationendaction": {
+                "name": "Верхня цільова тривалість кінцевої дії"
+            },
+            "targetfoodprobetemperatureendaction": {
+                "name": "Кінцева дія температурного датчика температури верхньої духовки"
+            },
+            "watertanklevel": {
+                "name": "Верхній рівень води духовки"
+            },
+            "waterhardness": {
+                "name": "Жорсткість води"
+            },
+            "descalingreminderstate": {
+                "name": "Нагадування про видалення накипу"
+            },
+            "clockstyle": {
+                "name": "Стиль годинника"
+            },
+            "language": {
+                "name": "Мова"
+            },
+            "localtimeautomaticmode": {
+                "name": "Автоматичний режим за місцевим часом"
+            },
+            "autolocaltimeoffset": {
+                "name": "Автоматичний зсув місцевого часу"
+            },
+            "favoriteorder": {
+                "name": "Улюблене замовлення"
+            },
+            "number": {
+                "name": "Кількість улюблених замовлень"
+            },
+            "favoriteselect": {
+                "name": "Улюблений вибір"
+            },
+            "favoritestatus": {
+                "name": "Улюблений статус"
+            },
+            "activemessageindex": {
+                "name": "Індекс активного повідомлення"
+            },
+            "appliancemode": {
+                "name": "Режим приладу"
+            },
+            "hobtohoodfanspeed": {
+                "name": "Швидкість вентилятора витяжки"
+            },
+            "hobtohoodstate": {
+                "name": "Стан капота"
+            },
+            "hoodfanlevel": {
+                "name": "Рівень вентилятора"
+            },
+            "hoodcharcfiltertimer": {
+                "name": "Таймер вугільного фільтра"
+            },
+            "hoodgreasefiltertimer": {
+                "name": "Таймер жиропоглинаючого фільтра"
+            },
+            "tvocfiltertime": {
+                "name": "Час фільтра Tvoc"
+            },
+            "fastmodetimetoend": {
+                "name": "Швидкий режим морозильної камери закінчується"
+            },
+            "sensortemperaturec": {
+                "name": "Температура морозильника"
+            },
+            "vacationholidaymode": {
+                "name": "Vacation holiday mode"
+            },
+            "sensorhumidity": {
+                "name": "Вологість"
+            },
+            "waterfilterstate": {
+                "name": "Стан фільтра для води"
+            },
+            "waterfilterlifetime": {
+                "name": "Термін служби водяного фільтра"
+            },
+            "waterfilterflow": {
+                "name": "Фільтр потоку води"
+            },
+            "airfilterstate": {
+                "name": "Стан повітряного фільтра"
+            },
+            "airfilterlifetime": {
+                "name": "Термін служби повітряного фільтра"
+            },
+            "coolingvalvestate": {
+                "name": "Стан клапана охолодження"
+            },
+            "defrostroutinestate": {
+                "name": "Стандартний стан розморожування"
+            },
+            "compressorstate": {
+                "name": "Стан компресора"
+            },
+            "compressorspeed": {
+                "name": "Швидкість компресора"
+            },
+            "coefficient": {
+                "name": "Коефіцієнт швидкодії компресора"
+            },
+            "exponent": {
+                "name": "Показник швидкості компресора"
+            },
+            "clonetargettemperaturemode": {
+                "name": "Режим клонування додаткової порожнини"
+            },
+            "temperatureadjustingstate": {
+                "name": "Регулювання додаткової порожнини"
+            },
+            "defrosttemperaturec": {
+                "name": "Температура розморожування льодогенератора"
+            },
+            "evaporatorfanstate": {
+                "name": "Стан вентилятора льодогенератора"
+            },
+            "icedispenserstate": {
+                "name": "Стан дозатора льоду"
+            },
+            "icetraywaterfillsetting": {
+                "name": "Налаштування наповнення лотка для льоду"
+            },
+            "airfilterlifetimebuythreshold": {
+                "name": "Повітряний фільтр купити поріг"
+            },
+            "airfilterlifetimechangethreshold": {
+                "name": "Поріг зміни повітряного фільтра"
+            },
+            "waterfilterflowbuythreshold": {
+                "name": "Поріг покупки фільтра для води (потік)"
+            },
+            "waterfilterflowchangethreshold": {
+                "name": "Поріг зміни водяного фільтра (потік)"
+            },
+            "waterfilterlifetimebuythreshold": {
+                "name": "Поріг покупки фільтра для води (час)"
+            },
+            "waterfilterlifetimechangethreshold": {
+                "name": "Поріг заміни водяного фільтра (час)"
+            },
+            "appliancemainboardswversion": {
+                "name": "Версія ПЗ головної плати"
+            },
+            "defaultextrarinse": {
+                "name": "Додаткове полоскання за замовчуванням"
+            },
+            "cyclephase": {
+                "name": "Фаза циклу"
+            },
+            "cyclesubphase": {
+                "name": "Підфаза циклу"
+            },
+            "measuredloadweight": {
+                "name": "Виміряна вага вантажу"
+            },
+            "doorlock": {
+                "name": "Дверний замок"
+            },
+            "totalwashcyclescount": {
+                "name": "Загальна кількість циклів прання"
+            },
+            "totalwashingtime": {
+                "name": "Загальний час прання"
+            },
+            "fcoptisenseloadweight": {
+                "name": "Вага навантаження"
+            },
+            "washingnominalloadweight": {
+                "name": "Вага завантаження білизни"
+            },
+            "adtankaconfiguration": {
+                "name": "Конфігурація танка"
+            },
+            "adtankbconfiguration": {
+                "name": "Конфігурація танка b"
+            },
+            "steamvalue": {
+                "name": "Рівень пари"
+            },
+            "timemanagerlevel": {
+                "name": "Менеджер часу"
+            },
+            "adtankasel": {
+                "name": "Auto-dose tank a"
+            },
+            "adtankbsel": {
+                "name": "Автодозатор b"
+            },
+            "analogspinspeed": {
+                "name": "Spin speed"
+            },
+            "analogtemperature": {
+                "name": "Температура"
+            },
+            "watersoftenermode": {
+                "name": "Режим пом'якшення води"
+            },
+            "maint1_threshold": {
+                "name": "Поріг обслуговування"
+            },
+            "detergentextradosage": {
+                "name": "Додаткове дозування миючого засобу"
+            },
+            "optisenseresult": {
+                "name": "Вага навантаження"
+            },
+            "softenerextradosage": {
+                "name": "Пом'якшувач додаткове дозування"
+            },
+            "tankadetloadfornominalweight": {
+                "name": "Резервуар має деталізаційне навантаження на номінальну вагу"
+            },
+            "tankareserve": {
+                "name": "Танк резервний"
+            },
+            "tankbdetloadfornominalweight": {
+                "name": "Резервуар b дет. навантаження для номінальної ваги"
+            },
+            "tankbreserve": {
+                "name": "Танк б резервний"
+            },
+            "waterusage": {
+                "name": "Використання води"
+            },
+            "adtankadetloaded": {
+                "name": "Завантажений бак із миючим засобом"
+            },
+            "adtankbdetloaded": {
+                "name": "Бак b завантажено миючим засобом"
+            },
+            "adtankbsoftloaded": {
+                "name": "Резервуар b пом’якшувача завантажено"
+            },
+            "ecolevel": {
+                "name": "Еко рівень"
+            },
+            "applianceuiswversion": {
+                "name": "Версія програмного забезпечення інтерфейсу пристрою"
+            },
+            "remotenotificationpending": {
+                "name": "Очікується віддалене сповіщення"
+            },
+            "minfinishintime": {
+                "name": "Мінімальний термін обробки"
+            },
+            "ewx1493a_wmeconomy": {
+                "name": "Режим економії"
+            },
+            "adfinetunedetlevel": {
+                "name": "Тонка автоматична доза миючого засобу"
+            },
+            "adfinetunesoftlevel": {
+                "name": "Тонка автоматична доза пом’якшувача"
+            },
+            "extrarinsenumber": {
+                "name": "Додаткове полоскання"
+            },
+            "threshold": {
+                "name": "Технічне обслуговування 1 поріг"
+            },
+            "timezonedatabasename": {
+                "name": "База даних часових поясів"
+            },
+            "totalsteamcyclecounter": {
+                "name": "Лічильник загального парового циклу"
+            },
+            "prewashphase": {
+                "name": "Фаза попереднього прання"
+            },
+            "dryingnominalloadweight": {
+                "name": "Номінальна вага навантаження"
+            },
+            "humiditytarget": {
+                "name": "Цільова вологість (активна)"
+            },
+            "tankalevel": {
+                "name": "Танк рівня"
+            },
+            "tankblevel": {
+                "name": "Бак b рівня"
+            },
+            "totaldrycyclescount": {
+                "name": "Загальні сухі цикли"
+            },
+            "totaldryingtime": {
+                "name": "Загальний час висихання"
+            },
+            "totalwashdrycyclescount": {
+                "name": "Загальна кількість циклів прання+сушіння"
+            },
+            "programsorder": {
+                "name": "Порядок програми"
+            },
+            "carelevel": {
+                "name": "Рівень догляду"
+            },
+            "drynessvalue": {
+                "name": "Рівень сухості (активний)"
+            },
+            "wmloadweight": {
+                "name": "Dwyw: вага завантаження білизни"
+            },
+            "wmloadmoisture": {
+                "name": "Dwyw: вологість прання"
+            },
+            "tdcloudtte": {
+                "name": "Dwyw: очікуваний час висихання"
+            },
+            "tdecpoverload": {
+                "name": "Dwyw: позначка перевантаження завантаження"
+            },
+            "wmloaderror": {
+                "name": "Dwyw: помилка завантаження білизни"
+            },
+            "wmsn": {
+                "name": "Dwyw: спарена серійна шайба"
+            },
+            "command": {
+                "name": "Dwyw: команда"
+            },
+            "displayonfloor": {
+                "name": "Дисплей на підлозі"
+            },
+            "energyscore": {
+                "name": "Оцінка енергії"
+            },
+            "waterscore": {
+                "name": "Оцінка води"
+            },
+            "ecoscore": {
+                "name": "Еко бал"
+            },
+            "miscellaneousstate": {
+                "name": "Різний стан"
+            },
+            "ambienttemperaturec": {
+                "name": "Температура навколишнього середовища c"
+            },
+            "ambienttemperaturef": {
+                "name": "Температура навколишнього середовища f"
+            },
+            "fanmode": {
+                "name": "Режим вентилятора"
+            },
+            "swingmode": {
+                "name": "Режим гойдалки"
+            },
+            "ambienthumidity": {
+                "name": "Вологість навколишнього середовища"
+            },
+            "filterstatus": {
+                "name": "Статус фільтра"
+            },
+            "powerconsumption": {
+                "name": "Споживана потужність"
+            },
+            "energyconsumption": {
+                "name": "Енергоспоживання"
+            },
+            "fanspeedstate": {
+                "name": "Стан швидкості вентилятора"
+            },
+            "filterstate": {
+                "name": "Стан фільтра"
+            },
+            "hepafilterlifetime": {
+                "name": "Термін служби фільтра Hepa"
+            },
+            "appliancecategory": {
+                "name": "Категорія приладу"
+            },
+            "vmno_niu": {
+                "name": "Версія Niu"
+            },
+            "vmno_mcu": {
+                "name": "Версія MCU"
+            },
+            "schedulersession": {
+                "name": "Сеанс планувальника"
+            },
+            "schedulermode": {
+                "name": "Режим планувальника"
+            },
+            "totalruntime": {
+                "name": "Загальний час роботи"
+            },
+            "compressorcoolingruntime": {
+                "name": "Час роботи компресора при охолодженні"
+            },
+            "compressorheatingruntime": {
+                "name": "Час роботи компресора підігріву"
+            },
+            "mainunittemp": {
+                "name": "Основна температура блоку"
+            },
+            "loge": {
+                "name": "Журнал e"
+            },
+            "logw": {
+                "name": "Log w"
+            },
+            "demandresponseau": {
+                "name": "Відповідь на попит au"
+            },
+            "pm25": {
+                "name": "Pm2,5"
+            },
+            "pm10": {
+                "name": "Pm10"
+            },
+            "modestate": {
+                "name": "Стан режиму"
+            },
+            "filterruntime": {
+                "name": "Час роботи фільтра"
+            },
+            "hepafilterstate": {
+                "name": "Стан фільтра Hepa"
+            },
+            "airqualitylevel": {
+                "name": "Рівень якості повітря"
+            },
+            "temperature": {
+                "name": "Температура навколишнього середовища"
+            },
+            "mode": {
+                "name": "Режим"
+            },
+            "temp": {
+                "name": "Температура"
+            },
+            "humidity": {
+                "name": "Вологість"
+            },
+            "pm1": {
+                "name": "Pm1"
+            },
+            "pm2_5": {
+                "name": "Pm2,5"
+            },
+            "tvoc": {
+                "name": "Tvoc"
+            },
+            "eco2": {
+                "name": "Eco2"
+            },
+            "filtertype": {
+                "name": "Тип фільтра"
+            },
+            "filterlife": {
+                "name": "Ресурс фільтра"
+            },
+            "workmode": {
+                "name": "Режим роботи"
+            },
+            "aqilight": {
+                "name": "Акі світло"
+            },
+            "louverswing": {
+                "name": "Гойдалки жалюзі"
+            },
+            "quietfan": {
+                "name": "Тихий вентилятор"
+            },
+            "humidificationfilter_resetdate": {
+                "name": "Дата скидання фільтра зволоження"
+            },
+            "filterlife_1": {
+                "name": "Ресурс фільтра"
+            },
+            "filterlife_2": {
+                "name": "Термін служби фільтра 2"
+            },
+            "filtertype_1": {
+                "name": "Тип фільтра"
+            },
+            "filtertype_2": {
+                "name": "Тип фільтра 2"
+            },
+            "filteruid_1": {
+                "name": "UID тегу nfc фільтра 1"
+            },
+            "filteruid_2": {
+                "name": "UID тегу nfc фільтра 2"
+            },
+            "pm2_5_approximate": {
+                "name": "Pm2,5 (приблизно)"
+            },
+            "uvruntime": {
+                "name": "Час виконання УФ"
+            },
+            "schedulingstate": {
+                "name": "Стан планування"
+            },
+            "errimpellerstuck": {
+                "name": "Error: impeller stuck"
+            },
+            "errpmnotresp": {
+                "name": "Помилка: датчик PM не відповідає"
+            },
+            "errcommsensordisplaybrd": {
+                "name": "Помилка: комунікація з платою дисплея"
+            },
+            "errcommsensoruibrd": {
+                "name": "Помилка: комунікація дошки інтерфейсу"
+            },
+            "signalstrength": {
+                "name": "Сила сигналу"
+            },
+            "rssi": {
+                "name": "Rssi"
+            },
+            "filterrfid": {
+                "name": "Filter rfid"
+            },
+            "errgasnotresp": {
+                "name": "Помилка: датчик газу не реагує"
+            },
+            "errnfctagnotpres_1": {
+                "name": "Помилка: тег nfc фільтра 1 відсутній"
+            },
+            "errnfctagnotpres_2": {
+                "name": "Помилка: тег nfc фільтра 2 відсутній"
+            },
+            "errnfctagpresnotvalid_1": {
+                "name": "Помилка: тег nfc фільтра 1 недійсний"
+            },
+            "errnfctagpresnotvalid_2": {
+                "name": "Помилка: тег nfc фільтра 2 недійсний"
+            },
+            "errnfctransceiver_1": {
+                "name": "Помилка: відфільтрувати трансивер nfc 1"
+            },
+            "errnfctransceiver_2": {
+                "name": "Помилка: фільтр 2 трансивера nfc"
+            },
+            "errtemprhnotresp": {
+                "name": "Помилка: датчик температури/вологості не відповідає"
+            },
+            "errwatertrayremoved": {
+                "name": "Помилка: піддон для води видалено"
+            },
+            "waterbucketlevel": {
+                "name": "Рівень відра з водою"
+            },
+            "batterystatus": {
+                "name": "Акумулятор"
+            },
+            "robotstatus": {
+                "name": "Статус робота"
+            },
+            "cleaningcommand": {
+                "name": "Команда очищення"
+            },
+            "dustbinstatus": {
+                "name": "Статус смітника"
+            },
+            "mainbrushsqm": {
+                "name": "Використання основної щітки"
+            },
+            "sidebrushsqm": {
+                "name": "Використання бічної щітки"
+            },
+            "filtersqm": {
+                "name": "Використання фільтра"
+            },
+            "state": {
+                "name": "Стан очищення"
+            },
+            "chargingstatus": {
+                "name": "Стан зарядки"
+            },
+            "vacuummode": {
+                "name": "Вакуумний режим"
+            },
+            "cleaningtype": {
+                "name": "Тип очищення"
+            },
+            "cleaningmode": {
+                "name": "Режим очищення"
+            },
+            "waterpumprate": {
+                "name": "Швидкість водяного насоса"
+            },
+            "waterstationaction": {
+                "name": "Акція водної станції"
+            },
+            "moproute": {
+                "name": "Швабра маршруту"
+            },
+            "notificationevent": {
+                "name": "Подія сповіщення"
+            },
+            "dirtcleanmode": {
+                "name": "Режим очищення від бруду"
+            },
+            "faultcode": {
+                "name": "Код несправності"
+            },
+            "filterusage": {
+                "name": "Використання фільтра"
+            },
+            "cleansize": {
+                "name": "Чистий розмір"
+            },
+            "cleantime": {
+                "name": "Чистий час"
+            },
+            "dustbagusage": {
+                "name": "Використання мішка для пилу"
+            },
+            "dustboxusage": {
+                "name": "Використання пилозбірника"
+            },
+            "emptyingtime": {
+                "name": "Час спорожнення"
+            },
+            "mainbrushusage": {
+                "name": "Використання основної щітки"
+            },
+            "sidebrushusage": {
+                "name": "Використання бічної щітки"
+            },
+            "mopusage": {
+                "name": "Використання швабри"
+            },
+            "moparmextensionfreq": {
+                "name": "Частота висування рук швабри"
+            },
+            "mopdrytime": {
+                "name": "Час висихання швабри"
+            },
+            "mopwashfreqarea": {
+                "name": "Область частоти миття шваброю"
+            },
+            "mopwashfreqtime": {
+                "name": "Частота миття шваброю"
+            },
+            "mopwashfreqtype": {
+                "name": "Тип частоти прання шваброю"
+            },
+            "numberofcleaningrepetitions": {
+                "name": "Повтори очищення"
+            },
+            "voicevolume": {
+                "name": "Гучність голосу"
+            },
+            "upgradeprogress": {
+                "name": "Прогрес оновлення"
+            },
+            "stationupgradestatus": {
+                "name": "Статус оновлення станції"
+            },
+            "upgradestate": {
+                "name": "Стан оновлення"
+            },
+            "selectedroomid": {
+                "name": "Вибраний ідентифікатор кімнати"
+            },
+            "maxusagedustbox": {
+                "name": "Максимальне використання пилозбірника"
+            },
+            "maxusagestationbag": {
+                "name": "Максимальне використання сумки на станції"
+            },
+            "dndstarttime": {
+                "name": "Не час початку"
+            },
+            "dndendtime": {
+                "name": "Dnd час закінчення"
+            },
+            "datamodelversion": {
+                "name": "Версія моделі даних"
+            },
+            "basestationversion": {
+                "name": "Версія базової станції"
+            },
+            "deviceid": {
+                "name": "ID пристрою"
+            },
+            "timezonedaylightrule": {
+                "name": "Правило денного часового поясу"
+            },
+            "timezonestandardname": {
+                "name": "Стандартна назва часового поясу"
+            },
+            "bintank": {
+                "name": "Бункерний бак"
+            },
+            "setvoicevolume": {
+                "name": "Рівень гучності голосу"
+            },
+            "mapid": {
+                "name": "Постійний ідентифікатор карти"
+            },
+            "sessionid": {
+                "name": "Ідентифікатор сеансу очищення"
+            },
+            "completion": {
+                "name": "Завершення очищення"
+            },
+            "areacovered": {
+                "name": "Охоплена площа"
+            },
+            "zones": {
+                "name": "Кількість зон на карті"
+            },
+            "zonestatus": {
+                "name": "Статус зони очищення"
+            },
+            "ovwater_tank_empty": {
+                "name": "Стан резервуара для води"
+            },
+            "foodprobeinsertionstate": {
+                "name": "Харчовий зонд"
+            },
+            "ovcleaning_ended": {
+                "name": "Статус очищення"
+            },
+            "ovfood_probe_end_of_cooking": {
+                "name": "Зонд закінчення приготування"
+            },
+            "connectivitystate": {
+                "name": "Стан підключення"
+            },
+            "executionstate": {
+                "name": "Стан виконання"
+            }
+        },
+        "switch": {
+            "uilockmode": {
+                "name": "Внутрішній замок від дітей"
+            },
+            "cavitylight": {
+                "name": "Порожнинне світло"
+            },
+            "childlock": {
+                "name": "Блокування від дітей"
+            },
+            "soundvolume": {
+                "name": "Гучність звуку"
+            },
+            "keysoundtone": {
+                "name": "Звук клавіш"
+            },
+            "windownotification": {
+                "name": "Вікно сповіщення"
+            },
+            "hoodfiltercharcenable": {
+                "name": "Активація вугільного фільтра"
+            },
+            "fastmode": {
+                "name": "Швидкий режим морозильної камери"
+            },
+            "sabbathmode": {
+                "name": "Суботній режим"
+            },
+            "ecomode": {
+                "name": "Еко режим"
+            },
+            "ui2lockmode": {
+                "name": "Режим блокування Ui 2"
+            },
+            "ewx1493a_prewashphase": {
+                "name": "Попереднє прання"
+            },
+            "ewx1493a_anticreasenosteam": {
+                "name": "Захист від зминання (без пари)"
+            },
+            "ewx1493a_anticreasewsteam": {
+                "name": "Протизминання за допомогою пари"
+            },
+            "ewx1493a_nightcycle": {
+                "name": "Нічний цикл"
+            },
+            "ewx1493a_wmeconomy": {
+                "name": "Режим економії"
+            },
+            "ewx1493a_rinsehold": {
+                "name": "Затримка полоскання"
+            },
+            "ewx1493a_intensive": {
+                "name": "Інтенсивне прання"
+            },
+            "ewx1493a_tcsensor": {
+                "name": "Датчик температури"
+            },
+            "ewx1493a_stain": {
+                "name": "Лікування плям"
+            },
+            "ewx1493a_drymode": {
+                "name": "Сухий режим"
+            },
+            "ewx1493a_easyiron": {
+                "name": "Легке прасування"
+            },
+            "ewx1493a_pod": {
+                "name": "Стручок"
+            },
+            "ewx1493a_steammode": {
+                "name": "Паровий режим"
+            },
+            "ewx1493a_ultramix": {
+                "name": "Ультра суміш"
+            },
+            "ewx1493a_wetmode": {
+                "name": "Вологий режим"
+            },
+            "networkinterfacealwayson": {
+                "name": "Мережа завжди ввімкнена"
+            },
+            "adlocalfinetuning": {
+                "name": "Автоматичне локальне налаштування дози"
+            },
+            "anticreasenosteam": {
+                "name": "Антизминання без пара"
+            },
+            "anticreasewsteam": {
+                "name": "Протизминання за допомогою пари"
+            },
+            "ultramix": {
+                "name": "Ультра суміш"
+            },
+            "prewashphase": {
+                "name": "Попереднє прання"
+            },
+            "stain": {
+                "name": "Дія плями"
+            },
+            "nightcycle": {
+                "name": "Нічний цикл"
+            },
+            "wmeconomy": {
+                "name": "Режим економії"
+            },
+            "rinsehold": {
+                "name": "Затримка полоскання"
+            },
+            "tcsensor": {
+                "name": "Датчик температури"
+            },
+            "soak": {
+                "name": "Замочити"
+            },
+            "softener": {
+                "name": "Пом'якшувач"
+            },
+            "defaultsoftplus": {
+                "name": "М'який плюс за замовчуванням"
+            },
+            "intensive": {
+                "name": "Інтенсивний"
+            },
+            "reverseplus": {
+                "name": "Зворотний плюс"
+            },
+            "tdeconomy_eco": {
+                "name": "Еко режим"
+            },
+            "tdeconomy_night": {
+                "name": "Нічний режим"
+            },
+            "tdeconomy_quick": {
+                "name": "Швидкий режим"
+            },
+            "refresh": {
+                "name": "Програма оновлення"
+            },
+            "keytone": {
+                "name": "Ключовий тон"
+            },
+            "preselectlast": {
+                "name": "Попередньо виберіть останній"
+            },
+            "extrapoweroption": {
+                "name": "Додаткова потужність"
+            },
+            "extrasilentoption": {
+                "name": "Дуже тихий"
+            },
+            "glasscareoption": {
+                "name": "Догляд за склом"
+            },
+            "sprayzoneoption": {
+                "name": "Зона розпилення"
+            },
+            "autodooropener": {
+                "name": "Автоматичне відкривання дверей"
+            },
+            "sanitizeoption": {
+                "name": "Продезінфікувати"
+            },
+            "onerackoption": {
+                "name": "Одна стійка"
+            },
+            "zonecleanoption": {
+                "name": "Зона чиста"
+            },
+            "xtradryoption": {
+                "name": "Екстрасухий"
+            },
+            "cleanairmode": {
+                "name": "Режим чистого повітря"
+            },
+            "sleepmode": {
+                "name": "Режим сну"
+            },
+            "batchschedulermode": {
+                "name": "Пакетний режим планувальника"
+            },
+            "verticalswing": {
+                "name": "Вертикальні гойдалки"
+            },
+            "turbofunction": {
+                "name": "Функція турбо"
+            },
+            "energysavingmode": {
+                "name": "Режим енергозбереження"
+            },
+            "autocleantrigger": {
+                "name": "Тригер автоматичного очищення"
+            },
+            "flappositionavoiduser": {
+                "name": "Користувач уникає положення клапана"
+            },
+            "horizontalswing": {
+                "name": "Горизонтальні гойдалки"
+            },
+            "humidification": {
+                "name": "зволоження"
+            },
+            "uilight": {
+                "name": "Ui світло"
+            },
+            "safetylock": {
+                "name": "Запобіжник"
+            },
+            "ionizer": {
+                "name": "Іонізатор"
+            },
+            "uvstate": {
+                "name": "УФ світло"
+            },
+            "mute": {
+                "name": "Вимкнути звук"
+            }
         }
     }
 }


### PR DESCRIPTION
- Add new translation keys: control_disabled_by_mode, fanspeed_disabled, services.start_zone_cleaning, and many others
- Extend and update translations for bg, cs, da, de, el, es, et, fi, fr, hr, hu, it, lb, lt, lv, nl, no, pl, pt, pt_br, ro, ru, sk, sl, sv, tr, uk
- Fix existing translations (token capitalization, maintenance item names, service descriptions, and others)

Closes #167