### PR TITLE
feat: bump electrolux-group-developer-sdk to 0.7.0 and integrate livestream closing callbacks

### DIFF
--- a/custom_components/electrolux/api_client.py
+++ b/custom_components/electrolux/api_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from electrolux_group_developer_sdk.client.appliance_client import (
@@ -208,7 +209,7 @@ class ElectroluxApiClient:
         self._client = ApplianceClient(self._token_manager)
         self._token_handler = None  # Track handler
         self._token_logger = None  # Track logger
-        self._sse_task = None  # Track SSE background task
+        self._sse_task: asyncio.Task[Any] | None = None  # Track SSE background task
         # Serialize SSE start/disconnect so concurrent listen_websocket calls cannot
         # leave two live SSE streams: the first (and only) stream wins; a later caller
         # waits and then replaces it. Prevents duplicate events / double full-state
@@ -440,7 +441,13 @@ class ElectroluxApiClient:
 
         return result.capabilities
 
-    async def watch_for_appliance_state_updates(self, appliance_ids, callback, on_connected=None):
+    async def watch_for_appliance_state_updates(
+        self,
+        appliance_ids: list[str],
+        callback: Callable[[dict[str, Any]], None],
+        on_connected: Callable[[], Awaitable[None]] | None = None,
+        on_disconnected: Callable[[BaseException | None], Any] | None = None,
+    ) -> None:
         """Safely start SSE event stream.
 
         Args:
@@ -449,6 +456,9 @@ class ElectroluxApiClient:
             on_connected: Optional async callable fired each time the SSE stream
                 successfully opens a connection.  Used by the coordinator's stale-
                 session health monitor to track liveness.
+            on_disconnected: Optional callable fired each time the SSE stream
+                disconnects or closes. Used by the coordinator to record drops
+                and start grace period debouncing.
         """
         # Serialize start so a second concurrent caller does not spawn a parallel
         # stream. The first caller that acquires the lock is the one that "owns" the
@@ -467,47 +477,57 @@ class ElectroluxApiClient:
                     self._client.add_listener(appliance_id, callback)
                     _LOGGER.debug("Added SSE listener for appliance %s", appliance_id)
 
-                # Build the optional on-connect callback list for the SDK.
+                # Build the optional on-connect and on-disconnect callback lists for the SDK.
                 on_connect_list = [on_connected] if on_connected is not None else None
+                on_disconnect_list = [on_disconnected] if on_disconnected is not None else None
 
                 # Start the event stream as a background task (it runs indefinitely)
                 if self.hass:
                     self._sse_task = self.hass.async_create_task(
-                        self._client.start_event_stream(do_on_livestream_opening_list=on_connect_list)
+                        self._client.start_event_stream(
+                            do_on_livestream_opening_list=on_connect_list,
+                            do_on_livestream_closing_list=on_disconnect_list,
+                        )
                     )
                 else:
                     self._sse_task = asyncio.create_task(
-                        self._client.start_event_stream(do_on_livestream_opening_list=on_connect_list)
+                        self._client.start_event_stream(
+                            do_on_livestream_opening_list=on_connect_list,
+                            do_on_livestream_closing_list=on_disconnect_list,
+                        )
                     )
 
                 # Add callback to handle task failures
-                def _handle_sse_failure(task):
+                def _handle_sse_failure(task: asyncio.Task[Any]) -> None:
                     if self.coordinator:
                         reason = None
                         if task.cancelled():
                             reason = "Stream cancelled"
-                        elif task.exception() is not None:
-                            reason = str(task.exception())
-                        else:
-                            reason = "Stream closed by server"
-                        self.coordinator.record_sse_disconnect(reason=reason, is_cancellation=task.cancelled())
+                            self.coordinator.record_sse_disconnect(reason=reason, is_cancellation=True)
+                        elif getattr(self.coordinator, "sse_connection_state", None) != "disconnected":
+                            task_exc = task.exception()
+                            if task_exc is not None:
+                                reason = str(task_exc)
+                            else:
+                                reason = "Stream closed by server"
+                            self.coordinator.record_sse_disconnect(reason=reason, is_cancellation=False)
 
                     if task.cancelled():
                         _LOGGER.debug(
                             "SSE event stream was cancelled for appliances %s",
                             ", ".join(appliance_ids),
                         )
-                    elif task.exception() is not None:
+                    elif (exc := task.exception()) is not None:
                         _LOGGER.error(
                             "SSE event stream failed for appliances %s: %s",
                             ", ".join(appliance_ids),
-                            task.exception(),
+                            exc,
                         )
                         # Check if it's an auth error and trigger reauth
                         if self.hass and self.config_entry:
-                            if is_auth_error(task.exception()):
-                                _LOGGER.debug(f"SSE auth error detected: {task.exception()}")
-                                asyncio.create_task(self._trigger_reauth(f"SSE auth error: {task.exception()}"))
+                            if is_auth_error(exc):
+                                _LOGGER.debug(f"SSE auth error detected: {exc}")
+                                asyncio.create_task(self._trigger_reauth(f"SSE auth error: {exc}"))
                         # Note: We don't mark appliances as offline here because SSE failure
                         # doesn't necessarily mean appliances are disconnected. Individual
                         # appliance connectivity is tracked through data updates and timeouts.
@@ -516,9 +536,9 @@ class ElectroluxApiClient:
                             "Appliance connectivity will be determined by individual data updates.",
                             ", ".join(appliance_ids),
                         )
