### PR TITLE
fix(coordinator): add progressive exponential backoff on stream setup and rotation failures

### DIFF
--- a/custom_components/electrolux/api_client.py
+++ b/custom_components/electrolux/api_client.py
@@ -491,11 +491,16 @@ class ElectroluxApiClient:
                         "Appliance connectivity will be determined by individual data updates.",
                         ", ".join(appliance_ids),
                     )
+                    if not is_auth_error(task.exception()):
+                        if self.coordinator and hasattr(self.coordinator, "handle_sse_stream_failure"):
+                            self.coordinator.handle_sse_stream_failure(task.exception())
                 else:
                     _LOGGER.debug(
                         "SSE event stream ended unexpectedly for appliances %s (no exception)",
                         ", ".join(appliance_ids),
                     )
+                    if self.coordinator and hasattr(self.coordinator, "handle_sse_stream_failure"):
+                        self.coordinator.handle_sse_stream_failure(None)
 
             self._sse_task.add_done_callback(_handle_sse_failure)
 

--- a/custom_components/electrolux/coordinator.py
+++ b/custom_components/electrolux/coordinator.py
@@ -155,6 +155,7 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
         self._capability_retry_task: asyncio.Task | None = None
         self._last_sse_resync_time = 0.0
         self._pending_sse_resync_task: asyncio.Task | None = None
+        self._sse_retry_task: asyncio.Task | None = None
         self._last_remote_control: dict[
             str, str
         ] = {}  # Track remoteControl state per appliance to detect panel interactions
@@ -765,6 +766,12 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
 
     async def _on_sse_connected(self) -> None:
         """Handle actual SSE connection events, including internal SDK reconnects."""
+        pending_retry = getattr(self, "_sse_retry_task", None)
+        if pending_retry and pending_retry is not asyncio.current_task() and not pending_retry.done():
+            pending_retry.cancel()
+        if getattr(self, "_sse_retry_task", None) is not asyncio.current_task():
+            self._sse_retry_task = None
+
         now = self.hass.loop.time()
         # Seed watchdog timestamp at connection-open time so a fresh stream gets
         # a full quiet window before being considered stalled.
@@ -811,6 +818,12 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
 
     async def listen_websocket(self) -> None:
         """Listen for state changes."""
+        pending_retry = getattr(self, "_sse_retry_task", None)
+        if pending_retry and pending_retry is not asyncio.current_task() and not pending_retry.done():
+            pending_retry.cancel()
+        if getattr(self, "_sse_retry_task", None) is not asyncio.current_task():
+            self._sse_retry_task = None
+
         if self.data is None:
             _LOGGER.warning("No coordinator data available, skipping SSE setup")
             return
@@ -1114,6 +1127,12 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
             time_to_end_monitor_task.cancel()
             await asyncio.gather(time_to_end_monitor_task, return_exceptions=True)
         self._time_to_end_monitor_task = None
+
+        sse_retry_task = getattr(self, "_sse_retry_task", None)
+        if sse_retry_task and not sse_retry_task.done():
+            sse_retry_task.cancel()
+            await asyncio.gather(sse_retry_task, return_exceptions=True)
+        self._sse_retry_task = None
 
         # Close API connection - util.py handles SSE stream cleanup
         try:
@@ -1805,6 +1824,52 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
             SSE_RESTART_MAX_COOLDOWN,
         )
 
