### PR TITLE
fix: only treat exact ON/OFF write capabilities as switches

### DIFF
--- a/custom_components/electrolux/api.py
+++ b/custom_components/electrolux/api.py
@@ -247,9 +247,14 @@ class ElectroluxLibraryEntity:
         if values and isinstance(values, dict) and len(values) > 0:
             upper_values = {str(k).upper() for k in values}
 
-            # Write-only ON/OFF pair (e.g. ice maker control) → single optimistic SWITCH
-            # instead of two separate BUTTON entities.
-            if upper_values >= {"ON", "OFF"} and access == "write":
+            # Write-only exact ON/OFF pair (e.g. ice maker control) → single optimistic
+            # SWITCH instead of two separate BUTTON entities. The value set must match
+            # exactly: multi-command sets that merely include ON/OFF among other
+            # commands (e.g. {ON, OFF, PAUSE, RESUME, START, STOPRESET}) are command
+            # buttons, not a toggle — sending "ON" there yields 406
+            # COMMAND_VALIDATION_ERROR in states where the appliance only accepts
+            # START/STOPRESET etc. (https://github.com/TTLucian/ha-electrolux/issues/200)
+            if upper_values == {"ON", "OFF"} and access == "write":
                 return SWITCH
 
             if access == "readwrite":

--- a/custom_components/electrolux/catalogs/catalog_dw.py
+++ b/custom_components/electrolux/catalogs/catalog_dw.py
@@ -50,6 +50,10 @@ CATALOG_DW: dict[str, ElectroluxDevice] = {
         entity_category=None,
         entity_icon="mdi:gesture-tap-button",
         available_when_states=DISHWASHER_EXECUTE_STATES,
+        # Multi-command capability (PAUSE/RESUME/START/STOPRESET, sometimes ON/OFF):
+        # one button per command value, never a toggle switch. Belt-and-braces with
+        # the exact-match check in api.get_entity_type() (issue #200).
+        entity_platform=Platform.BUTTON,
     ),
     # Cycle phase
     "cyclePhase": ElectroluxDevice(

--- a/tests/test_api_logic.py
+++ b/tests/test_api_logic.py
@@ -687,3 +687,83 @@ class TestApiPreciseCoverage:
         entity = self._entity({"executeCommand": {"type": "string", "access": "read"}})
         result = entity.get_entity_type("executeCommand")
         assert result == BUTTON
+
+    # Issue #200: write-only multi-command set containing ON/OFF is NOT a switch
+    def test_get_entity_type_write_multi_command_returns_button(self):
+        """6-value write set {ON, OFF, PAUSE, RESUME, START, STOPRESET} → BUTTON (issue #200)."""
+        from custom_components.electrolux.const import BUTTON
+
+        entity = self._entity(
+            {
+                "executeCommand": {
+                    "type": "string",
+                    "access": "write",
+                    "values": {
+                        "OFF": {},
+                        "ON": {},
+                        "PAUSE": {},
+                        "RESUME": {},
+                        "START": {},
+                        "STOPRESET": {},
+                    },
+                }
+            }
+        )
+        result = entity.get_entity_type("executeCommand")
+        assert result == BUTTON
+
+    def test_get_entity_type_write_five_command_set_returns_button(self):
+        """5-value write set {OFF, ON, RESUME, START, STOPRESET} → BUTTON (issue #200)."""
+        from custom_components.electrolux.const import BUTTON
+
+        entity = self._entity(
+            {
+                "executeCommand": {
+                    "type": "string",
+                    "access": "write",
+                    "values": {"OFF": {}, "ON": {}, "RESUME": {}, "START": {}, "STOPRESET": {}},
+                }
+            }
+        )
+        result = entity.get_entity_type("executeCommand")
+        assert result == BUTTON
+
+    # Issue #200: genuine write-only exact ON/OFF pair stays a SWITCH
+    def test_get_entity_type_write_exact_on_off_returns_switch(self):
+        """Exact write-only {ON, OFF} set (e.g. ice maker) → SWITCH (issue #200)."""
+        from custom_components.electrolux.const import SWITCH
+
+        entity = self._entity(
+            {"iceMaker/executeCommand": {"type": "string", "access": "write", "values": {"OFF": {}, "ON": {}}}}
+        )
+        result = entity.get_entity_type("iceMaker/executeCommand")
+        assert result == SWITCH
+
+    def test_get_entity_type_write_lowercase_on_off_returns_switch(self):
+        """Write-only {on, off} (lowercase, DAM AC) → SWITCH (issue #200)."""
+        from custom_components.electrolux.const import SWITCH
+
+        entity = self._entity(
+            {"airConditioner/executeCommand": {"type": "string", "access": "write", "values": {"off": {}, "on": {}}}}
+        )
+        result = entity.get_entity_type("airConditioner/executeCommand")
+        assert result == SWITCH
+
+    def test_get_entity_type_write_command_set_without_on_returns_button(self):
+        """Write-only {OFF, START} (no ON) → BUTTON, unaffected by the fix (issue #200)."""
+        from custom_components.electrolux.const import BUTTON
+
+        entity = self._entity(
+            {"executeCommand": {"type": "string", "access": "write", "values": {"OFF": {}, "START": {}}}}
+        )
+        result = entity.get_entity_type("executeCommand")
+        assert result == BUTTON
+
+    # Issue #200: catalog entry forces BUTTON for DW executeCommand
+    def test_dw_catalog_execute_command_entity_platform_is_button(self):
+        """catalog_dw.py executeCommand entry has entity_platform=Platform.BUTTON (issue #200)."""
+        from homeassistant.const import Platform
+
+        from custom_components.electrolux.catalogs.catalog_dw import CATALOG_DW
+
+        assert CATALOG_DW["executeCommand"].entity_platform == Platform.BUTTON


### PR DESCRIPTION
get_entity_type() used a superset check (upper_values >= {ON, OFF}) for write-only capabilities, so multi-command sets such as {ON, OFF, PAUSE, RESUME, START, STOPRESET} on some appliance types were exposed as a single toggle switch. Sending "ON" then fails with 406 COMMAND_VALIDATION_ERROR whenever the appliance only accepts START/STOPRESET etc. in the current state.

Use an exact match so only genuine ON/OFF pairs (ice maker, AC, door heater) remain switches; all other command sets become one button per command value, availability-gated by the published applianceState triggers. Also pin entity_platform=Platform.BUTTON on the DW catalog executeCommand entry (WM/WD/TD already force BUTTON via ButtonDeviceClass.RESTART).

Fixes #200. Regression from e3e97d64 (v3.6.6).