### PR TITLE
fix(button): gate source-scoped executeCommand buttons by their own applianceState

### DIFF
--- a/custom_components/electrolux/button.py
+++ b/custom_components/electrolux/button.py
@@ -159,6 +159,11 @@ class ElectroluxButton(ElectroluxEntity, ButtonEntity):
 
         self._execute_states_cache = states
         self._execute_states_cache_caps_id = caps_id
+        # Keep a reference to the capabilities object so CPython cannot recycle
+        # its id() onto a different dict while the cache entry is alive; id()
+        # is only unique among live objects, so a recycled id would otherwise
+        # serve stale rules from a previous appliance payload.
+        self._execute_states_cache_caps = caps
         return states
 
     def _appliance_capabilities(self) -> dict[str, Any] | None:
@@ -177,15 +182,44 @@ class ElectroluxButton(ElectroluxEntity, ButtonEntity):
             return None
         return getattr(getattr(appliance, "data", None), "capabilities", None)
 
+    def _current_appliance_state(self) -> str | None:
+        """Return the applianceState this button's rules are evaluated against.
+
+        The rules may be derived from a source-scoped ``applianceState`` (e.g.
+        ``upperOven/applianceState`` on a structured oven, which is an
+        independent state machine from the root one), so the compared state must
+        be read with the same scoping. Mirrors the "/"-aware path resolution in
+        ``ElectroluxEntity``: try the flat ``source/applianceState`` key first,
+        then the nested ``source`` -> ``applianceState`` layout, then the root.
+        """
+        if not self.entity_source:
+            return self.reported_state.get("applianceState")
+
+        scoped_path = f"{self.entity_source}/applianceState"
+        scoped_state = self.reported_state.get(scoped_path)
+        if scoped_state is not None:
+            return scoped_state
+
+        source_state = self.reported_state.get(self.entity_source)
+        if isinstance(source_state, dict):
+            nested_state = source_state.get("applianceState")
+            if nested_state is not None:
+                return nested_state
+
+        return self.reported_state.get("applianceState")
+
     @property
     def available(self) -> bool:
         # Check state restrictions first, appliance-derived or catalog-defined.
         # A command absent from the rules is left unrestricted, as before.
+        # A missing current state is also left unrestricted: gating on an
+        # unknown state would silently hide every rule-covered button on
+        # partial payloads, indistinguishable from a real disallowed state.
         if execute_states := self._execute_states:
             allowed_states = execute_states.get(self.val_to_send)
             if allowed_states is not None:
-                current_state = self.reported_state.get("applianceState")
-                if current_state not in allowed_states:
+                current_state = self._current_appliance_state()
+                if current_state is not None and current_state not in allowed_states:
                     return False
 
         return super().available