+    def handle_sse_stream_failure(self, error: Exception | None = None) -> None:
+        """Handle background SSE stream failures (e.g. get_livestream_config failure) by applying progressive backoff."""
+        if not self.hass or not self.hass.is_running:
+            return
+
+        # Cancel any existing scheduled retry task
+        pending = getattr(self, "_sse_retry_task", None)
+        if pending and not pending.done():
+            pending.cancel()
+
+        self._consecutive_sse_restarts += 1
+        backoff = self._sse_backoff_seconds(self._consecutive_sse_restarts)
+        err_msg = str(error) if error else "stream ended unexpectedly"
+
+        _LOGGER.warning(
+            "[STREAM-SETUP] Stream initialization failed (%s). Retrying in %0.1fs (attempt %d)",
+            err_msg,
+            backoff,
+            self._consecutive_sse_restarts,
+        )
+
+        self._sse_retry_task = self.hass.async_create_task(
+            self._delayed_sse_retry(backoff),
+            name=f"{DOMAIN}-sse-stream-retry",
+        )
+
+    async def _delayed_sse_retry(self, delay: float) -> None:
+        """Retry starting the SSE stream after backoff delay."""
+        try:
+            await asyncio.sleep(delay)
+            _LOGGER.debug(
+                "Executing scheduled SSE stream setup retry (attempt %d)",
+                self._consecutive_sse_restarts,
+            )
+            # Clear retry task reference before calling listen_websocket so it doesn't cancel itself
+            self._sse_retry_task = None
+            await self.listen_websocket()
+        except asyncio.CancelledError:
+            _LOGGER.debug("Scheduled SSE stream setup retry cancelled")
+            raise
+        except Exception as ex:
+            _LOGGER.warning("Scheduled SSE stream setup retry failed: %s", ex)
+        finally:
+            if getattr(self, "_sse_retry_task", None) is asyncio.current_task():
+                self._sse_retry_task = None
+
     async def _restart_sse_if_stalled(self, app_dict: dict[str, Any]) -> None:
         """Restart SSE if stream is stale while at least one appliance is connected."""
         sse_task = getattr(self.api, "_sse_task", None)
@@ -1843,12 +1908,13 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
             SSE_STALL_THRESHOLD,
         )
         self._consecutive_sse_restarts += 1
-        self._last_sse_restart_log_count += 1
+        self._last_sse_restart_log_count = getattr(self, "_last_sse_restart_log_count", 0) + 1
 
         # Log summary every 5 restarts or on the first few to avoid spam
         backoff_seconds = self._sse_backoff_seconds(self._consecutive_sse_restarts)
         backoff_desc = f"{int(backoff_seconds)}s" if backoff_seconds < 60 else f"{backoff_seconds / 60:.1f}min"
