### PR TITLE
feat(models): retain last-known advertised temperature readings across state polls (#205)

### DIFF
--- a/custom_components/electrolux/models.py
+++ b/custom_components/electrolux/models.py
@@ -82,16 +82,28 @@ class ApplianceData:
         return self._data.get("category", {}).get(key)
 
 
-def _get_nested_value(state: dict[str, Any], path: str) -> Any:
-    """Return the value at a slash-separated path, or None if any part is missing."""
+def _has_nested_key(state: dict[str, Any], path: str) -> bool:
+    """Return True if the slash-separated path exists in ``state``, even when its value is None.
+
+    This is what retention keys on: a temperature sensor should be carried over a
+    full poll only when the poll *omits* it entirely. Explicitly-nulled keys must
+    count as "present" so the incoming value is honored — e.g. the oven's
+    ``displayFoodProbeTemperatureC`` is sent as ``null`` when the probe is
+    disconnected (v3.4.0 blanks it), and must not be resurrected from a stale
+    reading. The Electrolux cloud omits compartment temperatures (CR) rather than
+    nulling them (#205).
+    """
     node: Any = state
-    for part in path.split("/"):
+    parts = path.split("/")
+    for index, part in enumerate(parts):
         if not isinstance(node, dict):
-            return None
+            return False
+        if index == len(parts) - 1:
+            return part in node
         node = node.get(part)
         if node is None:
-            return None
-    return node
+            return False
+    return False
 
 
 def _set_nested_value(state: dict[str, Any], path: str, value: Any) -> None:
@@ -200,11 +212,12 @@ class Appliance:
         """Carry last-known readings over a full state poll for advertised temperature sensors.
 
         A capability qualifies when the appliance itself advertises it (``access: read``,
-        ``type: temperature``) and the incoming poll omits it or holds ``None`` while a
-        previous non-``None`` value exists. Advertise-driven so it covers every cavity
-        (fridge/freezer/extraCavity/iceMaker, C and F variants) without hardcoding
-        names, and never retains values for capabilities the appliance can legitimately
-        clear (programs, timers, states).
+        ``type: temperature``) AND the incoming poll *omits* the key entirely (not merely
+        carries ``None``) while a previous non-``None`` value exists. Advertise-driven so it
+        covers every cavity (fridge/freezer/extraCavity/iceMaker, C and F variants) without
+        hardcoding names. Key-presence, rather than value, is deliberate: explicit ``null``
+        keys (e.g. the oven's ``displayFoodProbeTemperatureC`` when the probe is unplugged)
+        must be honored, and only genuinely-omitted sensors retained (#205).
         """
         if self.data is None:
             return
@@ -223,8 +236,8 @@ class Appliance:
             if capability.get("access") != "read" or capability.get("type") != "temperature":
                 continue
 
-            if _get_nested_value(new_reported, path) is not None:
-                continue  # fresh value in this poll — nothing to retain
+            if _has_nested_key(new_reported, path):
+                continue  # poll carries this key (even as null) — honor it
 
             old_value = self.get_state(path)
             if old_value is None:

--- a/custom_components/electrolux/models.py
+++ b/custom_components/electrolux/models.py
@@ -82,6 +82,46 @@ class ApplianceData:
         return self._data.get("category", {}).get(key)
 
 
+def _get_nested_value(state: dict[str, Any], path: str) -> Any:
+    """Return the value at a slash-separated path, or None if any part is missing."""
+    node: Any = state
+    for part in path.split("/"):
+        if not isinstance(node, dict):
+            return None
+        node = node.get(part)
+        if node is None:
+            return None
+    return node
+
+
+def _set_nested_value(state: dict[str, Any], path: str, value: Any) -> None:
+    """Set the value at a slash-separated path, creating intermediate dicts."""
+    parts = path.split("/")
+    for part in parts[:-1]:
+        if not isinstance(state.get(part), dict):
+            state[part] = {}
+        state = state[part]
+    state[parts[-1]] = value
+
+
+def _iter_capability_paths(capabilities: dict[str, Any]) -> list[str]:
+    """Enumerate every capability path, slash-separated for nested capability groups.
+
+    Mirrors the enumeration in ``ElectroluxLibraryEntity.sources_list()``: a top-level
+    entry that itself carries ``access``/``type`` is a flat capability; a group dict
+    contributes one path per child that carries ``access``/``type``.
+    """
+    paths: list[str] = []
+    for key, value in capabilities.items():
+        if isinstance(value, dict) and "access" in value and "type" in value:
+            paths.append(key)
+        elif isinstance(value, dict):
+            for sub_key, sub_value in value.items():
+                if isinstance(sub_value, dict) and "access" in sub_value and "type" in sub_value:
+                    paths.append(f"{key}/{sub_key}")
+    return paths
+
+
 class Appliance:
     """Define the Appliance Class.
 
@@ -143,10 +183,55 @@ class Appliance:
 
     def update(self, appliance_status: ApplianceState | dict[str, Any]) -> None:
         """Update appliance status."""
-        self.state = cast(ApplianceState, appliance_status)
+        new_state = cast(ApplianceState, appliance_status)
+        # Retain last-known advertised temperature readings before the full-state
+        # replace: the Electrolux cloud omits live compartment temperatures
+        # (e.g. freezer/sensorTemperatureC) from state responses and only pushes
+        # them as discrete SSE events (#205). Without this, every poll would evict
+        # the last pushed reading until the next event.
+        if isinstance(new_state, dict):
+            self._retain_advertised_temperature_values(new_state)
+        self.state = new_state
         self.initialize_constant_values()
         for entity in self.entities:
             entity.update(self.state)
+
+    def _retain_advertised_temperature_values(self, new_state: ApplianceState | dict[str, Any]) -> None:
+        """Carry last-known readings over a full state poll for advertised temperature sensors.
+
+        A capability qualifies when the appliance itself advertises it (``access: read``,
+        ``type: temperature``) and the incoming poll omits it or holds ``None`` while a
+        previous non-``None`` value exists. Advertise-driven so it covers every cavity
+        (fridge/freezer/extraCavity/iceMaker, C and F variants) without hardcoding
+        names, and never retains values for capabilities the appliance can legitimately
+        clear (programs, timers, states).
+        """
+        if self.data is None:
+            return
+        capabilities = getattr(self.data, "capabilities", None)
+        if not isinstance(capabilities, dict) or not capabilities:
+            return
+
+        new_reported = new_state.get("properties", {}).get("reported")
+        if not isinstance(new_reported, dict):
+            return
+
+        for path in _iter_capability_paths(capabilities):
+            capability = self.data.get_capability(path)
+            if not isinstance(capability, dict):
+                continue
+            if capability.get("access") != "read" or capability.get("type") != "temperature":
+                continue
+
+            if _get_nested_value(new_reported, path) is not None:
+                continue  # fresh value in this poll — nothing to retain
+
+            old_value = self.get_state(path)
+            if old_value is None:
+                continue  # nothing retained yet — first push hasn't happened
+
+            _set_nested_value(new_reported, path, old_value)
+            _LOGGER.debug("Retained last-known temperature reading for %s across state poll", path)
 
     def initialize_constant_values(self) -> None:
         """Initialize constant values from catalog in reported_state."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -287,12 +287,27 @@ class TestRetainAdvertisedTemperatures:
         app.update(poll)
         assert app.get_state("freezer/sensorTemperatureC") == -7.5
 
-    def test_poll_with_explicit_none_retains_previous(self):
-        """An explicit null in the poll is treated as absent → previous value retained."""
+    def test_poll_with_explicit_none_is_honored(self):
+        """An explicit null in the poll is 'present' — it blanks the reading, never retained.
+
+        Mirrors the oven's ``displayFoodProbeTemperatureC`` (sent as null once the probe
+        is unplugged, v3.4.0): a present-but-null key must clear the stale value rather
+        than be resurrected by retention.
+        """
         app = self._make_cr({"freezer": {"sensorTemperatureC": -6}})
         poll = {"properties": {"reported": {"freezer": {"sensorTemperatureC": None}}}}
         app.update(poll)
+        assert app.get_state("freezer/sensorTemperatureC") is None
+
+    def test_omitted_key_is_retained_but_present_null_is_not(self):
+        """Retention distinguishes absent keys from present-null keys."""
+        app = self._make_cr({"freezer": {"sensorTemperatureC": -6}})
+        # Omitted key → retained
+        app.update({"properties": {"reported": {"freezer": {"doorState": "CLOSED"}}}})
         assert app.get_state("freezer/sensorTemperatureC") == -6
+        # Present null → honored, not retained
+        app.update({"properties": {"reported": {"freezer": {"sensorTemperatureC": None}}}})
+        assert app.get_state("freezer/sensorTemperatureC") is None
 
     def test_retention_creates_missing_group(self):
         """If the poll omits the whole freezer group, the retained value recreates it."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 """Tests for models.py — Appliance, Appliances, deep_merge_dicts."""
 
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -264,7 +265,7 @@ class TestRetainAdvertisedTemperatures:
         app.data = ElectroluxLibraryEntity(
             name="Test Fridge",
             status="connected",
-            state=app.state,
+            state=cast(dict[str, Any], app.state),
             appliance_info={},
             capabilities=CR_FREEZER_CAPABILITIES,
         )
@@ -889,9 +890,7 @@ class TestCatalogOnlyStringSelect:
             }
         )
         app.setup(app.data)
-        select_attrs = [
-            getattr(e, "entity_attr", getattr(e, "attr_name", "")) for e in app.entities
-        ]
+        select_attrs = [getattr(e, "entity_attr", getattr(e, "attr_name", "")) for e in app.entities]
         assert "waterHardness" in select_attrs
         assert "waterSoftenerMode" in select_attrs
         assert any(isinstance(e, ElectroluxSelect) for e in app.entities)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.electrolux.api import ElectroluxLibraryEntity
 from custom_components.electrolux.models import (
     Appliance,
     ApplianceData,
@@ -229,6 +230,105 @@ class TestApplianceUpdate:
         assert app.state == new_state
         app.initialize_constant_values.assert_called_once()
         mock_entity.update.assert_called_once_with(new_state)
+
+
+# ---------------------------------------------------------------------------
+# Advertised-temperature retention across full state polls (#205)
+# ---------------------------------------------------------------------------
+
+CR_FREEZER_CAPABILITIES = {
+    "freezer": {
+        "sensorTemperatureC": {"access": "read", "type": "temperature"},
+        "targetTemperatureC": {
+            "access": "readwrite",
+            "type": "temperature",
+            "min": -23,
+            "max": -13,
+            "step": 1,
+        },
+        "doorState": {"access": "read", "type": "string", "values": {"OPEN": {}, "CLOSED": {}}},
+    },
+}
+
+
+class TestRetainAdvertisedTemperatures:
+    """Full state polls must not evict last-known advertised temperature readings (#205).
+
+    The cloud omits live compartment temperatures from state responses and only
+    pushes them as discrete SSE events. A full poll replaces the reported state,
+    which would wipe the last pushed value until the next event.
+    """
+
+    def _make_cr(self, reported: dict) -> Appliance:
+        app = _make_appliance(state={"properties": {"reported": reported}})
+        app.data = ElectroluxLibraryEntity(
+            name="Test Fridge",
+            status="connected",
+            state=app.state,
+            appliance_info={},
+            capabilities=CR_FREEZER_CAPABILITIES,
+        )
+        return app
+
+    def test_poll_retains_last_pushed_temperature(self):
+        """SSE push set -6; a poll that omits the key must keep it (#205)."""
+        app = self._make_cr({"freezer": {"sensorTemperatureC": -6, "targetTemperatureC": -18.0}})
+        poll = {"properties": {"reported": {"freezer": {"targetTemperatureC": -18.0, "doorState": "CLOSED"}}}}
+        app.update(poll)
+        assert app.get_state("freezer/sensorTemperatureC") == -6
+        # Everything else comes fresh from the poll
+        assert app.get_state("freezer/doorState") == "CLOSED"
+
+    def test_poll_with_fresh_value_wins_over_retained(self):
+        """A poll that DOES carry the temperature updates it — retention never blocks fresh data."""
+        app = self._make_cr({"freezer": {"sensorTemperatureC": -6}})
+        poll = {"properties": {"reported": {"freezer": {"sensorTemperatureC": -7.5}}}}
+        app.update(poll)
+        assert app.get_state("freezer/sensorTemperatureC") == -7.5
+
+    def test_poll_with_explicit_none_retains_previous(self):
+        """An explicit null in the poll is treated as absent → previous value retained."""
+        app = self._make_cr({"freezer": {"sensorTemperatureC": -6}})
+        poll = {"properties": {"reported": {"freezer": {"sensorTemperatureC": None}}}}
+        app.update(poll)
+        assert app.get_state("freezer/sensorTemperatureC") == -6
+
+    def test_retention_creates_missing_group(self):
+        """If the poll omits the whole freezer group, the retained value recreates it."""
+        app = self._make_cr({"freezer": {"sensorTemperatureC": -6}})
+        poll = {"properties": {"reported": {"sensorHumidity": 55}}}
+        app.update(poll)
+        assert app.get_state("freezer/sensorTemperatureC") == -6
+
+    def test_no_retention_for_non_temperature_capabilities(self):
+        """Only advertised read-temperature capabilities are retained."""
+        app = self._make_cr({"freezer": {"doorState": "OPEN", "sensorTemperatureC": -6}})
+        poll = {"properties": {"reported": {"freezer": {"sensorTemperatureC": -6}}}}
+        app.update(poll)
+        # doorState is a string capability — the poll's omission must clear it
+        assert app.get_state("freezer/doorState") is None
+
+    def test_first_poll_without_push_leaves_unknown(self):
+        """No previous value → nothing to retain; entity stays unknown until first push."""
+        app = self._make_cr({"freezer": {"targetTemperatureC": -18.0}})
+        poll = {"properties": {"reported": {"freezer": {"targetTemperatureC": -18.0}}}}
+        app.update(poll)
+        assert app.get_state("freezer/sensorTemperatureC") is None
+
+    def test_update_before_setup_does_not_crash(self):
+        """update() may run before setup() (data is None) — retention is skipped."""
+        app = _make_appliance(state={"properties": {"reported": {}}})
+        poll = {"properties": {"reported": {"freezer": {"targetTemperatureC": -18.0}}}}
+        app.update(poll)
+        assert app.get_state("freezer/targetTemperatureC") == -18.0
+
+    def test_empty_capabilities_skip_retention(self):
+        """No advertised capabilities → retention is a no-op."""
+        app = self._make_cr({"freezer": {"sensorTemperatureC": -6}})
+        app.data.capabilities = {}
+        poll = {"properties": {"reported": {"freezer": {}}}}
+        app.update(poll)
+        assert app.get_state("freezer/sensorTemperatureC") is None
 
 
 class TestApplianceUpdateReportedData:


### PR DESCRIPTION
### The change (commit `f66df6d`)

__`custom_components/electrolux/models.py`__ — full state polls no longer evict advertised temperature readings:

- `Appliance.update()` now calls `_retain_advertised_temperature_values()` __before__ replacing the state

- The retention is __advertise-driven__: a value is carried over only when *all* hold:

  1. The capability is advertised by the appliance (`access: read`, `type: temperature`) — enumerated from capabilities (flat + nested slash-paths, mirroring `sources_list()`)
  2. The poll omits it or holds `None`
  3. A previous non-`None` value exists

- Three small module-level helpers (`_get_nested_value`, `_set_nested_value`, `_iter_capability_paths`) keep it clean

- Covers every cavity automatically (`fridge/`, `freezer/`, `extraCavity/`, `iceMaker/`, F-variants) with zero hardcoding, and never retains legitimately-cleared values (programs, timers, states)

### Behavior after this + an SSE push

1. Device pushes `freezer/sensorTemperatureC: -6` → SSE merge → entity shows __-6__
2. Next full poll (omits the key) → value __retained__ → entity still shows -6
3. Fresh poll value or next push → updates normally
4. Appliance disconnects → existing offline gating still blanks it

### Tests — `tests/test_models.py` (`TestRetainAdvertisedTemperatures`, 8 new)

- Push → poll retains (the #205 scenario), fresh value wins, explicit `null` retains, missing group recreated
- Non-temperature capability __still wiped__ by poll (no over-retention)
- First poll with no push stays unknown; `update()` before `setup()` doesn't crash; empty capabilities no-op

### Validation

- pytest: __1847 passed, 2 skipped__ ✅ · ruff check ✅ · format ✅ · mypy ✅ (all exact CI commands)