-                        if not is_auth_error(task.exception()):
+                        if not is_auth_error(exc):
                             if self.coordinator and hasattr(self.coordinator, "handle_sse_stream_failure"):
-                                self.coordinator.handle_sse_stream_failure(task.exception())
+                                self.coordinator.handle_sse_stream_failure(exc)
                     else:
                         _LOGGER.debug(
                             "SSE event stream ended unexpectedly for appliances %s (no exception)",
@@ -527,7 +547,8 @@ class ElectroluxApiClient:
                         if self.coordinator and hasattr(self.coordinator, "handle_sse_stream_failure"):
                             self.coordinator.handle_sse_stream_failure(None)
 
-                self._sse_task.add_done_callback(_handle_sse_failure)
+                if self._sse_task is not None:
+                    self._sse_task.add_done_callback(_handle_sse_failure)
 
                 _LOGGER.debug("Started SSE event stream for %d appliances", len(appliance_ids))
 

--- a/custom_components/electrolux/coordinator.py
+++ b/custom_components/electrolux/coordinator.py
@@ -285,25 +285,36 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
         is_cancellation: bool = False,
     ) -> None:
         """Record SSE stream disconnection with reconnection grace period."""
-        self._consecutive_sse_drops += 1
+        debounce_task = getattr(self, "_sse_disconnect_debounce_task", None)
+        is_existing_grace_period = debounce_task is not None and not debounce_task.done()
+
+        if not is_existing_grace_period:
+            self._consecutive_sse_drops = getattr(self, "_consecutive_sse_drops", 0) + 1
+        elif not hasattr(self, "_consecutive_sse_drops"):
+            self._consecutive_sse_drops = 0
+
         self._last_sse_disconnect_reason = reason or ("Stream cancelled" if is_cancellation else "Stream disconnected")
         self._sse_connection_state = "reconnecting" if is_cancellation else "disconnected"
 
-        debounce_task = getattr(self, "_sse_disconnect_debounce_task", None)
-        if debounce_task and not debounce_task.done():
-            debounce_task.cancel()
+        if is_existing_grace_period:
+            pass
+        elif self._sse_connected and self.hass:
 
-        async def _debounce_disconnect() -> None:
-            try:
-                await asyncio.sleep(SSE_DISCONNECT_GRACE_PERIOD)
-                self._sse_connected = False
-                self._sse_connection_state = "disconnected"
-                if hasattr(self, "_listeners"):
-                    self.async_update_listeners()
-            except asyncio.CancelledError:
-                pass
+            async def _debounce_disconnect() -> None:
+                try:
+                    await asyncio.sleep(SSE_DISCONNECT_GRACE_PERIOD)
+                    if getattr(self, "_sse_connection_state", None) == "streaming":
+                        return
+                    self._sse_connected = False
+                    self._sse_connection_state = "disconnected"
+                    if hasattr(self, "_listeners"):
+                        self.async_update_listeners()
+                except asyncio.CancelledError:
+                    pass
+                finally:
+                    if getattr(self, "_sse_disconnect_debounce_task", None) is asyncio.current_task():
+                        self._sse_disconnect_debounce_task = None
 
-        if self.hass:
             self._sse_disconnect_debounce_task = self.hass.async_create_task(
                 _debounce_disconnect(),
                 name=f"{DOMAIN}-sse-disconnect-debounce",
@@ -531,6 +542,11 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
 
     def incoming_data(self, data: dict[str, Any]) -> None:
         """Process incoming data."""
+        debounce_task = getattr(self, "_sse_disconnect_debounce_task", None)
+        if debounce_task and not debounce_task.done():
+            debounce_task.cancel()
+        self._sse_disconnect_debounce_task = None
+
         # Track stream liveness for stalled-SSE watchdog logic.
         now = self.hass.loop.time()
         self._last_sse_message_time = now
@@ -995,6 +1011,13 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
             name=f"{DOMAIN}-sse-resync",
         )
 
+    def _on_sse_disconnected(self, error: BaseException | None = None) -> None:
+        """Handle SSE stream disconnection callback from SDK."""
+        if isinstance(error, asyncio.CancelledError):
+            return
+        reason = str(error) if error and str(error) else "Stream closed by server"
+        self.record_sse_disconnect(reason=reason, is_cancellation=False)
+
     async def listen_websocket(self) -> None:
         """Listen for state changes."""
         pending_retry = getattr(self, "_sse_retry_task", None)