-        if self._last_sse_restart_log_count <= 3 or self._last_sse_restart_log_count % 5 == 0:
+        log_count = getattr(self, "_last_sse_restart_log_count", 0)
+        if log_count <= 3 or log_count % 5 == 0:
             _LOGGER.info(
                 "SSE watchdog initiating stream restart (restart #%d, backoff %s)",
                 self._consecutive_sse_restarts,

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1039,18 +1039,22 @@ class TestWatchForApplianceStateUpdates:
         hass.async_create_task = MagicMock(return_value=task)
 
         client = _make_client(hass=hass)
+        client.coordinator = MagicMock()
+        client.coordinator.handle_sse_stream_failure = MagicMock()
         client._client = MagicMock()
         client._client.start_event_stream = MagicMock(return_value=MagicMock())
 
         await client.watch_for_appliance_state_updates(["app1"], MagicMock())
 
-        # Simulate non-auth error (no reauth)
+        # Simulate non-auth error (no reauth, but coordinator stream failure handled)
         task.cancelled = MagicMock(return_value=False)
-        task.exception = MagicMock(return_value=Exception("general network error"))
+        error_ex = Exception("general network error")
+        task.exception = MagicMock(return_value=error_ex)
         captured_cb["cb"](task)
 
         # call_soon_threadsafe should not have been called (no auth error)
         hass.loop.call_soon_threadsafe.assert_not_called()
+        client.coordinator.handle_sse_stream_failure.assert_called_once_with(error_ex)
 
     @pytest.mark.asyncio
     async def test_sse_ended_without_exception(self):
@@ -1069,6 +1073,8 @@ class TestWatchForApplianceStateUpdates:
         hass.async_create_task = MagicMock(return_value=task)
 
         client = _make_client(hass=hass)
+        client.coordinator = MagicMock()
+        client.coordinator.handle_sse_stream_failure = MagicMock()
         client._client = MagicMock()
         client._client.start_event_stream = MagicMock(return_value=MagicMock())
 
@@ -1077,7 +1083,9 @@ class TestWatchForApplianceStateUpdates:
         # Simulate task completed without cancellation or exception
         task.cancelled = MagicMock(return_value=False)
         task.exception = MagicMock(return_value=None)
-        captured_cb["cb"](task)  # Should not raise
+        captured_cb["cb"](task)
+
+        client.coordinator.handle_sse_stream_failure.assert_called_once_with(None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_coordinator_advanced.py
+++ b/tests/test_coordinator_advanced.py
@@ -92,6 +92,7 @@ def coordinator(mock_hass, mock_api):
         coord._pending_state_refresh_tasks = {}
         coord._last_sse_resync_time = 0.0
         coord._pending_sse_resync_task = None
+        coord._sse_retry_task = None
         return coord
 
 

--- a/tests/test_coordinator_coverage_gaps.py
+++ b/tests/test_coordinator_coverage_gaps.py
@@ -94,6 +94,7 @@ def coordinator(mock_hass, mock_api):
         coord._pending_state_refresh_tasks = {}
         coord._last_sse_resync_time = 0.0
         coord._pending_sse_resync_task = None
+        coord._sse_retry_task = None
         return coord
 
 

--- a/tests/test_coordinator_methods.py
+++ b/tests/test_coordinator_methods.py
@@ -91,6 +91,7 @@ def coordinator(mock_hass, mock_api):
         coord._pending_state_refresh_tasks = {}
         coord._last_sse_resync_time = 0.0
         coord._pending_sse_resync_task = None
+        coord._sse_retry_task = None
         monitor_task = MagicMock()
         monitor_task.done.return_value = True
         coord._sse_stall_monitor_task = monitor_task
@@ -1588,3 +1589,167 @@ class TestCleanupRemovedAppliancesEdgeCases:
         coordinator.api.get_appliances_list = AsyncMock(return_value=[{"applianceId": "app1"}])
 
         await coordinator.cleanup_removed_appliances()  # Should not raise
+
+
+# ===========================================================================
+# Progressive Backoff on Stream Setup Failures (handle_sse_stream_failure)
+# ===========================================================================
+
+
+class TestStreamSetupProgressiveBackoff:
+    @pytest.mark.asyncio
+    async def test_handle_sse_stream_failure_increments_restarts_and_schedules_backoff(self, coordinator):
+        """handle_sse_stream_failure increments consecutive restarts and schedules exponential retry."""
+        coordinator.hass.is_running = True
+        created_tasks = []
+
+        def _mock_create_task(coro, **kwargs):
+            if asyncio.iscoroutine(coro):
+                coro.close()
+            t = MagicMock()
+            t.done.return_value = False
+            created_tasks.append((t, kwargs.get("name")))
+            return t
+
+        coordinator.hass.async_create_task = MagicMock(side_effect=_mock_create_task)
+
+        # Attempt 1: DNS timeout
+        coordinator.handle_sse_stream_failure(Exception("Timeout while contacting DNS servers"))
+        assert coordinator._consecutive_sse_restarts == 1
+        assert coordinator._sse_backoff_seconds(1) == 30.0
+        assert coordinator._sse_retry_task is not None
+        assert created_tasks[-1][1] == "electrolux-sse-stream-retry"
+
+        # Attempt 2: Connection reset
+        coordinator.handle_sse_stream_failure(Exception("Cannot connect to host"))
+        assert coordinator._consecutive_sse_restarts == 2
+        assert coordinator._sse_backoff_seconds(2) == 60.0
+
+    @pytest.mark.asyncio
+    async def test_handle_sse_stream_failure_cancels_previous_retry(self, coordinator):
+        """handle_sse_stream_failure cancels an existing active retry task before scheduling a new one."""
+        coordinator.hass.is_running = True
+        old_task = MagicMock()
+        old_task.done.return_value = False
+        old_task.cancel = MagicMock()
+        coordinator._sse_retry_task = old_task
+
+        def _mock_create_task(coro, **kwargs):
+            if asyncio.iscoroutine(coro):
+                coro.close()
+            t = MagicMock()
+            t.done.return_value = False
+            return t
+
+        coordinator.hass.async_create_task = MagicMock(side_effect=_mock_create_task)
+
+        coordinator.handle_sse_stream_failure(Exception("Stream failed"))
+        old_task.cancel.assert_called_once()
+        assert coordinator._sse_retry_task is not old_task
+
+    @pytest.mark.asyncio
+    async def test_handle_sse_stream_failure_noop_when_hass_not_running(self, coordinator):
+        """handle_sse_stream_failure does nothing if Home Assistant is not running."""
+        coordinator.hass.is_running = False
+        coordinator.handle_sse_stream_failure(Exception("Some error"))
+        assert coordinator._consecutive_sse_restarts == 0
+        assert coordinator._sse_retry_task is None
+
+    @pytest.mark.asyncio
+    async def test_delayed_sse_retry_executes_listen_websocket(self, coordinator):
+        """_delayed_sse_retry sleeps for the delay and then calls listen_websocket."""
+        coordinator.listen_websocket = AsyncMock()
+        sleep_delays = []
+
+        async def _mock_sleep(delay):
+            sleep_delays.append(delay)
+
+        with patch("asyncio.sleep", side_effect=_mock_sleep):
+            await coordinator._delayed_sse_retry(15.0)
+
+        assert sleep_delays == [15.0]
+        coordinator.listen_websocket.assert_awaited_once()
+        assert coordinator._sse_retry_task is None
+
+    @pytest.mark.asyncio
+    async def test_delayed_sse_retry_task_executes_real_listen_websocket_without_self_cancellation(self, coordinator):
+        """_delayed_sse_retry running as an asyncio task executes real listen_websocket without self-cancelling."""
+        ap = _make_appliance("app1")
+        coordinator.data = {"appliances": _make_appliances({"app1": ap})}
+        coordinator.api.watch_for_appliance_state_updates = AsyncMock()
+
+        # Schedule as actual asyncio task
+        retry_task = asyncio.create_task(coordinator._delayed_sse_retry(0.001))
+        coordinator._sse_retry_task = retry_task
+
+        await retry_task
+
+        assert not retry_task.cancelled()
+        coordinator.api.watch_for_appliance_state_updates.assert_awaited_once()
+        assert coordinator._sse_retry_task is None
+
+    @pytest.mark.asyncio
+    async def test_delayed_sse_retry_handles_cancellation(self, coordinator):
+        """_delayed_sse_retry re-raises CancelledError and clears _sse_retry_task."""
+        with (
+            patch("asyncio.sleep", side_effect=asyncio.CancelledError()),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await coordinator._delayed_sse_retry(15.0)
+
+        assert coordinator._sse_retry_task is None
+
+    @pytest.mark.asyncio
+    async def test_delayed_sse_retry_catches_listen_exception(self, coordinator):
+        """_delayed_sse_retry catches exceptions from listen_websocket without unhandled exception."""
+        coordinator.listen_websocket = AsyncMock(side_effect=Exception("Failed to start SSE"))
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await coordinator._delayed_sse_retry(15.0)
+
+        coordinator.listen_websocket.assert_awaited_once()
+        assert coordinator._sse_retry_task is None
+
+    @pytest.mark.asyncio
+    async def test_on_sse_connected_cancels_pending_retry_task(self, coordinator):
+        """_on_sse_connected cancels and clears active retry task on successful connection."""
+        retry_task = MagicMock()
+        retry_task.done.return_value = False
+        retry_task.cancel = MagicMock()
+        coordinator._sse_retry_task = retry_task
+
+        coordinator._consecutive_sse_restarts = 3
+        coordinator._sse_data_received_since_connect = True
+        coordinator._last_sse_resync_time = 0.0
+        coordinator._perform_sse_resync = AsyncMock()
+
+        await coordinator._on_sse_connected()
+
+        retry_task.cancel.assert_called_once()
+        assert coordinator._sse_retry_task is None
+        assert coordinator._consecutive_sse_restarts == 0
+
+    @pytest.mark.asyncio
+    async def test_listen_websocket_cancels_pending_retry_task(self, coordinator):
+        """Direct call to listen_websocket cancels any pending retry task."""
+        retry_task = MagicMock()
+        retry_task.done.return_value = False
+        retry_task.cancel = MagicMock()
+        coordinator._sse_retry_task = retry_task
+        coordinator.data = None  # early return
+
+        await coordinator.listen_websocket()
+
+        retry_task.cancel.assert_called_once()
+        assert coordinator._sse_retry_task is None
+
+    @pytest.mark.asyncio
+    async def test_close_websocket_cancels_pending_retry_task(self, coordinator):
+        """close_websocket cancels and clears any pending retry task."""
+        retry_task = asyncio.create_task(asyncio.sleep(100))
+        coordinator._sse_retry_task = retry_task
+        coordinator.api.close = AsyncMock()
+
+        await coordinator.close_websocket()
+
+        assert retry_task.cancelled()
+        assert coordinator._sse_retry_task is None

--- a/tests/test_coordinator_update_paths.py
+++ b/tests/test_coordinator_update_paths.py
@@ -92,6 +92,7 @@ def coordinator(mock_hass, mock_api):
         coord.last_update_success = True
         coord._last_remote_control = {}
         coord._pending_state_refresh_tasks = {}
+        coord._sse_retry_task = None
         return coord
 
 


### PR DESCRIPTION
## Summary

The recent Electrolux cloud disruptions provided a great real-world testing ground for monitoring and connection resiliency work. Telemetry and connection state tracking helped spot an edge case where a transient DNS/gateway timeout during scheduled 2-hour token rotation caused the integration to remain disconnected from live SSE events for 2 full hours until the next rotation cycle.

This PR adds progressive exponential backoff to recover automatically from failures during stream setup and rotation rather than waiting for the next 2-hour renewal tick.

---

## Root Cause

1. Every 2 hours, `renew_websocket()` initiates stream reconnection to rotate tokens.
2. `listen_websocket()` spawns `watch_for_appliance_state_updates()` as a background task (`_sse_task`) and returns immediately.
3. Because `listen_websocket()` returns without error, `renew_websocket()` considers the renewal successful and sleeps for 2 hours (`renew_interval = 7200s`).
4. In the background task, the SDK calls `get_livestream_config()`. If this initial request encounters a transient network error (e.g. DNS timeout, 5xx, gateway error), `_sse_task` terminates.
5. The callback `_handle_sse_failure()` logged the error but did not notify the coordinator or schedule a retry. Meanwhile, the stall watchdog skipped because `sse_task.done()` was `True`.

### Real-World Log Trace (2-Hour Gap)

```log
2026-08-24 03:02:37.587 WARNING (MainThread) [custom_components.electrolux] [STREAM-SETUP] Failed to livestream config: Cannot connect to host api.developer.electrolux.one:443 ssl:default [Timeout while contacting DNS servers]
2026-08-24 03:02:37.587 INFO (MainThread) [custom_components.electrolux] Stream state changed: streaming -> disconnected (drops=2, backoff=0.0s)
... (silent gap with no live updates for 2 hours) ...
2026-08-24 05:02:13.815 INFO (MainThread) [custom_components.electrolux] Scheduled 2-hour token rotation triggered proactive stream refresh
2026-08-24 05:02:14.120 INFO (MainThread) [custom_components.electrolux] Stream connected successfully to live.eu.developer.electrolux.one (state: streaming)
```

---

## Changes in this PR

1. **Failure Propagation (`api_client.py`):**
   * Updated `_handle_sse_failure()` so non-authentication exceptions and unexpected stream endings notify `coordinator.handle_sse_stream_failure()`.
2. **Progressive Exponential Backoff (`coordinator.py`):**
   * Added `handle_sse_stream_failure()` and `_delayed_sse_retry()`.
   * Applies bounded exponential backoff: $15\text{s} \times \min(2^{\text{restarts}}, 120)$ ($15\text{s} \rightarrow 30\text{s} \rightarrow 60\text{s} \rightarrow \dots \rightarrow \max 30\text{m}$) to recover quickly from transient hiccups while protecting against request storms during prolonged outages.
   * Logs: `[STREAM-SETUP] Stream initialization failed (<error>). Retrying in <backoff>s (attempt <N>)`.
3. **Task Lifecycle & Cancellation Safety (`coordinator.py`):**
   * Clears `_sse_retry_task` before calling `listen_websocket()` and includes current-task checks (`pending_retry is not asyncio.current_task()`) to prevent self-cancellation.
   * Cancels pending retries when an SSE connection is successfully established or when `close_websocket()` runs on config entry unload.

---

## Testing & Validation

* **Unit & Integration Tests:**
  * Added `TestStreamSetupProgressiveBackoff` in `tests/test_coordinator_methods.py` covering delay calculations, task deduplication, HA lifecycle guards, exception absorption, and end-to-end task execution without self-cancellation.
  * Added failure callback routing tests in `tests/test_api_client.py`.
* **CI Checks:**
  * `uv run pytest` $\rightarrow$ **1,727 passed** (0 failures).
  * Test coverage: **95.51%** (exceeds 70% threshold).
  * `uv run ruff check` $\rightarrow$ Clean (0 errors).
