### PR TITLE
Fix: Structured Oven (SO) START button stuck unavailable at READY_TO_START

### DIFF
--- a/custom_components/electrolux/execute_command_states.py
+++ b/custom_components/electrolux/execute_command_states.py
@@ -53,20 +53,24 @@ OVEN_EXECUTE_STATES: dict[str, list[str]] = {
 }
 
 # ---------------------------------------------------------------------------
-# Structured Oven (SO / upperOven) — SO-944035035_01.json
+# Structured Oven (SO / upperOven)
 # ---------------------------------------------------------------------------
-# The structured oven has only three applianceState values: ALARM, OFF, RUNNING.
-# There are NO conditional triggers in the sample — no PAUSED, DELAYED_START,
-# READY_TO_START, or END_OF_CYCLE states exist for this appliance type.
-# Using OVEN_EXECUTE_STATES here would make START permanently invisible because
-# it requires READY_TO_START / END_OF_CYCLE which never occur on a structured oven.
-# applianceState  → accepted executeCommand values
-# OFF             → START   (oven is idle/ready)
-# RUNNING         → STOPRESET
-STRUCTURED_OVEN_EXECUTE_STATES: dict[str, list[str]] = {
-    "START": ["OFF"],
-    "STOPRESET": ["RUNNING"],
-}
+# The structured oven's ``upperOven/applianceState`` is an independent state machine
+# from the root one. While the root-level capability on some samples only exposes
+# ALARM/OFF/RUNNING, the cavity's OWN machine is the full plain-oven one
+# (ALARM, DELAYED_START, END_OF_CYCLE, IDLE, OFF, PAUSED,
+# READY_TO_START, RUNNING) — verified on SO-944005079_00 (issue #206),
+# whose upperOven/applianceState reports the same vocabulary as an OV.
+# The executeCommand rule is evaluated against that scoped cavity machine, so it
+# must use the same gating as OVEN_EXECUTE_STATES. (Structurally, the two tables are
+# identical here — reuse it keep them in lockstep.)
+# applianceState   → accepted executeCommand values
+# READY_TO_START  → START
+# END_OF_CYCLE    → START   (re-start after cycle ends)
+# RUNNING          → STOPRESET
+# PAUSED           → STOPRESET
+# DELAYED_START    → STOPRESET
+STRUCTURED_OVEN_EXECUTE_STATES: dict[str, list[str]] = OVEN_EXECUTE_STATES
 
 # ---------------------------------------------------------------------------
 # Washer (WM) — WM-914915144_00.json

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -10,6 +10,7 @@ from custom_components.electrolux.button import ElectroluxButton
 from custom_components.electrolux.const import BUTTON
 from custom_components.electrolux.execute_command_states import (
     DRYER_EXECUTE_STATES,
+    STRUCTURED_OVEN_EXECUTE_STATES,
     WASHER_EXECUTE_STATES,
     execute_phase_states_from_capabilities,
     execute_states_from_capabilities,
@@ -856,7 +857,7 @@ class TestSourceScopedStateGating:
             icon="mdi:test",
             catalog_entry=ElectroluxDevice(
                 capability_info={"access": "write"},
-                available_when_states={"START": ["OFF"], "STOPRESET": ["RUNNING"]},
+                available_when_states=STRUCTURED_OVEN_EXECUTE_STATES,
             ),
             val_to_send=val_to_send,
         )