@@ -1023,6 +1046,7 @@ class ElectroluxCoordinator(DataUpdateCoordinator):
                 ids,
                 self.incoming_data,
                 on_connected=self._on_sse_connected,
+                on_disconnected=self._on_sse_disconnected,
             )
             self._ensure_sse_stall_monitor_started()
             self._ensure_time_to_end_monitor_started()

--- a/custom_components/electrolux/manifest.json
+++ b/custom_components/electrolux/manifest.json
@@ -8,6 +8,6 @@
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/TTLucian/ha-electrolux/issues",
     "loggers": ["electrolux_group_developer_sdk"],
-    "requirements": ["electrolux-group-developer-sdk"],
+    "requirements": ["electrolux-group-developer-sdk>=0.7.0"],
     "version": "3.7.7"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ test = [
     "pytest-cov>=4.0.0",
     "aiohttp>=3.14.3,<4.0.0",
     "pyjwt>=2.12.1,<3.0.0",
-    "electrolux-group-developer-sdk",
+    "electrolux-group-developer-sdk>=0.7.0",
     "mypy>=2.3.1",
     "ruff>=0.16.5",
 ]
@@ -23,7 +23,7 @@ dev = [
     "aiohttp>=3.14.3,<4.0.0",
     "deep_translator",
     "pydantic>=2.13.5,<3.0.0",
-    "electrolux-group-developer-sdk",
+    "electrolux-group-developer-sdk>=0.7.0",
     "pre-commit",
 ]
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,4 +5,4 @@ pytest-asyncio>=1.4.0
 pytest-cov>=4.0.0
 aiohttp>=3.14.3,<4.0.0
 pyjwt>=2.10.1,<3.0.0
-electrolux-group-developer-sdk
+electrolux-group-developer-sdk>=0.7.0

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -948,6 +948,39 @@ class TestWatchForApplianceStateUpdates:
         client.disconnect_websocket.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_watch_for_appliance_state_updates_passes_lifecycle_callbacks(self):
+        hass = MagicMock()
+        _task = MagicMock()
+        _task.add_done_callback = MagicMock()
+
+        def _create_task_side_effect(coro):
+            if asyncio.iscoroutine(coro):
+                coro.close()
+            return _task
+
+        hass.async_create_task = MagicMock(side_effect=_create_task_side_effect)
+
+        client = _make_client(hass=hass)
+        client._client = MagicMock()
+        client._client.start_event_stream = MagicMock(return_value=MagicMock())
+
+        callback = MagicMock()
+        on_connected = MagicMock()
+        on_disconnected = MagicMock()
+
+        await client.watch_for_appliance_state_updates(
+            ["app1"],
+            callback,
+            on_connected=on_connected,
+            on_disconnected=on_disconnected,
+        )
+
+        client._client.start_event_stream.assert_called_once_with(
+            do_on_livestream_opening_list=[on_connected],
+            do_on_livestream_closing_list=[on_disconnected],
+        )
+
+    @pytest.mark.asyncio
     async def test_sse_failure_callback_cancelled(self):
         """SSE done callback logs when task is cancelled."""
         hass = MagicMock()

--- a/tests/test_coordinator_connectivity.py
+++ b/tests/test_coordinator_connectivity.py
@@ -16,9 +16,7 @@ def mock_hass():
     hass.loop = MagicMock()
     hass.loop.time.return_value = 1000000000
     hass.async_create_task = MagicMock(
-        side_effect=lambda coro, **kwargs: (
-            coro.close() if asyncio.iscoroutine(coro) else None
-        )
+        side_effect=lambda coro, **kwargs: coro.close() if asyncio.iscoroutine(coro) else None
     )
     return hass
 
@@ -37,9 +35,7 @@ def mock_api_client():
     """Mock API client."""
     client = MagicMock()
     client.get_appliances_list = AsyncMock()
-    client.get_appliance_state = AsyncMock(
-        return_value={"connectivityState": "connected"}
-    )
+    client.get_appliance_state = AsyncMock(return_value={"connectivityState": "connected"})
     client.watch_for_appliance_state_updates = AsyncMock()
     client.disconnect_websocket = AsyncMock()
     client._auth_failed = False
@@ -67,6 +63,10 @@ def coordinator(mock_hass, mock_api_client, mock_config_entry):
         coord._last_update_times = {}
         coord._last_sse_restart_time = 0
         coord._consecutive_sse_restarts = 0
+        coord._consecutive_sse_drops = 0
+        coord._last_sse_disconnect_reason = None
+        coord._sse_connected = True
+        coord._sse_connection_state = "streaming"
         coord.renew_task = None
         coord.listen_task = None
         coord._deferred_tasks = set()
