### PR TITLE
feat(coordinator): add event-driven desync recovery when timeToEnd decrements

### DIFF
--- a/custom_components/electrolux/coordinator.py
+++ b/custom_components/electrolux/coordinator.py
@@ -605,6 +605,28 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
                 )
                 self._schedule_deferred_update(appliance_id)
 
+            # Desync recovery: if timeToEnd is decrementing while applianceState is NOT
+            # in an active running/drying state, the appliance has started running but the
+            # applianceState SSE event was dropped by the cloud. Force a state refresh.
+            appliance = appliances.get_appliance(appliance_id) if appliances else None
+            current_state = (
+                str(appliance.reported_state.get("applianceState") if appliance else "").upper().replace(" ", "_")
+            )
+            if (
+                current_state not in ACTIVE_TIME_TO_END_STATES
+                and old_value is not None
+                and new_value is not None
+                and 0 < new_value < old_value
+            ):
+                _LOGGER.info(
+                    "timeToEnd decremented (%s → %s) while applianceState=%s for %s — desync detected, scheduling state refresh",
+                    old_value,
+                    new_value,
+                    current_state,
+                    appliance_id,
+                )
+                self._schedule_state_refresh(appliance_id)
+
             # Track this value for next comparison
             self._last_time_to_end[appliance_id] = new_value
 

--- a/tests/test_coordinator_update_paths.py
+++ b/tests/test_coordinator_update_paths.py
@@ -810,3 +810,93 @@ class TestSetupEntities:
 
         with pytest.raises(asyncio.CancelledError):
             await coordinator.setup_entities()
+
+
+# ---------------------------------------------------------------------------
+# Desync recovery: timeToEnd decrement while not in ACTIVE_TIME_TO_END_STATES
+# ---------------------------------------------------------------------------
+
+
+class TestDesyncRecovery:
+    def test_timetoend_decrement_in_ready_to_start_schedules_state_refresh(
+        self, coordinator
+    ):
+        """When timeToEnd decrements while applianceState is READY_TO_START,
+
+        a state-refresh is scheduled to recover from the dropped RUNNING SSE event.
+        """
+        appliance = _make_appliance("app1")
+        appliance.reported_state = {"applianceState": "READY_TO_START"}
+        appliances = _make_appliances({"app1": appliance})
+        coordinator.data = {"appliances": appliances}
+        coordinator._appliances_cache = appliances
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator._schedule_state_refresh = MagicMock()
+        coordinator._last_time_to_end = {"app1": 13500}
+
+        # Incoming SSE event: timeToEnd decrements from 13500 to 13440
+        data = {
+            "applianceId": "app1",
+            "property": "timeToEnd",
+            "value": 13440,
+        }
+        coordinator.incoming_data(data)
+
+        # State refresh must be scheduled immediately
+        coordinator._schedule_state_refresh.assert_called_once_with("app1")
+        assert coordinator._last_time_to_end["app1"] == 13440
+
+    def test_timetoend_static_in_ready_to_start_does_not_schedule_refresh(
+        self, coordinator
+    ):
+        """When timeToEnd is unchanged while in READY_TO_START,
+
+        no state refresh is scheduled (avoids unnecessary API calls while idle).
+        """
+        appliance = _make_appliance("app1")
+        appliance.reported_state = {"applianceState": "READY_TO_START"}
+        appliances = _make_appliances({"app1": appliance})
+        coordinator.data = {"appliances": appliances}
+        coordinator._appliances_cache = appliances
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator._schedule_state_refresh = MagicMock()
+        coordinator._last_time_to_end = {"app1": 13500}
+
+        # Incoming SSE event: same value (e.g. duplicate or idle selection)
+        data = {
+            "applianceId": "app1",
+            "property": "timeToEnd",
+            "value": 13500,
+        }
+        coordinator.incoming_data(data)
+
+        # No state refresh should be scheduled
+        coordinator._schedule_state_refresh.assert_not_called()
+
+    def test_timetoend_decrement_in_running_does_not_schedule_desync_refresh(
+        self, coordinator
+    ):
+        """When timeToEnd decrements while already in RUNNING,
+
+        normal operation applies and desync recovery is not triggered.
+        """
+        appliance = _make_appliance("app1")
+        appliance.reported_state = {"applianceState": "RUNNING"}
+        appliances = _make_appliances({"app1": appliance})
+        coordinator.data = {"appliances": appliances}
+        coordinator._appliances_cache = appliances
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator._schedule_state_refresh = MagicMock()
+        coordinator._last_time_to_end = {"app1": 13500}
+
+        # Incoming SSE event: timeToEnd decrements normally during RUNNING
+        data = {
+            "applianceId": "app1",
+            "property": "timeToEnd",
+            "value": 13440,
+        }
+        coordinator.incoming_data(data)
+
+        # Desync recovery should not trigger because state is already RUNNING
+        coordinator._schedule_state_refresh.assert_not_called()
+        assert coordinator._last_time_to_end["app1"] == 13440


### PR DESCRIPTION
### Summary
Adds event-driven state desync recovery when `timeToEnd` decrements while the appliance is in an idle/ready state.

### Problem
Under rare cloud conditions, the Electrolux Cloud API starts sending real-time `timeToEnd` countdown SSE frames (e.g. `13500 → 13440 → 13380...`) but drops the initial `applianceState: RUNNING` event frame. Home Assistant remains in `READY_TO_START`, `IDLE`, or `OFF` while the cycle is actively counting down. Because SSE frames continue arriving every 60s, stream-silence watchdogs never trigger.

### Solution
When an incoming SSE `timeToEnd` value decrements (`0 < new_value < old_value`) while `applianceState` is NOT in `ACTIVE_TIME_TO_END_STATES`, the coordinator immediately schedules a state refresh (`_schedule_state_refresh(appliance_id)`) to query the cloud REST API and restore the running state.

### Testing
Added `TestDesyncRecovery` in `test_coordinator_update_paths.py` verifying state-refresh scheduling on countdown decrements, static countdown preservation, and normal running operation (1,773 passing unit tests, 95.48% coverage).