### PR TITLE
feat(cr): add applianceUiSwVersion + blacklist fPRPN_/fSPN_ (#194)

### DIFF
--- a/custom_components/electrolux/catalogs/catalog_cr.py
+++ b/custom_components/electrolux/catalogs/catalog_cr.py
@@ -567,6 +567,18 @@ CATALOG_CR: dict[str, ElectroluxDevice] = {
         entity_registry_enabled_default=False,
         friendly_name="Main Board Software Version",
     ),
+    "applianceUiSwVersion": ElectroluxDevice(
+        capability_info={
+            "access": "read",
+            "type": "string",
+        },
+        device_class=None,
+        unit=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_icon="mdi:information",
+        entity_registry_enabled_default=False,
+        friendly_name="UI Software Version",
+    ),
     "ecoMode": ElectroluxDevice(
         capability_info={
             "access": "readwrite",

--- a/custom_components/electrolux/const.py
+++ b/custom_components/electrolux/const.py
@@ -125,6 +125,8 @@ ATTRIBUTES_BLACKLIST: list[str] = [
     "^fCPN_TD(Alert|EndOfCycle|Maintenances)$",  # Internal tumble-dryer push-notification flags, no live user value
     "^fCApplianceFeature_EUDryWhatWashed$",  # Internal appliance feature flag, no user-facing state/control
     "^hMEPN_DHAlerts$",  # Internal dehumidifier notification flag, no live user-facing value
+    "^fPRPN_",  # Internal refrigerator push-notification flags (AirFilter/WaterFilter Change/Order), no user value (#194)
+    "^fSPN_",  # Internal refrigerator status-notification flags (e.g. CRConnectionLost), no user value (#194)
     "^dummy_for_empty_cycle(_DW)?$",  # Placeholder/internal sentinel capability used for empty-cycle programs
     "^hideExecuteCommand$",  # Internal API trigger-control flag (governs executeCommand visibility via triggers)
     "^keyModel$",  # Hardware identity constant, no user-facing value

--- a/tests/test_catalog_cr.py
+++ b/tests/test_catalog_cr.py
@@ -1,0 +1,105 @@
+"""Tests for the CR (refrigerator) catalog and attribute filtering (#194).
+
+Covers:
+- ATTRIBUTES_BLACKLIST patterns hiding internal fPRPN_/fSPN_ flags
+- catalog_cr.py applianceUiSwVersion diagnostic entry
+- entity-type resolution for the MDR4 (925061028_00) capability schema
+"""
+
+import re
+
+from homeassistant.const import EntityCategory
+
+from custom_components.electrolux.api import ElectroluxLibraryEntity
+from custom_components.electrolux.catalogs.catalog_cr import CATALOG_CR
+from custom_components.electrolux.const import ATTRIBUTES_BLACKLIST, SENSOR
+
+# fPRPN_/fSPN_ capability names observed on real CR appliances
+# (issue #194 diagnostics + local CR samples)
+INTERNAL_CR_FLAGS = [
+    "fPRPN_AirFilterChange",
+    "fPRPN_AirFilterOrder",
+    "fPRPN_WaterFilterChange",
+    "fPRPN_WaterFilterOrder",
+    "fSPN_CRConnectionLost",
+]
+
+
+def _is_blacklisted(name: str) -> bool:
+    return any(re.match(pattern, name) for pattern in ATTRIBUTES_BLACKLIST)
+
+
+class TestInternalFlagBlacklist:
+    """fPRPN_/fSPN_ internal flags must not become entities."""
+
+    def test_all_observed_flags_blacklisted(self):
+        for name in INTERNAL_CR_FLAGS:
+            assert _is_blacklisted(name), f"{name} should be blacklisted"
+
+    def test_real_capabilities_not_collateral_blocked(self):
+        """Legitimate CR capabilities must stay discoverable."""
+        for name in [
+            "waterFilterState",
+            "airFilterLifeTime",
+            "compressorSpeed",
+            "reminderTime",
+            "uiLockMode",
+            "sensorHumidity",
+            "fridge/targetTemperatureC",
+            "freezer/fastMode",
+            "iceMaker/iceDispenserState",
+            "extraCavity/doorState",
+            "applianceUiSwVersion",
+        ]:
+            assert not _is_blacklisted(name), f"{name} must not be blacklisted"
+
+
+class TestCatalogUiSwVersion:
+    """catalog_cr.py applianceUiSwVersion diagnostic entry."""
+
+    def test_entry_exists(self):
+        assert "applianceUiSwVersion" in CATALOG_CR
+
+    def test_capability_info(self):
+        entry = CATALOG_CR["applianceUiSwVersion"]
+        assert entry.capability_info["access"] == "read"
+        assert entry.capability_info["type"] == "string"
+
+    def test_diagnostic_and_disabled_by_default(self):
+        entry = CATALOG_CR["applianceUiSwVersion"]
+        assert entry.entity_category == EntityCategory.DIAGNOSTIC
+        assert entry.entity_registry_enabled_default is False
+
+
+class TestMdr4EntityTypes:
+    """Entity-type resolution for the issue #194 capability schema."""
+
+    def _entity(self, caps):
+        return ElectroluxLibraryEntity(
+            name="test",
+            status="connected",
+            state={},
+            appliance_info={},
+            capabilities=caps,
+        )
+
+    def test_ui_sw_version_is_sensor(self):
+        entity = self._entity({"applianceUiSwVersion": {"type": "string", "access": "read"}})
+        assert entity.get_entity_type("applianceUiSwVersion") == SENSOR
+
+    def test_main_board_sw_version_is_sensor(self):
+        entity = self._entity({"applianceMainBoardSwVersion": {"type": "string", "access": "read"}})
+        assert entity.get_entity_type("applianceMainBoardSwVersion") == SENSOR
+
+    def test_fridge_target_temperature_is_number(self):
+        from custom_components.electrolux.const import NUMBER
+
+        entity = self._entity({"fridge": {"targetTemperatureC": {"type": "temperature", "access": "readwrite"}}})
+        assert entity.get_entity_type("fridge/targetTemperatureC") == NUMBER
+
+    def test_freezer_fast_mode_readwrite_is_switch(self):
+        from custom_components.electrolux.const import SWITCH
+
+        caps = {"freezer": {"fastMode": {"type": "string", "access": "readwrite", "values": {"OFF": {}, "ON": {}}}}}
+        entity = self._entity(caps)
+        assert entity.get_entity_type("freezer/fastMode") == SWITCH


### PR DESCRIPTION
- catalog_cr.py: add applianceUiSwVersion diagnostic sensor entry
- const.py: blacklist ^fPRPN_ and ^fSPN_ internal notification flags so they don't surface as cryptic generic sensors
- tests/test_catalog_cr.py: cover blacklist patterns, the new catalog entry, and MDR4 capability-schema entity-type resolution

Closes #194 