@@ -82,6 +82,9 @@ def coordinator(mock_hass, mock_api_client, mock_config_entry):
         coord._last_token_update = 0.0
         coord._appliances_cache = None
         coord._can_restart_sse = MagicMock(return_value=True)
+        coord._unsub_refresh = None
+        coord._listeners = {}
+        coord._last_remote_control = {}
         return coord
 
 
@@ -89,9 +92,7 @@ class TestCoordinatorConnectivity:
     """Test coordinator connectivity and error handling."""
 
     @pytest.mark.asyncio
-    async def test_appliance_offline_marks_unavailable_without_reauth(
-        self, coordinator, mock_api_client
-    ):
+    async def test_appliance_offline_marks_unavailable_without_reauth(self, coordinator, mock_api_client):
         """Test that appliance offline errors mark entities unavailable without triggering reauth."""
         # Setup mock appliance data
         from custom_components.electrolux.models import Appliance
@@ -109,9 +110,7 @@ class TestCoordinatorConnectivity:
         coordinator.data = {"appliances": appliances}
 
         # Mock network error during appliance state fetch
-        mock_api_client.get_appliance_state.side_effect = NetworkError(
-            "Network connection failed"
-        )
+        mock_api_client.get_appliance_state.side_effect = NetworkError("Network connection failed")
 
         # Call update data - expect UpdateFailed when all appliances fail
         from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -129,9 +128,7 @@ class TestCoordinatorConnectivity:
         # (In real HA, this would mark the entity as unavailable)
 
     @pytest.mark.asyncio
-    async def test_sse_stream_recovery_attempts_reconnection(
-        self, coordinator, mock_api_client, mock_hass
-    ):
+    async def test_sse_stream_recovery_attempts_reconnection(self, coordinator, mock_api_client, mock_hass):
         """Test that SSE stream disconnection triggers reconnection attempts."""
         # Setup mock appliance data
         from custom_components.electrolux.models import Appliance
@@ -166,9 +163,7 @@ class TestCoordinatorConnectivity:
             # Simulate task failure
             coordinator.api._sse_task = MagicMock()
             coordinator.api._sse_task.cancelled.return_value = False
-            coordinator.api._sse_task.exception.return_value = Exception(
-                "Connection lost"
-            )
+            coordinator.api._sse_task.exception.return_value = Exception("Connection lost")
 
             # Trigger the failure callback (this would happen automatically in real scenario)
             # For testing, we manually call the callback logic
@@ -178,9 +173,7 @@ class TestCoordinatorConnectivity:
         # that SSE can be started successfully.
 
     @pytest.mark.asyncio
-    async def test_successful_appliance_poll_updates_state(
-        self, coordinator, mock_api_client
-    ):
+    async def test_successful_appliance_poll_updates_state(self, coordinator, mock_api_client):
         """Test that successful appliance polling updates the appliance state."""
         # Setup mock appliance data
         from custom_components.electrolux.models import Appliance
@@ -198,12 +191,8 @@ class TestCoordinatorConnectivity:
         coordinator.data = {"appliances": appliances}
 
         # Debug: check before update
-        print(
-            f"Before update - Appliances object id: {id(coordinator.data['appliances'])}"
-        )
-        print(
-            f"Before update - Appliances dict: {coordinator.data['appliances'].get_appliances()}"
-        )
+        print(f"Before update - Appliances object id: {id(coordinator.data['appliances'])}")
+        print(f"Before update - Appliances dict: {coordinator.data['appliances'].get_appliances()}")
 
         # Mock successful appliance state response
         mock_state = {
@@ -212,9 +201,7 @@ class TestCoordinatorConnectivity:
             "power": "on",
         }
         mock_api_client.get_appliance_state.return_value = mock_state
-        mock_api_client.get_appliances_list.return_value = [
-            {"applianceId": appliance_id}
-        ]  # Mock the list
+        mock_api_client.get_appliances_list.return_value = [{"applianceId": appliance_id}]  # Mock the list
 
         # Call update data
         result = await coordinator._async_update_data()
@@ -225,9 +212,7 @@ class TestCoordinatorConnectivity:
         print(f"Appliances in result: {result['appliances'].get_appliances()}")
         print(f"Appliance ID: {appliance_id}")
         print(f"Coordinator data appliances id: {id(coordinator.data['appliances'])}")
-        print(
-            f"Coordinator data appliances dict: {coordinator.data['appliances'].get_appliances()}"
-        )
+        print(f"Coordinator data appliances dict: {coordinator.data['appliances'].get_appliances()}")
 
         # Verify the appliance state was updated
         updated_appliance = result["appliances"].get_appliances()[appliance_id]
@@ -289,14 +274,10 @@ class TestSSERecovery:
             pass
 
         # Verify that disconnect_websocket was called at least once