@@ -917,6 +918,9 @@ class TestSourceScopedStateGating:
         The table is evaluated against the scoped state, never the root machine.
         """
         caps = {"applianceState": SO_ROOT_APPLIANCE_STATE}
+        # Regression for #206: with the structured-oven table now gating START on
+        # READY_TO_START/END_OF_CYCLE (like a plain OV), a cavity at OFF must NOT
+        # expose START, while a cavity at READY_TO_START must.
         entity = self._make_button(
             mock_coordinator,
             "upperOven",
@@ -924,8 +928,24 @@ class TestSourceScopedStateGating:
             caps,
             {"applianceState": "RUNNING", "upperOven/applianceState": "OFF"},
         )
-        # Root RUNNING would have blocked START via the root machine; the
-        # scoped state OFF matches the table's START rule instead.
+        # Root RUNNING would have blocked START via the root machine; the scoped
+        # state OFF no longer matches the table's START rule (issue #206).
+        assert entity.available is False
+
+    def test_scoped_button_fallback_ready_to_start_enables_start(self, mock_coordinator):
+        """Structured oven with no triggers: START is available at READY_TO_START (#206).
+
+        The reported cavity state is READY_TO_START with a program selected — exactly
+        when the official app lets you start. The catalog fallback must now allow it.
+        """
+        caps = {"applianceState": SO_ROOT_APPLIANCE_STATE}
+        entity = self._make_button(
+            mock_coordinator,
+            "upperOven",
+            "START",
+            caps,
+            {"applianceState": "OFF", "upperOven/applianceState": "READY_TO_START"},
+        )
         assert entity.available is True
 
     def test_scoped_derivation_ignores_root_appliance_state_capability(self):
@@ -965,11 +985,12 @@ class TestSourceScopedStateGating:
         assert entity.available is True
 
         # Replace capabilities with a payload publishing no triggers: the rules
-        # must refresh to the catalog table, where START is only valid in OFF.
+        # must refresh to the catalog table (START valid in READY_TO_START and
+        # END_OF_CYCLE).
         appliance = MagicMock()
         appliance.data.capabilities = {
             "applianceState": {
-                "values": {"READY_TO_START": {}, "OFF": {}},
+                "values": {"READY_TO_START": {}, "END_OF_CYCLE": {}},
                 "triggers": [],
             }
         }
@@ -977,14 +998,14 @@ class TestSourceScopedStateGating:
         appliances.get_appliance.return_value = appliance
         mock_coordinator.data = {"appliances": appliances}
 
-        # The appliance moved to OFF: fresh rules (catalog table) allow START
-        # there, while the stale dryer-derived rules (START only in
+        # The appliance moved to END_OF_CYCLE: fresh rules (catalog table) allow
+        # START there, while the stale dryer-derived rules (START only in
         # READY_TO_START) would keep the button disabled.
-        reported = {"applianceState": "OFF", "connectivityState": "connected"}
+        reported = {"applianceState": "END_OF_CYCLE", "connectivityState": "connected"}
         entity.appliance_status = {"properties": {"reported": reported}}
         entity._reported_state_cache = reported
 
-        assert entity._execute_states == {"START": ["OFF"], "STOPRESET": ["RUNNING"]}
+        assert entity._execute_states == STRUCTURED_OVEN_EXECUTE_STATES
         assert entity.available is True
 
 


### PR DESCRIPTION
## Fix: Structured Oven (SO) START button stuck unavailable at READY_TO_START

Fixes #206

### What the new sample revealed

Until now, every known structured-oven sample published `applianceState` triggers on its cavity, so button gating always came from runtime derivation — the `STRUCTURED_OVEN_EXECUTE_STATES` fallback table had **never been exercised by a real appliance**. The #206 diagnostics (SO-944005079_00) are the first trigger-less SO sample, and they exposed that the fallback was written from the wrong state machine:

- The table only allows `START` in `OFF` — transcribed from the **root's** 3-state machine (ALARM/OFF/RUNNING).
- But the cavity's own `upperOven/applianceState` is an independent 8-value plain-oven machine, and it reports `READY_TO_START` (program selected) while the root simultaneously reports `OFF`.
- The cloud confirms the correct rule: the reported state contains `upperOven/executeCommand: "START"` at `READY_TO_START`.

Result: on trigger-less SO models the cavity's START button was permanently unavailable — exactly the reporter's bug.

### Fix

The cavity machine's vocabulary is identical to a plain oven's, so the fallback now reuses the correct table:

```python
# START:     READY_TO_START, END_OF_CYCLE
# STOPRESET: RUNNING, PAUSED, DELAYED_START
STRUCTURED_OVEN_EXECUTE_STATES: dict[str, list[str]] = OVEN_EXECUTE_STATES
```

Models publishing triggers are unaffected (derivation wins); root state remains ignored (#189 scoping intact).

### Tests

New regression test for the previously-uncovered path: trigger-less SO, cavity `READY_TO_START` → START available; cavity `OFF` → unavailable. 1839 passed; ruff + mypy (CI commands) pass.