### PR TITLE
feat: proper catalog entry + default-disable for OV targetMicrowavePower (#193)

### DIFF
--- a/custom_components/electrolux/catalogs/catalog_ov.py
+++ b/custom_components/electrolux/catalogs/catalog_ov.py
@@ -256,6 +256,19 @@ CATALOG_OV: dict[str, ElectroluxDevice] = {
         entity_category=None,
         entity_icon="mdi:thermometer-probe",
     ),
+    "targetMicrowavePower": ElectroluxDevice(
+        # Combi-microwave ovens (keyModel GT3_CMW) and some steam ovens advertise
+        # this control. The API provides no unit, min, max or step for it, so the
+        # number platform's generic defaults apply. On models where every
+        # MICROWAVE_* program value carries "disabled": true in the live capability
+        # schema (remote microwave start is disallowed), the entity is disabled by
+        # default via ElectroluxEntity.entity_registry_enabled_default (#193).
+        capability_info={"access": "readwrite", "type": "number"},
+        device_class=None,
+        unit=None,
+        entity_category=None,
+        entity_icon="mdi:microwave",
+    ),
     "targetTemperatureC": ElectroluxDevice(
         capability_info={"access": "readwrite", "type": "temperature"},
         device_class=NumberDeviceClass.TEMPERATURE,

--- a/custom_components/electrolux/entity.py
+++ b/custom_components/electrolux/entity.py
@@ -765,9 +765,51 @@ class ElectroluxEntity(CoordinatorEntity):
         # Default icon fallback
         return self._icon
 
+    def _microwave_programs_all_disabled(self) -> bool:
+        """Return True when every MICROWAVE_* program value is remotely disabled.
+
+        Combi-microwave ovens (keyModel GT3_CMW) advertise a ``program``
+        capability that includes MICROWAVE_* values, but Electrolux marks each
+        of them ``"disabled": true`` in the live capability schema — remote
+        starting of microwave functions is not permitted. On such models the
+        ``targetMicrowavePower`` control can never be exercised, so it is
+        hidden by default (#193). Returns False for models that DO allow
+        microwave programs (entity stays enabled) and for appliances without
+        MICROWAVE_* values at all.
+        """
+        try:
+            appliance = self.get_appliance
+            appliance_data = getattr(appliance, "data", None)
+        except KeyError, AttributeError, TypeError:
+            return False
+        capabilities = getattr(appliance_data, "capabilities", None)
+        if not isinstance(capabilities, dict):
+            return False
+        values = capabilities.get("program", {})
+        if not isinstance(values, dict):
+            return False
+        values = values.get("values", {})
+        if not isinstance(values, dict):
+            return False
+        microwave_values = [
+            value
+            for key, value in values.items()
+            if str(key).upper().startswith("MICROWAVE_") and isinstance(value, dict)
+        ]
+        if not microwave_values:
+            return False
+        return all(bool(value.get("disabled")) for value in microwave_values)
+
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added to the entity registry."""
+        # Dynamic suppression: on combi-microwave ovens where the API disables
+        # remote selection of every MICROWAVE_* program, the microwave power
+        # control can never do anything — register it but keep it disabled by
+        # default so users can still enable it explicitly (#193).
+        if self.entity_attr == "targetMicrowavePower" and self._microwave_programs_all_disabled():
+            return False
+
         # Use catalog entry value if available, otherwise default to True
         if self._catalog_entry:
             return self._catalog_entry.entity_registry_enabled_default

--- a/custom_components/electrolux/number.py
+++ b/custom_components/electrolux/number.py
@@ -903,5 +903,7 @@ class ElectroluxNumber(ElectroluxEntity, NumberEntity):
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added to the entity registry."""
-        # Always enable entities by default - availability is controlled by the available property
-        return True
+        # Delegate to the base class so catalog overrides and dynamic
+        # suppression rules apply (e.g. targetMicrowavePower on combi-microwave
+        # ovens where every MICROWAVE_* program is remotely disabled, #193).
+        return super().entity_registry_enabled_default

--- a/tests/test_entity_registry_enabled_default.py
+++ b/tests/test_entity_registry_enabled_default.py
@@ -1,0 +1,220 @@
+"""Tests for OV targetMicrowavePower catalog entry & registry-enabled-default suppression on combi-microwave models.
+
+Covers:
+- catalog_ov.py entry for targetMicrowavePower (icon, no device class/unit)
+- _microwave_programs_all_disabled() detection logic (all / some / no MICROWAVE_*)
+- entity_registry_enabled_default suppression on ElectroluxNumber
+- number bounds fallback for the min/max-less capability
+"""
+
+from types import SimpleNamespace
+from typing import ClassVar
+from unittest.mock import MagicMock
+
+from homeassistant.const import Platform
+
+from custom_components.electrolux.catalogs.catalog_ov import CATALOG_OV
+from custom_components.electrolux.const import NUMBER
+from custom_components.electrolux.number import ElectroluxNumber
+
+
+def make_number(entity_attr="targetMicrowavePower", capabilities=None, catalog_entry=None):
+    """Build an ElectroluxNumber with optional appliance capabilities."""
+    coordinator = MagicMock()
+    coordinator.hass = MagicMock()
+    coordinator.hass.loop = MagicMock()
+    coordinator.hass.loop.time.return_value = 1_000_000.0
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.data = {"api_key": "test_api_key_1234567890abcdef"}
+    coordinator._last_update_times = {}
+
+    mock_appliance = MagicMock()
+    mock_appliance.state = {"properties": {"reported": {}}, "connectionState": "connected"}
+    if capabilities is not None:
+        # Only these attributes are accessed by the suppression helper
+        mock_appliance.data = SimpleNamespace(capabilities=capabilities)
+    mock_appliances = MagicMock()
+    mock_appliances.get_appliance.return_value = mock_appliance
+    coordinator.data = {"appliances": mock_appliances}
+
+    entity = ElectroluxNumber(
+        coordinator=coordinator,
+        name="Target Microwave Power",
+        config_entry=coordinator.config_entry,
+        pnc_id="944066813_02",
+        entity_type=Platform.NUMBER,
+        entity_name="targetMicrowavePower",
+        entity_attr=entity_attr,
+        entity_source=None,
+        capability={"access": "readwrite", "type": "number"},
+        unit=None,
+        device_class=None,
+        entity_category=None,
+        icon="mdi:microwave",
+        catalog_entry=catalog_entry,
+    )
+    entity.hass = coordinator.hass
+    return entity
+
+
+def microwave_program_values(disabled: bool, extra_values: dict | None = None) -> dict:
+    """Build a program capability like the API schema of combi-microwave ovens."""
+    microwave_names = [
+        "MICROWAVE_CONVENTIONAL_COOKING",
+        "MICROWAVE_DEFROST",
+        "MICROWAVE_FULL",
+        "MICROWAVE_GRILL",
+        "MICROWAVE_LIQUID",
+        "MICROWAVE_REHEAT",
+        "MICROWAVE_TRUE_FAN",
+    ]
+    values = {name: {"disabled": disabled} for name in microwave_names}
+    values.update(extra_values or {})
+    return values
+
+
+# ---SECTION-BREAK---
+
+
+class TestCatalogEntry:
+    """catalog_ov.py entry for targetMicrowavePower."""
+
+    def test_entry_exists(self):
+        assert "targetMicrowavePower" in CATALOG_OV
+
+    def test_capability_info(self):
+        entry = CATALOG_OV["targetMicrowavePower"]
+        assert entry.capability_info["access"] == "readwrite"
+        assert entry.capability_info["type"] == "number"
+
+    def test_no_device_class_or_unit(self):
+        """The API provides no unit or range — no guesses."""
+        entry = CATALOG_OV["targetMicrowavePower"]
+        assert entry.device_class is None
+        assert entry.unit is None
+
+    def test_icon(self):
+        assert CATALOG_OV["targetMicrowavePower"].entity_icon == "mdi:microwave"
+
+
+class TestMicrowaveProgramsAllDisabled:
+    """_microwave_programs_all_disabled() detection logic."""
+
+    def test_all_disabled_true(self):
+        caps = {"program": {"values": microwave_program_values(disabled=True)}}
+        entity = make_number(capabilities=caps)
+        assert entity._microwave_programs_all_disabled() is True
+
+    def test_some_enabled_false(self):
+        caps = {
+            "program": {
+                "values": microwave_program_values(
+                    disabled=True,
+                    extra_values={"MICROWAVE_FULL": {"disabled": False}, "TRUE_FAN": {}},
+                )
+            }
+        }
+        entity = make_number(capabilities=caps)
+        assert entity._microwave_programs_all_disabled() is False
+
+    def test_no_microwave_values_false(self):
+        """Regular ovens without MICROWAVE_* programs are unaffected."""
+        caps = {"program": {"values": {"TRUE_FAN": {}, "GRILL": {}}}}
+        entity = make_number(capabilities=caps)
+        assert entity._microwave_programs_all_disabled() is False
+
+    def test_no_program_capability_false(self):
+        entity = make_number(capabilities={"applianceState": {"values": {}}})
+        assert entity._microwave_programs_all_disabled() is False
+
+    def test_no_capabilities_false(self):
+        entity = make_number(capabilities=None)
+        assert entity._microwave_programs_all_disabled() is False
+
+
+class TestEntityRegistryEnabledDefault:
+    """Suppression flows through ElectroluxNumber.entity_registry_enabled_default."""
+
+    def test_suppressed_when_all_microwave_disabled(self):
+        caps = {"program": {"values": microwave_program_values(disabled=True)}}
+        entity = make_number(capabilities=caps)
+        assert entity.entity_registry_enabled_default is False
+
+    def test_enabled_when_microwave_programs_allowed(self):
+        caps = {
+            "program": {
+                "values": microwave_program_values(
+                    disabled=True,
+                    extra_values={"MICROWAVE_FULL": {"disabled": False}},
+                )
+            }
+        }
+        entity = make_number(capabilities=caps)
+        assert entity.entity_registry_enabled_default is True
+
+    def test_enabled_for_oven_without_microwave_programs(self):
+        caps = {"program": {"values": {"TRUE_FAN": {}, "GRILL": {}}}}
+        entity = make_number(capabilities=caps)
+        assert entity.entity_registry_enabled_default is True
+
+    def test_other_attributes_not_suppressed(self):
+        """Only targetMicrowavePower is subject to the suppression rule."""
+        caps = {"program": {"values": microwave_program_values(disabled=True)}}
+        entity = make_number(entity_attr="targetTemperatureC", capabilities=caps)
+        assert entity.entity_registry_enabled_default is True
+
+    def test_catalog_override_still_respected(self):
+        """A catalog entry disabling an entity by default still wins (non-microwave attrs)."""
+        caps = {"program": {"values": microwave_program_values(disabled=True)}}
+        catalog = MagicMock()
+        catalog.entity_registry_enabled_default = False
+        entity = make_number(entity_attr="targetTemperatureC", capabilities=caps, catalog_entry=catalog)
+        assert entity.entity_registry_enabled_default is False
+
+
+class TestNumberBoundsFallback:
+    """The capability has no min/max/step — number.py defaults must kick in."""
+
+    def test_entity_type_resolution(self):
+        """readwrite number capability resolves to NUMBER."""
+        entity = make_number()
+        assert entity.entity_type == NUMBER
+
+    def test_min_max_fallback(self):
+        entity = make_number()
+        assert entity.native_min_value is not None
+        assert entity.native_max_value is not None
+        assert entity.native_step is not None
+
+
+class TestIssueSample:
+    """Smoke test using the program schema from the issue #193 diagnostics.
+
+    (samples/ is gitignored in this repo, so the excerpt is inlined.)
+    """
+
+    ISSUE_PROGRAM_VALUES: ClassVar[dict] = {
+        "AUGRATIN": {},
+        "BOTTOM": {},
+        "MICROWAVE_CONVENTIONAL_COOKING": {"disabled": True},
+        "MICROWAVE_DEFROST": {"disabled": True},
+        "MICROWAVE_FULL": {"disabled": True},
+        "MICROWAVE_GRILL": {"disabled": True},
+        "MICROWAVE_GRILL_FAN": {"disabled": True},
+        "MICROWAVE_LIQUID": {"disabled": True},
+        "MICROWAVE_REHEAT": {"disabled": True},
+        "MICROWAVE_TRUE_FAN": {"disabled": True},
+        "PIZZA": {},
+        "TRUE_FAN": {},
+    }
+
+    def test_issue_schema_all_microwave_disabled(self):
+        program_values = self.ISSUE_PROGRAM_VALUES
+        microwave = {k: v for k, v in program_values.items() if k.startswith("MICROWAVE_")}
+        assert microwave, "schema must contain MICROWAVE_* program values"
+        assert all(v.get("disabled") for v in microwave.values())
+
+        caps = {"program": {"values": program_values}}
+        entity = make_number(capabilities=caps)
+        assert entity._microwave_programs_all_disabled() is True
+        assert entity.entity_registry_enabled_default is False


### PR DESCRIPTION
Combi-microwave ovens (keyModel GT3_CMW) advertise targetMicrowavePower as a bare readwrite number with no unit, min, max or step. With no catalog entry it fell through to the generic dynamic-capability fallback as an unlabeled number entity. Since Electrolux marks every MICROWAVE_* program value "disabled": true on these models, remote microwave start is not permitted and the control can never be exercised.

- Add a catalog_ov.py entry (mdi:microwave icon, no device class/unit — the API provides neither, so the number platform defaults apply)
- Add ElectroluxEntity._microwave_programs_all_disabled(): when every MICROWAVE_* value in the live program capability is disabled, the entity registers disabled by default (users can still enable it). ElectroluxNumber now delegates entity_registry_enabled_default to the base class so the rule applies on the number platform.
- 17 new tests (catalog entry, detection logic, suppression, bounds fallback, inlined issue-schema smoke test)

Fixes #193