-        assert (
-            mock_api_client.disconnect_websocket.called
-        ), "disconnect_websocket should have been called"
+        assert mock_api_client.disconnect_websocket.called, "disconnect_websocket should have been called"
 
         # Verify that listen_websocket was called at least once
-        assert (
-            coordinator.listen_websocket.called
-        ), "listen_websocket should have been called"
+        assert coordinator.listen_websocket.called, "listen_websocket should have been called"
 
 
 # Mock appliance states for different device types
@@ -355,9 +336,7 @@ class TestMultiApplianceMatrix:
         coordinator.data = {"appliances": appliances}
 
         mock_api_client.get_appliance_state.return_value = MOCK_OVEN_STATE
-        mock_api_client.get_appliances_list.return_value = [
-            {"applianceId": appliance_id}
-        ]
+        mock_api_client.get_appliances_list.return_value = [{"applianceId": appliance_id}]
 
         result = await coordinator._async_update_data()
 
@@ -384,9 +363,7 @@ class TestMultiApplianceMatrix:
         coordinator.data = {"appliances": appliances}
 
         mock_api_client.get_appliance_state.return_value = MOCK_WASHER_STATE
-        mock_api_client.get_appliances_list.return_value = [
-            {"applianceId": appliance_id}
-        ]
+        mock_api_client.get_appliances_list.return_value = [{"applianceId": appliance_id}]
 
         result = await coordinator._async_update_data()
 
@@ -413,9 +390,7 @@ class TestMultiApplianceMatrix:
         coordinator.data = {"appliances": appliances}
 
         mock_api_client.get_appliance_state.return_value = MOCK_AC_STATE
-        mock_api_client.get_appliances_list.return_value = [
-            {"applianceId": appliance_id}
-        ]
+        mock_api_client.get_appliances_list.return_value = [{"applianceId": appliance_id}]
 
         result = await coordinator._async_update_data()
 
@@ -425,9 +400,7 @@ class TestMultiApplianceMatrix:
         assert updated_appliance.state["targetTemperatureC"] == 22
 
     @pytest.mark.asyncio
-    async def test_malformed_data_temperature_as_string(
-        self, coordinator, mock_api_client
-    ):
+    async def test_malformed_data_temperature_as_string(self, coordinator, mock_api_client):
         """Test handling of malformed data where temperature is sent as string instead of number."""
         from custom_components.electrolux.models import Appliance
 
@@ -453,9 +426,7 @@ class TestMultiApplianceMatrix:
             "powerState": "standby",
         }
         mock_api_client.get_appliance_state.return_value = malformed_state
-        mock_api_client.get_appliances_list.return_value = [
-            {"applianceId": appliance_id}
-        ]
+        mock_api_client.get_appliances_list.return_value = [{"applianceId": appliance_id}]
 
         # This should not crash the coordinator
         result = await coordinator._async_update_data()
@@ -468,9 +439,7 @@ class TestMultiApplianceMatrix:
         assert updated_appliance.state["targetTemperatureC"] == "180"
 
     @pytest.mark.asyncio
-    async def test_malformed_data_connectivity_state_invalid(
-        self, coordinator, mock_api_client
-    ):
+    async def test_malformed_data_connectivity_state_invalid(self, coordinator, mock_api_client):
         """Test handling of malformed data where connectivityState has invalid value."""
         from custom_components.electrolux.models import Appliance
 
@@ -493,9 +462,7 @@ class TestMultiApplianceMatrix:
             "temperature": "40",
         }
         mock_api_client.get_appliance_state.return_value = malformed_state
-        mock_api_client.get_appliances_list.return_value = [
-            {"applianceId": appliance_id}
-        ]
+        mock_api_client.get_appliances_list.return_value = [{"applianceId": appliance_id}]
 
         # This should not crash the coordinator
         result = await coordinator._async_update_data()
@@ -508,9 +475,7 @@ class TestMultiApplianceMatrix:
         assert updated_appliance.state["connectivityState"] == "invalid_status"
 
     @pytest.mark.asyncio
-    async def test_malformed_data_missing_required_fields(
-        self, coordinator, mock_api_client
-    ):
+    async def test_malformed_data_missing_required_fields(self, coordinator, mock_api_client):
         """Test handling of malformed data with missing required fields."""
         from custom_components.electrolux.models import Appliance
 
@@ -533,9 +498,7 @@ class TestMultiApplianceMatrix:
             # Missing connectivityState
         }
         mock_api_client.get_appliance_state.return_value = malformed_state
-        mock_api_client.get_appliances_list.return_value = [
-            {"applianceId": appliance_id}
-        ]
+        mock_api_client.get_appliances_list.return_value = [{"applianceId": appliance_id}]
 
         # This should not crash the coordinator
         result = await coordinator._async_update_data()