--- a/custom_components/electrolux/execute_command_states.py
+++ b/custom_components/electrolux/execute_command_states.py
@@ -167,6 +167,14 @@ def execute_states_from_capabilities(
     read, matching the trigger handling in ``entity.py``. Compound conditions
     (a dict operand) and ``disabled`` actions carry no command list and are
     skipped.
+
+    Scoping: with ``entity_source`` set, only that source's own
+    ``{source}/applianceState`` capability is read — it is an independent state
+    machine (a structured oven's cavity does not follow the main appliance's
+    ALARM/OFF/RUNNING machine). Falling back to the root ``applianceState``
+    would apply the wrong machine to the source's buttons, so the caller falls
+    back to the catalog table instead. Without ``entity_source`` only the root
+    ``applianceState`` is read.
     """
     if not isinstance(capabilities, dict):
         return None
@@ -174,9 +182,12 @@ def execute_states_from_capabilities(
     appliance_state: Any | None = None
 
     if entity_source:
+        # Scoped buttons are gated by their own state machine only. Falling
+        # back to the root applianceState would silently apply the main
+        # appliance's machine to a sub-appliance (see docstring), so return
+        # None and let the caller use the catalog table.
         appliance_state = capabilities.get(f"{entity_source}/applianceState")
-
-    if appliance_state is None:
+    else:
         appliance_state = capabilities.get("applianceState")
 
     if not isinstance(appliance_state, dict):

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -814,6 +814,228 @@ class TestExecuteStatesFromCapabilities:
         assert execute_states_from_capabilities(caps) is None
 
 
+# Mirrors the real SO-944035035_01 structure (samples/SO-944035035_01.json):
+# the structured oven publishes TWO independent applianceState machines and the
+# reported values diverge (root OFF while the cavity is READY_TO_START).
+SO_ROOT_APPLIANCE_STATE = {
+    "values": {"ALARM": {}, "OFF": {}, "RUNNING": {}},
+    "triggers": [],
+}
+SO_UPPER_OVEN_APPLIANCE_STATE = {
+    "values": {
+        "ALARM": {},
+        "DELAYED_START": {},
+        "END_OF_CYCLE": {},
+        "IDLE": {},
+        "OFF": {},
+        "PAUSED": {},
+        "READY_TO_START": {},
+        "RUNNING": {},
+    },
+    "triggers": [
+        {
+            "condition": {"operand_1": "value", "operand_2": "RUNNING", "operator": "eq"},
+            "action": {"executeCommand": {"values": {"STOPRESET": {}}}},
+        },
+        {
+            "condition": {"operand_1": "value", "operand_2": "PAUSED", "operator": "eq"},
+            "action": {"executeCommand": {"values": {"RESUME": {}, "STOPRESET": {}}}},
+        },
+        {
+            "condition": {"operand_1": "value", "operand_2": "READY_TO_START", "operator": "eq"},
+            "action": {"executeCommand": {"values": {"START": {}}}},
+        },
+    ],
+}
+SO_CAPABILITIES = {
+    "applianceState": SO_ROOT_APPLIANCE_STATE,
+    "upperOven/applianceState": SO_UPPER_OVEN_APPLIANCE_STATE,
+}
+
+
+class TestSourceScopedStateGating:
+    """Source-scoped buttons must be gated by their own state machine only."""
+
+    @pytest.fixture
+    def mock_coordinator(self):
+        coordinator = MagicMock()
+        coordinator.hass = MagicMock()
+        coordinator.hass.loop = MagicMock()
+        coordinator.hass.loop.time.return_value = 1000000.0
+        coordinator._last_update_times = {}
+        coordinator.config_entry = MagicMock()
+        coordinator.config_entry.data = {"api_key": "key"}
+        return coordinator
+
+    def _make_button(self, coordinator, entity_source, val_to_send, capabilities, reported):
+        """Build an executeCommand button with a given source and reported payload."""
+        from custom_components.electrolux.model import ElectroluxDevice
+
+        appliance = MagicMock()
+        appliance.data.capabilities = capabilities
+        appliances = MagicMock()
+        appliances.get_appliance.return_value = appliance
+        coordinator.data = {"appliances": appliances}
+
+        entity = ElectroluxButton(
+            coordinator=coordinator,
+            capability={"access": "write", "type": "boolean"},
+            name="Oven",
+            config_entry=coordinator.config_entry,
+            pnc_id="TEST_PNC",
+            entity_type=BUTTON,
+            entity_name="execute_command",
+            entity_attr="executeCommand",
+            entity_source=entity_source,
+            unit="",
+            device_class="",
+            entity_category=EntityCategory.CONFIG,
+            icon="mdi:test",
+            catalog_entry=ElectroluxDevice(
+                capability_info={"access": "write"},
+                available_when_states={"START": ["OFF"], "STOPRESET": ["RUNNING"]},
+            ),
+            val_to_send=val_to_send,
+        )
+        reported = {"connectivityState": "connected", **reported}
+        entity.appliance_status = {"properties": {"reported": reported}}
+        entity._reported_state_cache = reported
+        return entity
+
+    def test_scoped_rules_use_scoped_state_flat_layout(self, mock_coordinator):
+        """STOPRESET follows upperOven/applianceState, not the root machine."""
+        # Root says OFF (START-able), cavity says RUNNING (STOPRESET-able).
+        entity = self._make_button(
+            mock_coordinator,
+            "upperOven",
+            "STOPRESET",
+            SO_CAPABILITIES,
+            {"applianceState": "OFF", "upperOven/applianceState": "RUNNING"},
+        )
+        assert entity.available is True
+
+    def test_scoped_rules_use_scoped_state_nested_layout(self, mock_coordinator):
+        """The nested upperOven -> applianceState layout is also resolved."""
+        entity = self._make_button(
+            mock_coordinator,
+            "upperOven",
+            "STOPRESET",
+            SO_CAPABILITIES,
+            {"applianceState": "OFF", "upperOven": {"applianceState": "RUNNING"}},
+        )
+        assert entity.available is True
+
+    def test_scoped_button_blocked_by_its_own_machine(self, mock_coordinator):
+        """Cavity is OFF: STOPRESET is invalid there, even though root allows it."""
+        entity = self._make_button(
+            mock_coordinator,
+            "upperOven",
+            "STOPRESET",
+            SO_CAPABILITIES,
+            {"applianceState": "OFF", "upperOven/applianceState": "OFF"},
+        )
+        assert entity.available is False
+
+    def test_root_state_change_does_not_flip_scoped_button(self, mock_coordinator):
+        """Only the cavity's own state may gate the cavity's buttons."""
+        for root_state in ("OFF", "RUNNING", "ALARM"):
+            entity = self._make_button(
+                mock_coordinator,
+                "upperOven",
+                "START",
+                SO_CAPABILITIES,
+                {"applianceState": root_state, "upperOven/applianceState": "READY_TO_START"},
+            )
+            assert entity.available is True, root_state
+
+    def test_scoped_button_without_scoped_capability_falls_back_to_table(
+        self, mock_coordinator
+    ):
+        """No upperOven/applianceState capability: the catalog table applies.
+
+        The table is evaluated against the scoped state, never the root machine.
+        """
+        caps = {"applianceState": SO_ROOT_APPLIANCE_STATE}
+        entity = self._make_button(
+            mock_coordinator,
+            "upperOven",
+            "START",
+            caps,
+            {"applianceState": "RUNNING", "upperOven/applianceState": "OFF"},
+        )
+        # Root RUNNING would have blocked START via the root machine; the
+        # scoped state OFF matches the table's START rule instead.
+        assert entity.available is True
+
+    def test_scoped_derivation_ignores_root_appliance_state_capability(self):
+        """With entity_source set, the root machine must not be derived."""
+        assert (
+            execute_states_from_capabilities(SO_CAPABILITIES, entity_source="upperOven")
+            == {
+                "STOPRESET": ["RUNNING", "PAUSED"],
+                "RESUME": ["PAUSED"],
+                "START": ["READY_TO_START"],
+            }
+        )
+
+    def test_scoped_derivation_returns_none_without_scoped_capability(self):
+        """Missing scoped capability: caller falls back to the catalog table."""
+        caps = {
+            "applianceState": {
+                "triggers": DRYER_TRIGGERS["applianceState"]["triggers"]
+            }
+        }
+        assert execute_states_from_capabilities(caps, entity_source="upperOven") is None
+
+    def test_missing_current_state_fails_open(self, mock_coordinator):
+        """A partial payload must not hide every rule-covered button."""
+        entity = self._make_button(
+            mock_coordinator,
+            None,
+            "START",
+            DRYER_TRIGGERS,
+            {},  # no applianceState reported at all
+        )
+        assert entity.available is True
+
+    def test_cache_invalidates_when_capabilities_object_changes(
+        self, mock_coordinator
+    ):
+        """A new capabilities payload must refresh the rules, even if the old
+        object is garbage-collected and its id() gets recycled."""
+        entity = self._make_button(
+            mock_coordinator,
+            None,
+            "START",
+            DRYER_TRIGGERS,
+            {"applianceState": "READY_TO_START"},
+        )
+        assert entity.available is True
+
+        # Replace capabilities with a payload publishing no triggers: the rules
+        # must refresh to the catalog table, where START is only valid in OFF.
+        appliance = MagicMock()
+        appliance.data.capabilities = {
+            "applianceState": {
+                "values": {"READY_TO_START": {}, "OFF": {}},
+                "triggers": [],
+            }
+        }
+        appliances = MagicMock()
+        appliances.get_appliance.return_value = appliance
+        mock_coordinator.data = {"appliances": appliances}
+
+        # The appliance moved to OFF: fresh rules (catalog table) allow START
+        # there, while the stale dryer-derived rules (START only in
+        # READY_TO_START) would keep the button disabled.
+        reported = {"applianceState": "OFF", "connectivityState": "connected"}
+        entity.appliance_status = {"properties": {"reported": reported}}
+        entity._reported_state_cache = reported
+
+        assert entity._execute_states == {"START": ["OFF"], "STOPRESET": ["RUNNING"]}
+        assert entity.available is True
+
+
 class TestButtonAvailabilityPrefersAppliance:
     """Test that button availability follows the appliance over the catalog."""
 


### PR DESCRIPTION
The state comparison in ElectroluxButton.available always read the root applianceState, while execute_states_from_capabilities derives the rules from the source-scoped one (e.g. upperOven/applianceState on a structured oven). The two are independent state machines: samples/SO-944035035_01 shows root OFF while the cavity reports READY_TO_START, so cavity buttons were gated by the wrong machine. The comparison now resolves the scoped state the same way (flat source/applianceState key, nested source object, then root).

execute_states_from_capabilities no longer silently falls back to the root applianceState when a scoped capability is missing; the caller falls back to the catalog table instead, which is the intended fallback.

Also: a missing current state now fails open instead of hiding every rule-covered button on partial payloads, and the _execute_states cache keeps a reference to the capabilities object so a recycled id() cannot serve stale rules from a previous payload.