### PR TITLE
feat(rvc): add 700series vacuum entity + diagnostic sensors

### DIFF
--- a/tests/test_vacuum.py
+++ b/tests/test_vacuum.py
@@ -1032,9 +1032,7 @@ class TestElectroluxVacuum700series:
             patch(
                 "custom_components.electrolux.vacuum.ElectroluxVacuum"
             ) as mock_vacuum_class,
-            patch(
-                "custom_components.electrolux.vacuum.async_get_current_platform"
-            ),
+            patch("custom_components.electrolux.vacuum.async_get_current_platform"),
         ):
             await async_setup_entry(hass, entry, async_add_entities)
 


### PR DESCRIPTION
## Summary
- Add `"700series"` to `_RVC_TYPES` so vacuum entities are actually created for 700series appliances (was mapped in `catalog_core.py` but missing from the vacuum type set)
- Add 5 diagnostic sensor entries to `catalog_rvc.py`: `dockType`, `logE`, `logW`, `niuStatus`, `soundPackFile`
- Add tests covering 700series vacuum entity creation and diagnostic catalog entries

## Test plan
- [x] `uv run pytest` — 145 tests pass
- [x] `uv run ruff check` — clean
- [x] `uv run black --check` — clean
- [ ] Verify on a real 700series device (Luxxie) that vacuum entity appears and diagnostic sensors report data

Closes #159