@@ -548,3 +511,205 @@ class TestMultiApplianceMatrix:
         # (The coordinator's update logic handles missing connectivityState gracefully)
         assert updated_appliance.state["mode"] == "cool"
         assert updated_appliance.state["targetTemperatureC"] == 22
+
+    @pytest.mark.asyncio
+    async def test_on_sse_disconnected_records_error(self, coordinator):
+        """_on_sse_disconnected callback records the error reason and initiates grace period."""
+        coordinator._sse_connected = True
+        coordinator._sse_connection_state = "streaming"
+
+        coordinator._on_sse_disconnected(Exception("Connection reset by peer"))
+
+        assert coordinator.sse_connection_state == "disconnected"
+        assert coordinator.sse_connected is True
+        assert coordinator.last_sse_disconnect_reason == "Connection reset by peer"
+        assert coordinator.consecutive_sse_drops == 1
+
+    @pytest.mark.asyncio
+    async def test_on_sse_disconnected_default_reason_when_none(self, coordinator):
+        """_on_sse_disconnected uses default reason when error is None."""
+        coordinator._sse_connected = True
+        coordinator._sse_connection_state = "streaming"
+
+        coordinator._on_sse_disconnected(None)
+
+        assert coordinator.sse_connection_state == "disconnected"
+        assert coordinator.last_sse_disconnect_reason == "Stream closed by server"
+        assert coordinator.consecutive_sse_drops == 1
+
+    @pytest.mark.asyncio
+    async def test_on_sse_disconnected_ignores_cancelled_error(self, coordinator):
+        """_on_sse_disconnected ignores asyncio.CancelledError to prevent double-counting drops."""
+        coordinator._sse_connected = True
+        coordinator._sse_connection_state = "streaming"
+        coordinator._consecutive_sse_drops = 0
+
+        coordinator._on_sse_disconnected(asyncio.CancelledError())
+
+        assert coordinator.sse_connection_state == "streaming"
+        assert coordinator.sse_connected is True
+        assert coordinator.consecutive_sse_drops == 0
+        assert coordinator.last_sse_disconnect_reason is None
+
+    @pytest.mark.asyncio
+    async def test_on_sse_disconnected_empty_exception_message_fallback(self, coordinator):
+        """_on_sse_disconnected uses default reason when Exception has an empty message."""
+        coordinator._sse_connected = True
+        coordinator._sse_connection_state = "streaming"
+
+        coordinator._on_sse_disconnected(Exception(""))
+
+        assert coordinator.sse_connection_state == "disconnected"
+        assert coordinator.sse_connected is True
+        assert coordinator.last_sse_disconnect_reason == "Stream closed by server"
+        assert coordinator.consecutive_sse_drops == 1
+
+    @pytest.mark.asyncio
+    async def test_record_sse_disconnect_preserves_debounce_timer_and_drops_on_retries(self, coordinator):
+        """record_sse_disconnect does not reset debounce timer or inflate drops on rapid retries."""
+        coordinator._sse_connected = True
+        coordinator._sse_connection_state = "streaming"
+
+        created_tasks = []
+
+        def _fake_create_task(coro, name=None, eager_start=True):
+            task = asyncio.create_task(coro)
+            created_tasks.append(task)
+            return task
+
+        coordinator.hass.async_create_task = _fake_create_task
+
+        # Initial drop at t=0
+        coordinator.record_sse_disconnect(reason="Connection reset", is_cancellation=False)
+        assert coordinator.consecutive_sse_drops == 1
+        assert len(created_tasks) == 1
+        first_debounce_task = created_tasks[0]
+
+        # Retry 1 failure while grace period is active
+        coordinator.record_sse_disconnect(reason="Connection refused", is_cancellation=False)
+        assert coordinator.consecutive_sse_drops == 1
+        assert len(created_tasks) == 1  # Did not spawn a second task
+        assert not first_debounce_task.cancelled()  # Did not cancel existing task
+
+        # Retry 2 failure while grace period is still active
+        coordinator.record_sse_disconnect(reason="Timeout", is_cancellation=False)
+        assert coordinator.consecutive_sse_drops == 1
+        assert len(created_tasks) == 1
+
+        first_debounce_task.cancel()
+        await asyncio.gather(first_debounce_task, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_record_sse_disconnect_when_already_disconnected_does_not_spawn_debounce(self, coordinator):
+        """record_sse_disconnect does not create a debounce task if already disconnected."""
+        coordinator._sse_connected = False
+        coordinator._sse_connection_state = "disconnected"
+        coordinator._sse_disconnect_debounce_task = None
+
+        created_tasks = []
+
+        def _fake_create_task(coro, name=None, eager_start=True):
+            task = asyncio.create_task(coro)
+            created_tasks.append(task)
+            return task
+
+        coordinator.hass.async_create_task = _fake_create_task
+
+        coordinator.record_sse_disconnect(reason="Connection refused", is_cancellation=False)
+
+        assert coordinator.sse_connected is False
+        assert coordinator.sse_connection_state == "disconnected"
+        assert len(created_tasks) == 0
+        assert coordinator._sse_disconnect_debounce_task is None
+
+    @pytest.mark.asyncio
+    async def test_incoming_data_cancels_active_debounce_task(self, coordinator):
+        """incoming_data cancels active debounce task and resets consecutive drops."""
+        coordinator._sse_connected = True
+        coordinator._sse_connection_state = "disconnected"
+        coordinator._appliances_cache = MagicMock()
+        coordinator.data = {"appliances": coordinator._appliances_cache}
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator._process_incremental_update = MagicMock()
+
+        created_tasks = []
+
+        def _fake_create_task(coro, name=None, eager_start=True):
+            task = asyncio.create_task(coro)
+            created_tasks.append(task)
+            return task
+
+        coordinator.hass.async_create_task = _fake_create_task
+
+        # Start a debounce task via record_sse_disconnect
+        coordinator.record_sse_disconnect(reason="Connection dropped", is_cancellation=False)
+        debounce_task = coordinator._sse_disconnect_debounce_task
+        assert debounce_task is not None
+        assert not debounce_task.done()
+
+        # Incoming data arrives before debounce finishes
+        coordinator.incoming_data({"applianceId": "app1", "property": "state", "value": "on"})
+
+        assert coordinator.sse_connected is True
+        assert coordinator.sse_connection_state == "streaming"
+        assert coordinator.consecutive_sse_drops == 0
+        await asyncio.sleep(0)
+        assert debounce_task.cancelled() or debounce_task.done()
+        assert coordinator._sse_disconnect_debounce_task is None
+
+    @pytest.mark.asyncio
+    async def test_debounce_disconnect_aborts_if_state_returned_to_streaming(self, coordinator):
+        """_debounce_disconnect does not disconnect if state transitioned back to streaming."""
+        coordinator._sse_connected = True
+        coordinator._sse_connection_state = "disconnected"
+
+        def _fake_create_task(coro, name=None, eager_start=True):
+            return asyncio.create_task(coro)
+
+        coordinator.hass.async_create_task = _fake_create_task
+
+        with patch("custom_components.electrolux.coordinator.SSE_DISCONNECT_GRACE_PERIOD", 0.01):
+            coordinator.record_sse_disconnect(reason="Connection refused", is_cancellation=False)
+            assert coordinator._sse_disconnect_debounce_task is not None
+
+            # State transitions back to streaming right before sleep finishes
+            coordinator._sse_connection_state = "streaming"
+            coordinator._sse_connected = True
+
+            await asyncio.sleep(0.05)
+
+            # Debounce completed, but streaming guard kept connection alive
+            assert coordinator.sse_connected is True
+            assert coordinator.sse_connection_state == "streaming"
+            assert coordinator._sse_disconnect_debounce_task is None
+
+    @pytest.mark.asyncio
+    async def test_record_sse_disconnect_increments_drops_after_grace_period_expired(self, coordinator):
+        """record_sse_disconnect increments drops on retry failures after grace period expired."""
+        coordinator._sse_connected = True
+        coordinator._sse_connection_state = "streaming"
+
+        def _fake_create_task(coro, name=None, eager_start=True):
+            return asyncio.create_task(coro)
+
+        coordinator.hass.async_create_task = _fake_create_task
+
+        with patch("custom_components.electrolux.coordinator.SSE_DISCONNECT_GRACE_PERIOD", 0.01):
+            coordinator.record_sse_disconnect(reason="Drop 1", is_cancellation=False)
+            assert coordinator.consecutive_sse_drops == 1
+
+            # Wait for grace period to expire
+            await asyncio.sleep(0.05)
+            assert coordinator.sse_connected is False
+            assert coordinator._sse_disconnect_debounce_task is None
+
+            # Next retry failure after grace period expiration increments drops
+            coordinator.record_sse_disconnect(reason="Drop 2", is_cancellation=False)
+            assert coordinator.consecutive_sse_drops == 2
+            assert coordinator.sse_connected is False
+
+            # Further retry failure increments drops again
+            coordinator.record_sse_disconnect(reason="Drop 3", is_cancellation=False)
+            assert coordinator.consecutive_sse_drops == 3
+            assert coordinator.sse_connected is False
+

--- a/tests/test_coordinator_coverage_gaps.py
+++ b/tests/test_coordinator_coverage_gaps.py
@@ -156,6 +156,7 @@ class TestListenWebsocketGaps:
         mock_api.watch_for_appliance_state_updates.assert_awaited_once()
         kwargs = mock_api.watch_for_appliance_state_updates.await_args.kwargs
         assert kwargs["on_connected"] == coordinator._on_sse_connected
+        assert kwargs["on_disconnected"] == coordinator._on_sse_disconnected
 
     async def test_listen_websocket_starts_watchdog_monitor_task(self, coordinator, mock_api):
         """listen_websocket should start SSE watchdog monitor after successful setup."""

--- a/uv.lock
+++ b/uv.lock
@@ -810,7 +810,7 @@ wheels = [
 
 [[package]]
 name = "electrolux-group-developer-sdk"
-version = "0.6.1"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -818,9 +818,9 @@ dependencies = [
     { name = "pyjwt" },
     { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/0f/10dafa55a40f5848fbee10c225848ccc8d49453a53f8c20ba0d0a8baa0e6/electrolux_group_developer_sdk-0.6.1.tar.gz", hash = "sha256:28be39f8895ca01f703127130d1e1e6149476a19f4b696a6ba30d784b4aedfeb", size = 38095, upload-time = "2026-07-24T09:24:15.814Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/c6/a7bf426d7cf31eff15c5397bdd3250e9d4c9cc45540bc61b0216bd219c29/electrolux_group_developer_sdk-0.7.0.tar.gz", hash = "sha256:d558cf41c900c760e91ae447a526aba0b510e812d78dc07b4f055fed4d70dfcf", size = 39074, upload-time = "2026-09-04T12:51:44.798Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/26/0b0e8c23c2b0e597670adcc13abae6d9cbfa4854a43aca46e50f68964ab8/electrolux_group_developer_sdk-0.6.1-py3-none-any.whl", hash = "sha256:6883a89f39529a63cf569bc4e333eb0e151fbc37152227248589e9cf3841f62d", size = 73164, upload-time = "2026-07-24T09:24:16.7Z" },
+    { url = "https://files.pythonhosted.org/packages/23/99/c7852afa84a6d88c8d42ab692c2281d1ff1d80be94200f404fed555a9e27/electrolux_group_developer_sdk-0.7.0-py3-none-any.whl", hash = "sha256:de62a4076d309517799c89101d5d6fc59b087bb97bcbc7ccba5aef42b7978147", size = 74242, upload-time = "2026-09-04T12:51:45.584Z" },
 ]
 
 [[package]]
@@ -1001,13 +1001,13 @@ test = [
 dev = [
     { name = "aiohttp", specifier = ">=3.14.3,<4.0.0" },
     { name = "deep-translator" },
-    { name = "electrolux-group-developer-sdk" },
+    { name = "electrolux-group-developer-sdk", specifier = ">=0.7.0" },
     { name = "pre-commit" },
     { name = "pydantic", specifier = ">=2.13.5,<3.0.0" },
 ]
 test = [
     { name = "aiohttp", specifier = ">=3.14.3,<4.0.0" },
-    { name = "electrolux-group-developer-sdk" },
+    { name = "electrolux-group-developer-sdk", specifier = ">=0.7.0" },
     { name = "homeassistant", specifier = ">=2026.8.3,<2027.0.0" },
     { name = "mypy", specifier = ">=2.3.1" },
     { name = "pyjwt", specifier = ">=2.12.1,<3.0.0" },


### PR DESCRIPTION
### Summary

Bumps `electrolux-group-developer-sdk` requirement to `>=0.7.0` and integrates the new `do_on_livestream_closing_list` callbacks for stream disconnection handling and debounced reconnect tracking.

### Context & Motivation

In `electrolux-group-developer-sdk` 0.7.0 (PR #28), `start_event_stream` added `do_on_livestream_closing_list` callback support. The callback is invoked when an SSE stream connection closes or terminates due to network/server exceptions during consumption.

Previously, stream disconnection handling relied primarily on stream silence watchdog timers or subsequent reconnection events. Hooking into the closing callback enables immediate notification when the SSE connection terminates.

### Changes

- **SDK Requirement**: Updated `electrolux-group-developer-sdk` requirement to `>=0.7.0` in `manifest.json`, `pyproject.toml`, and `requirements_test.txt`, and updated `uv.lock`.
- **API Client**: Forwarded `do_on_livestream_closing_list` parameter from `watch_for_appliance_state_updates` to the SDK's `start_event_stream`.
- **Coordinator Disconnect Handling**:
  - Registered `_on_sse_disconnected` to receive stream close events.
  - Recorded drops and initiated the disconnect grace period timer when closed due to network/server exceptions.
  - Ignored `asyncio.CancelledError` in the callback to avoid false drop counts during coordinator unloads or planned restarts.
  - Preserved active disconnect debounce timer across rapid SDK retry attempts.
  - Cancelled pending disconnect timer in `incoming_data` upon receiving valid data frames, with a state guard preventing stale disconnection transitions.
- **Tests**: Added test cases in `test_api_client.py` and `test_coordinator_connectivity.py` covering callback forwarding, cancellation handling, and disconnect debounce reset paths (1,847 tests passing, 95.24% coverage).
